### PR TITLE
Add functionality to create thumbnails

### DIFF
--- a/backend-worker/Dockerfile
+++ b/backend-worker/Dockerfile
@@ -3,6 +3,6 @@
 FROM --platform=linux/amd64 mambaorg/micromamba:0.24.0-buster
 
 ARG MAMBA_DOCKERFILE_ACTIVATE=1
-RUN micromamba install -c conda-forge -y pygeoprocessing natcap.invest requests flask_cors
+RUN micromamba install -c conda-forge -y pygeoprocessing natcap.invest requests flask_cors pillow
 
 CMD /opt/conda/bin/python

--- a/backend-worker/worker.py
+++ b/backend-worker/worker.py
@@ -266,16 +266,12 @@ def _reproject_to_nlud(parcel_wkt_epsg3857):
     return parcel_geom
 
 
-def _create_new_lulc(parcel_wkt_epsg3857, target_local_gtiff_path,
-                     copy_pixel_values=False):
+def _create_new_lulc(parcel_wkt_epsg3857, target_local_gtiff_path):
     """Create an LULC raster in the NLCD projection covering the parcel.
 
     Args:
         parcel_wkt_epsg3857 (str): The parcel WKT in EPSG:3857 (Web Mercator)
         target_local_gtiff_path (str): Where the target raster should be saved
-        copy_pixel_values=False (bool): Whether to copy pixel values from the
-            original raster into the new one.  If False, the raster will be
-            filled with nodata.
 
     Returns:
         ``None``
@@ -306,25 +302,7 @@ def _create_new_lulc(parcel_wkt_epsg3857, target_local_gtiff_path,
         [buf_minx, PIXELSIZE_X, 0, buf_maxy, 0, PIXELSIZE_Y])
     band = target_raster.GetRasterBand(1)
     band.SetNoDataValue(NLCD_NODATA)
-    if copy_pixel_values:
-        source_raster = gdal.Open(NLCD_RASTER_PATH)
-        source_band = source_raster.GetRasterBand(1)
-        xoff = round(abs((buf_minx - NLCD_ORIGIN_X) / PIXELSIZE_X))
-        yoff = round(abs((buf_maxy - NLCD_ORIGIN_Y) / PIXELSIZE_Y))
-        source_array = source_band.ReadAsArray(
-            xoff=xoff,
-            yoff=yoff,
-            win_xsize=n_cols,
-            win_ysize=n_rows
-        )
-        print(source_array)
-        band.WriteArray(source_array)
-
-        source_band = None
-        source_raster = None
-
-    else:
-        band.Fill(NLCD_NODATA)
+    band.Fill(NLCD_NODATA)
     target_raster = None
     band = None
 

--- a/backend-worker/worker.py
+++ b/backend-worker/worker.py
@@ -12,14 +12,12 @@ import numpy
 import numpy.testing
 import pygeoprocessing
 import requests
-import shapely.affinity
 import shapely.geometry
 import shapely.wkt
 from osgeo import gdal
 from osgeo import ogr
 from osgeo import osr
 from PIL import Image
-from PIL import ImageDraw
 
 logging.basicConfig(level=logging.INFO)
 LOGGER = logging.getLogger(__name__)


### PR DESCRIPTION
This partially addresses #44 by adding a function to create a thumbnail of a parcel from its wkt and then rendering that as a PNG.  I haven't yet included this in worker.py's `do_work()` because it sounds like we may need a separate job request for this?  Let me know how you think we should hand this!