### PR TITLE
Add LULC legend control to map

### DIFF
--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -76,6 +76,21 @@ html, body, #root, .App {
   font-weight: 600;
 }
 
+.map-lulc-legend {
+  background-color: rgba(255,255,255,0.9);
+  display: flex;
+  /*height: 1rem;/*
+  /*padding-bottom: 2rem;*/
+  width: 250px;
+  position: absolute;
+  bottom: 1rem;
+  right: 1rem;
+  border-radius: 5px;
+  padding: 0.5rem;
+  font-weight: 600;
+  align-items: center;
+}
+
 /*.edit-wallpaper {
   display: flex;
   align-items: baseline;

--- a/frontend/src/map/legendControl.jsx
+++ b/frontend/src/map/legendControl.jsx
@@ -1,0 +1,36 @@
+import React, { useState } from 'react';
+
+import landuseCodes from '../../../appdata/NLCD_2016.lulcdata.json';
+
+
+export default function LegendControl(props) {
+  const {
+    lulcCode,
+  } = props;
+
+
+  return (
+    <div>
+      {
+        (lulcCode)
+          ? (
+            <>
+              <div className="map-lulc-legend">
+                <div
+                  style={{
+                    backgroundColor: landuseCodes[lulcCode].color,
+                    width: '20px',
+                    height: '20px',
+                    display: 'inline-block',
+                    margin: '0.5em',
+                  }}
+                />
+                <span>{landuseCodes[lulcCode].name}</span>
+              </div>
+            </>
+          )
+          : <div />
+      }
+    </div>
+  );
+}


### PR DESCRIPTION
Adding event handler to map for `pointermove` that sets the state for a LULC code the mouse pointer is hovering over. That code is then displayed in a box on the bottom right of the map.

Added a new react component file to handle the display of the legend control component.

The code style should only show when there is a LULC selected (visible) and it should correspond to the LULC layer "in front". That is, if a base LULC and Scenario LULC are both visible, the Scenario LULC should be the one reported.

I actually think I got the CSS working okay. Desire is to have the display box in the bottom right at fixed width and height. The color box and corresponding text should be centered vertically.

Possible solution for #45 

![image](https://github.com/natcap/urban-online-workflow/assets/2659980/d6ae4659-92a9-4584-8abf-9075aaaf2c42)
