### PR TITLE
Job queue: first draft

### DIFF
--- a/server/sql_app/README.md
+++ b/server/sql_app/README.md
@@ -1,5 +1,7 @@
 #FastAPI setup (using Python 3.9+)
 
+> `pip install requests`
+> `pip install sqlalchecmy`
 > `pip install fastapi`
 > `pip install "uvicorn[standard]"`
 

--- a/server/sql_app/crud.py
+++ b/server/sql_app/crud.py
@@ -1,10 +1,12 @@
 """CRUD: Create, Read, Update, and Delete"""
 import asyncio
+import logging
+import sys
+import time
+
 from fastapi import HTTPException
 from sqlalchemy.orm import Session
 import uuid
-import sys
-import logging
 
 from . import models, schemas
 
@@ -145,6 +147,14 @@ def update_job(db: Session, job: schemas.Job, job_id: int):
     #return db_job
     return "success"
 
+# Normally blocking call (InVEST model, PGP call, wallpapering, ...)
+def test_job_task(job_details):
+    LOGGER.debug('Running job operation')
+
+    sleep_time = job_details['param']
+    # Sleep for the "sleep_time" seconds.
+    time.sleep(sleep_time)
+    LOGGER.debug(f'Done sleeping for {sleep_time} seconds')
 
 def create_pattern(db: Session, session_id: str, pattern: schemas.Pattern):
     #TODO: Implement

--- a/server/sql_app/crud.py
+++ b/server/sql_app/crud.py
@@ -148,10 +148,10 @@ def update_job(db: Session, job: schemas.Job, job_id: int):
     return "success"
 
 # Normally blocking call (InVEST model, PGP call, wallpapering, ...)
-def test_job_task(job_details):
+def test_job_task(job_param):
     LOGGER.debug('Running job operation')
 
-    sleep_time = job_details['param']
+    sleep_time = job_param
     # Sleep for the "sleep_time" seconds.
     time.sleep(sleep_time)
     LOGGER.debug(f'Done sleeping for {sleep_time} seconds')

--- a/server/sql_app/main.py
+++ b/server/sql_app/main.py
@@ -1,3 +1,8 @@
+import asyncio
+import time
+import logging
+import sys
+
 from fastapi import Depends, FastAPI, HTTPException
 from fastapi.testclient import TestClient
 from sqlalchemy.orm import Session
@@ -5,8 +10,24 @@ from sqlalchemy.orm import Session
 from . import crud, models, schemas
 from .database import SessionLocal, engine
 
+
+logging.basicConfig(
+    level=logging.DEBUG,
+    format=(
+        '%(asctime)s (%(relativeCreated)d) %(levelname)s %(name)s'
+        ' [%(funcName)s:%(lineno)d] %(message)s'),
+    stream=sys.stdout)
+LOGGER = logging.getLogger(__name__)
+
 # Create the db tables
 models.Base.metadata.create_all(bind=engine)
+
+
+# Create a queue that we will use to store our "workload".
+QUEUE = asyncio.PriorityQueue()
+TASKS = []
+STATUS = {0: "pending", 1: "running", 2: "success", 3: "failed"}
+
 
 # Normally you would probably initialize your db (create tables, etc) with
 # Alembic. Would also use Alembic for "migrations" (that's its main job).
@@ -41,6 +62,46 @@ def get_db():
 
 # With that, we can just call crud.get_user directly from inside of the path
 # operation function and use that session.
+
+
+# To make sure Exceptions aren't silently ignored:
+# https://stackoverflow.com/questions/27297638/when-asyncio-task-gets-stored-after-creation-exceptions-from-task-get-muted/27299160#27299160
+def handle_result(fut):
+    if fut.exception():
+        fut.result()  # This will raise the exception.
+
+
+# Our worker to run tasks
+async def worker(name, queue):
+    while True:
+        # Get a "work item" out of the queue.
+        job_priority, job_details = await queue.get()
+        LOGGER.debug(f'job details: {job_details}')
+
+        # I had a try/except here before adding the `add_done_callback` because
+        # there was an exception happening that I was never seeing in the console
+        try:
+            job_schema = schemas.JobBase(**{"name": "my-job", "description": "my-desc", "status": 1})
+            LOGGER.debug('Update job')
+            crud.update_job(db=job_details['db'], job=job_schema, job_id=job_details['job_id'])
+        except Exception as err:
+            LOGGER.error(f'Error: {err}')
+
+        # Sleep for the "sleep_for" seconds.
+        #await asyncio.sleep(sleep_for)
+        run_op = job_details['job']
+        # 'gather' and 'to_thread' allows us to await blocking calls for
+        # I/O bound or CPU bound processes.
+        await asyncio.gather(
+            asyncio.to_thread(run_op, job_details))
+
+        # Notify the queue that the "work item" has been processed.
+        queue.task_done()
+        job_schema = schemas.JobBase(**{"name": "my-job", "description": "my-desc", "status": 2})
+        LOGGER.debug('Update job')
+        crud.update_job(db=job_details['db'], job=job_schema, job_id=job_details['job_id'])
+
+        LOGGER.debug(f'{name} has slept for {job_details["param"]} seconds')
 
 
 ### User / Session Endpoints ###
@@ -117,6 +178,22 @@ def read_scenarios(session_id: str, db: Session = Depends(get_db)):
 
 
 ### Job Endpoints ###
+
+@app.get("/test-async-job/{sleep_time}")
+async def test_async_job(sleep_time: int, db: Session = Depends(get_db)):
+    job_schema = schemas.JobBase(**{"name": "my-job", "description": "my-desc", "status": 0})
+    job_db = crud.create_job(db, job_schema)
+
+    job_task = {'job': crud.test_job_task, 'param': sleep_time, 'job_id': job_db.job_id, 'db': db}
+    priority = 2
+
+    QUEUE.put_nowait((priority, job_task))
+    task = asyncio.create_task(worker(f'worker-{len(TASKS)+1}', QUEUE))
+    task.add_done_callback(handle_result)
+    TASKS.append(task)
+    LOGGER.debug('return job added')
+    return "job added"
+
 
 @app.post("/jobs/", response_model=schemas.Job)
 def create_job(

--- a/server/sql_app/main_async.py
+++ b/server/sql_app/main_async.py
@@ -1,0 +1,70 @@
+import asyncio
+import time
+
+from fastapi import Depends, FastAPI, HTTPException
+from fastapi.testclient import TestClient
+from sqlalchemy.orm import Session
+
+from . import crud, models, schemas
+from .database import SessionLocal, engine
+
+# Create the db tables
+models.Base.metadata.create_all(bind=engine)
+
+
+app = FastAPI()
+
+
+# Dependency
+def get_db():
+    db = SessionLocal()
+    try:
+        yield db
+    finally:
+        db.close()
+
+
+# Create a queue that we will use to store our "workload".
+QUEUE = asyncio.Queue()
+TASKS = []
+
+# Normally blocking call (InVEST model, PGP call, wallpapering, ...)
+def my_op(sleep_time):
+    print('Running my_op')
+    time.sleep(sleep_time)
+    # Sleep for the "sleep_for" seconds.
+    #await asyncio.sleep(sleep_time)
+    print(f'Done sleeping for {sleep_time} seconds')
+
+# Our worker to run tasks
+async def worker(name, queue):
+    while True:
+        # Get a "work item" out of the queue.
+        job_details = await queue.get()
+        print(f'job details: {job_details}')
+
+        # Sleep for the "sleep_for" seconds.
+        #await asyncio.sleep(sleep_for)
+        run_op = job_details['job']
+        # 'gather' and 'to_thread' allows us to await blocking calls for
+        # I/O bound or CPU bound processes.
+        await asyncio.gather(
+            asyncio.to_thread(run_op, job_details['param']))
+
+        # Notify the queue that the "work item" has been processed.
+        queue.task_done()
+
+        print(f'{name} has slept for {job_details["param"]} seconds')
+
+
+# Endpoint
+
+@app.get("/test-async-job/{sleep_time}")
+async def test_async_job(sleep_time: int, db: Session = Depends(get_db)):
+    job_task = {'job': my_op, 'param': sleep_time}
+    QUEUE.put_nowait(job_task)
+    task = asyncio.create_task(worker(f'worker-{len(TASKS)+1}', QUEUE))
+    TASKS.append(task)
+    print('return job added')
+    return "job added"
+

--- a/server/sql_app/main_async.py
+++ b/server/sql_app/main_async.py
@@ -1,5 +1,7 @@
 import asyncio
 import time
+import logging
+import sys
 
 from fastapi import Depends, FastAPI, HTTPException
 from fastapi.testclient import TestClient
@@ -8,12 +10,26 @@ from sqlalchemy.orm import Session
 from . import crud, models, schemas
 from .database import SessionLocal, engine
 
+
+logging.basicConfig(
+    level=logging.DEBUG,
+    format=(
+        '%(asctime)s (%(relativeCreated)d) %(levelname)s %(name)s'
+        ' [%(funcName)s:%(lineno)d] %(message)s'),
+    stream=sys.stdout)
+LOGGER = logging.getLogger(__name__)
+
 # Create the db tables
 models.Base.metadata.create_all(bind=engine)
 
 
 app = FastAPI()
 
+# To make sure Exceptions aren't silently ignored:
+# https://stackoverflow.com/questions/27297638/when-asyncio-task-gets-stored-after-creation-exceptions-from-task-get-muted/27299160#27299160
+def handle_result(fut):
+    if fut.exception():
+        fut.result()  # This will raise the exception.
 
 # Dependency
 def get_db():
@@ -25,23 +41,35 @@ def get_db():
 
 
 # Create a queue that we will use to store our "workload".
-QUEUE = asyncio.Queue()
+QUEUE = asyncio.PriorityQueue()
 TASKS = []
+STATUS = {0: "pending", 1: "running", 2: "success", 3: "failed"}
 
 # Normally blocking call (InVEST model, PGP call, wallpapering, ...)
-def my_op(sleep_time):
-    print('Running my_op')
+def my_op(job_details):
+    LOGGER.debug('Running my_op')
+
+    sleep_time = job_details['param']
     time.sleep(sleep_time)
     # Sleep for the "sleep_for" seconds.
     #await asyncio.sleep(sleep_time)
-    print(f'Done sleeping for {sleep_time} seconds')
+    LOGGER.debug(f'Done sleeping for {sleep_time} seconds')
 
 # Our worker to run tasks
 async def worker(name, queue):
     while True:
         # Get a "work item" out of the queue.
-        job_details = await queue.get()
-        print(f'job details: {job_details}')
+        job_priority, job_details = await queue.get()
+        LOGGER.debug(f'job details: {job_details}')
+
+        # I had a try/except here before adding the `add_done_callback` because
+        # there was an exception happening that I was never seeing in the console
+        try:
+            job_schema = schemas.JobBase(**{"name": "my-job", "description": "my-desc", "status": 1})
+            LOGGER.debug('Update job')
+            crud.update_job(db=job_details['db'], job=job_schema, job_id=job_details['job_id'])
+        except Exception as err:
+            LOGGER.error(f'Error: {err}')
 
         # Sleep for the "sleep_for" seconds.
         #await asyncio.sleep(sleep_for)
@@ -49,22 +77,31 @@ async def worker(name, queue):
         # 'gather' and 'to_thread' allows us to await blocking calls for
         # I/O bound or CPU bound processes.
         await asyncio.gather(
-            asyncio.to_thread(run_op, job_details['param']))
+            asyncio.to_thread(run_op, job_details))
 
         # Notify the queue that the "work item" has been processed.
         queue.task_done()
+        job_schema = schemas.JobBase(**{"name": "my-job", "description": "my-desc", "status": 2})
+        LOGGER.debug('Update job')
+        crud.update_job(db=job_details['db'], job=job_schema, job_id=job_details['job_id'])
 
-        print(f'{name} has slept for {job_details["param"]} seconds')
+        LOGGER.debug(f'{name} has slept for {job_details["param"]} seconds')
 
 
 # Endpoint
 
 @app.get("/test-async-job/{sleep_time}")
 async def test_async_job(sleep_time: int, db: Session = Depends(get_db)):
-    job_task = {'job': my_op, 'param': sleep_time}
-    QUEUE.put_nowait(job_task)
+    job_schema = schemas.JobBase(**{"name": "my-job", "description": "my-desc", "status": 0})
+    job_db = crud.create_job(db, job_schema)
+
+    job_task = {'job': my_op, 'param': sleep_time, 'job_id': job_db.job_id, 'db': db}
+    priority = 2
+
+    QUEUE.put_nowait((priority, job_task))
     task = asyncio.create_task(worker(f'worker-{len(TASKS)+1}', QUEUE))
+    task.add_done_callback(handle_result)
     TASKS.append(task)
-    print('return job added')
+    LOGGER.debug('return job added')
     return "job added"
 

--- a/server/sql_app/models.py
+++ b/server/sql_app/models.py
@@ -47,7 +47,10 @@ class Scenario(Base):
 
     scenario_id = Column(Integer, primary_key=True, index=True)
     name = Column(String, index=True)
-    description = Column(String, index=True)
+    description = Column(String)
+    wkt = Column(String, default="bounding-box-geometry-here")
+    lulc_result = Column(String, default="https://my-lulc.tif")
+    lulc_base = Column(String, default="https://my-lulc-base.tif")
     owner_id = Column(String, ForeignKey("users.session_id"))
 
     owner = relationship("User", back_populates="scenarios")

--- a/server/sql_app/models.py
+++ b/server/sql_app/models.py
@@ -15,7 +15,7 @@ class Job(Base):
     """SQLAlchemy model."""
     __tablename__ = "jobs"
 
-    id = Column(Integer, primary_key=True, index=True)
+    job_id = Column(Integer, primary_key=True, index=True)
     name = Column(String, index=True)
     description = Column(String, index=True)
     status = Column(String, index=True)

--- a/server/sql_app/schemas.py
+++ b/server/sql_app/schemas.py
@@ -69,9 +69,6 @@ class JobBase(BaseModel):
     status: str
 
 
-#TODO: will we need to periodically clean up completed / failed jobs?
-# If so, we should make sure the frontend has what it needs to get removed job
-# results.
 class Job(JobBase):
     """Pydantic model (schema) used when reading data, when returning it from API."""
     job_id: int
@@ -82,6 +79,13 @@ class Job(JobBase):
 
 class JobStatus(BaseModel):
     status: str
+
+    class Config:
+        orm_mode = True
+
+
+class JobOut(BaseModel):
+    job_id: int
 
     class Config:
         orm_mode = True

--- a/server/sql_app/schemas.py
+++ b/server/sql_app/schemas.py
@@ -74,7 +74,7 @@ class JobBase(BaseModel):
 # results.
 class Job(JobBase):
     """Pydantic model (schema) used when reading data, when returning it from API."""
-    id: int
+    job_id: int
 
     class Config:
         orm_mode = True

--- a/server/sql_app/schemas.py
+++ b/server/sql_app/schemas.py
@@ -17,6 +17,9 @@ class Scenario(ScenarioBase):
     """Pydantic model (schema) used when reading data, when returning it from API."""
     scenario_id: int
     owner_id: str
+    wkt: str
+    lulc_result: str
+    lulc_base: str
 
     class Config:
         orm_mode = True


### PR DESCRIPTION
This PR introduces a simple job queue for the backend that uses `ansycio.PriorityQueue`. For now the queue definition and the worker live in the endpoints file directly. In the future we would probably separate these out, having a separate process handle the workers. But, hopefully this is a good step that allows us to connect the frontend and backend initially.