### PR TITLE
Pattern thumbnail endpoint

### DIFF
--- a/backend-worker/worker.py
+++ b/backend-worker/worker.py
@@ -576,7 +576,7 @@ NLCD_COLORS.update(dict(
     get_classnames_from_raster_attr_table(NLCD_RASTER_PATH).items()))
 
 
-def make_thumbnail(pattern_wkt_epsg3857, colors_dict, target_thumnail_path,
+def make_thumbnail(pattern_wkt_epsg3857, colors_dict, target_thumbnail_path,
                    working_dir=None):
     working_dir = tempfile.mkdtemp(dir=working_dir, prefix='thumbnail-')
     thumbnail_gtiff_path = os.path.join(working_dir, 'pattern.tif')
@@ -593,7 +593,6 @@ def make_thumbnail(pattern_wkt_epsg3857, colors_dict, target_thumnail_path,
     raw_image = Image.open(thumbnail_gtiff_path)
     # 'P' mode indicates palletted color
     image = raw_image.convert('P')
-    print(numpy.asarray(image))
 
     rgb_colors = {}
     for lucode, hex_color in colors_dict.items():
@@ -614,7 +613,7 @@ def make_thumbnail(pattern_wkt_epsg3857, colors_dict, target_thumnail_path,
     factor = 30  # taken from the pixelsize so we can just deal in native units
     image = image.resize((image.width * factor,
                           image.height * factor))
-    image.save(target_thumnail_path)
+    image.save(target_thumbnail_path)
     shutil.rmtree(working_dir, ignore_errors=True)
 
 

--- a/server/sql_app/main.py
+++ b/server/sql_app/main.py
@@ -1,5 +1,6 @@
 import json
 import logging
+import os
 import queue
 import sys
 
@@ -288,46 +289,47 @@ def worker_pattern_response(
         pattern_job (pydantic model): a pydantic model with the following 
             key/vals
 
+        {
             "result": {
                 "pattern_thumbnail_path": "relative path to file location",
-                "status": "success | failed",
-                "server_attrs": {
-                   "job_id": int, "scenario_id": int
-                   }
+                }
+            "status": "success | failed",
+            "server_attrs": {
+               "job_id": int, "scenario_id": int
+               }
+       }
     """
-    LOGGER.debug("Entering jobsqueue/pattern")
-    LOGGER.debug(pattern_job)
     # Update job in db based on status
     job_db = crud.get_job(db, job_id=pattern_job.server_attrs['job_id'])
     # Update Pattern in db with the result
     pattern_db = crud.get_pattern(db, pattern_id=pattern_job.server_attrs['pattern_id'])
 
-    job_status = scenario_job.status
+    job_status = pattern_job.status
     if job_status == "success":
         # Update the job status in the DB to "success"
         job_update = schemas.JobBase(
             status=STATUS_SUCCESS,
             name=job_db.name, description=job_db.description)
-        # Update the scenario lulc path and stats
-        scenario_update = schemas.ScenarioUpdate(
-            lulc_url_result=scenario_job.result['lulc_path'],
-            lulc_stats=json.dumps(scenario_job.result['lulc_stats']))
+        # Update the pattern thumbnail path
+        pattern_update = schemas.PatternUpdate(
+            pattern_thumbnail_path=pattern_job.result['pattern_thumbnail_path'],
+            )
     else:
         # Update the job status in the DB to "failed"
         job_update = schemas.JobBase(
             status=STATUS_FAILED,
             name=job_db.name, description=job_db.description)
-        # Update the the scenario lulc path stats with None
-        scenario_update = schemas.ScenarioUpdate(
-            lulc_url_result=None, lulc_stats=None)
+        # Update the pattern thumbnail path with None
+        pattern_update = schemas.PatternUpdate(
+            pattern_thumbnail_path=None)
 
     LOGGER.debug('Update job status')
     _ = crud.update_job(
-        db=db, job=job_update, job_id=scenario_job.server_attrs['job_id'])
-    LOGGER.debug('Update scenario result')
-    _ = crud.update_scenario(
-        db=db, scenario=scenario_update,
-        scenario_id=scenario_job.server_attrs['scenario_id'])
+        db=db, job=job_update, job_id=pattern_job.server_attrs['job_id'])
+    LOGGER.debug('Update pattern result')
+    _ = crud.update_pattern(
+        db=db, pattern=pattern_update,
+        pattern_id=pattern_job.server_attrs['pattern_id'])
 
 
 @app.post("/jobs/", response_model=schemas.Job)
@@ -354,19 +356,41 @@ def read_jobs(skip: int = 0, limit: int = 100, db: Session = Depends(get_db)):
 ### Task Endpoints ###
 
 @app.post("/pattern/{session_id}", response_model=schemas.PatternResponse)
-def create_pattern(session_id: str, pattern: schemas.PatternBase, db: Session = Depends(get_db)):
-    """Create a wallpapering pattern by just saving the wkt in the db."""
+def create_pattern(session_id: str, pattern: schemas.PatternBase,
+                   db: Session = Depends(get_db)):
+    """Create a wallpapering pattern by saving the wkt and a thumbnail."""
+    # Create job entry for pattern task
+    job_schema = schemas.JobBase(
+        **{"name": "create_pattern",
+           "description": "create pattern thumbnail",
+           "status": STATUS_PENDING})
+
+    job_db = crud.create_job(
+        db=db, session_id=session_id, job=job_schema)
 
     pattern_db = crud.create_pattern(
         db=db, session_id=session_id, pattern=pattern)
 
-    return pattern_db
+    # Construct worker job and add to the queue
+    worker_task = {
+        "job_type": "pattern_thumbnail",
+        "server_attrs": {
+            "job_id": job_db.job_id, "pattern_id": pattern_db.pattern_id
+        },
+        "job_args": {
+            "pattern_wkt": pattern_db.wkt,
+            "lulc_source_url": os.path.join(WORKING_ENV,BASE_LULC),
+        }
+    }
+
+    QUEUE.put_nowait((HIGH_PRIORITY, worker_task))
+
+    return {**worker_task['server_attrs'], "label": pattern.label}
 
 
-@app.get("/pattern/", response_model=list[schemas.PatternResponse])
+@app.get("/pattern/", response_model=list[schemas.Pattern])
 def get_patterns(db: Session = Depends(get_db)):
     """Get a list of the wallpapering patterns saved in the db."""
-
     pattern_db = crud.get_patterns(db=db)
 
     return pattern_db

--- a/server/sql_app/models.py
+++ b/server/sql_app/models.py
@@ -77,6 +77,7 @@ class Pattern(Base):
     pattern_id = Column(Integer, primary_key=True, index=True)
     label = Column(String, index=True)
     wkt = Column(String)
+    pattern_thumbnail_path = Column(String)
     # each pattern has an associated session owner
     owner_id = Column(String, ForeignKey("sessions.session_id"))
 

--- a/server/sql_app/schemas.py
+++ b/server/sql_app/schemas.py
@@ -112,7 +112,7 @@ class PatternBase(BaseModel):
 class Pattern(PatternBase):
     """Pydantic model used when reading data, when returning it from API."""
     pattern_id: int
-    owner_id: str
+    pattern_thumbnail_path: Union[str, None] = None
 
     class Config:
         orm_mode = True
@@ -122,9 +122,15 @@ class PatternResponse(BaseModel):
     """Pydantic model for the response after the pattern creation."""
     pattern_id: int
     label: str
+    job_id: int
 
     class Config:
         orm_mode = True
+
+
+class PatternUpdate(BaseModel):
+    """Pydantic model for updating Pattern in the DB."""
+    pattern_thumbnail_path: Union[str, None] = None
 
 
 class ParcelStatsBase(BaseModel):


### PR DESCRIPTION
This PR finishes the loop with PR #54 by creating server api endpoints to facilitate the creation of pattern thumbnails.

Pattern creation is now a job that is put on the queue for the backend worker to generate a thumbnail. Once the worker completes the task the api endpoint will return the following when requested by the frontend:

```python
[
  {
    "label": "test2",
    "wkt": "POLYGON ((-10968318.16 3429247.98, -10968318.16 3429447.98, -10968518.16 3429447.98, -10968518.16 3429247.98, -10968318.16 3429247.98))",
    "pattern_id": 1,
    "pattern_thumbnail_path": "/opt/appdata/model_outputs/thumbnails/pattern_1_thumbnail.png"
  },
  {
    "label": "test3",
    "wkt": "POLYGON ((-10968318.16 3429247.98, -10968318.16 3429447.98, -10968518.16 3429447.98, -10968518.16 3429247.98, -10968318.16 3429247.98))",
    "pattern_id": 2,
    "pattern_thumbnail_path": "/opt/appdata/model_outputs/thumbnails/pattern_2_thumbnail.png"
  },
]
```

Fixes #44 