### PR TITLE
add a serviceshed polygon to the map if invest results exist.

### DIFF
--- a/backend-worker/worker.py
+++ b/backend-worker/worker.py
@@ -804,10 +804,16 @@ def do_work(host, port, outputs_location):
                     LOGGER.info(f'Post processing {invest_model} model')
                     model_result_path = model_meta['derive_results'](workspace_dir)
 
+                try:
+                    # For now, we only expect this to work for urban-cooling
+                    serviceshed = args_dict['aoi_vector_path']
+                except KeyError:
+                    serviceshed = ''
                 data = {
                     'result': {
                         'invest-result': model_result_path,
                         'model': job_args['invest_model'],
+                        'serviceshed': serviceshed
                     }
                 }
             else:

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -24,6 +24,7 @@ export default function App() {
   const [patternSamplingMode, setPatternSamplingMode] = useState(false);
   const [patternSampleWKT, setPatternSampleWKT] = useState(null);
   const [selectedScenario, setSelectedScenario] = useState(null);
+  const [serviceshedPath, setServiceshedPath] = useState(null);
 
   const switchStudyArea = async (id) => {
     let area;
@@ -94,6 +95,7 @@ export default function App() {
 
   useEffect(() => {
     refreshScenarios();
+    setServiceshedPath('');
   }, [studyArea.id]);
 
   return (
@@ -111,6 +113,7 @@ export default function App() {
               setPatternSampleWKT={setPatternSampleWKT}
               scenarios={scenarios}
               selectedScenario={selectedScenario}
+              serviceshedPath={serviceshedPath}
             />
             <EditMenu
               sessionID={sessionID}
@@ -126,6 +129,7 @@ export default function App() {
               togglePatternSamplingMode={togglePatternSamplingMode}
               patternSampleWKT={patternSampleWKT}
               setSelectedScenario={setSelectedScenario}
+              setServiceshedPath={setServiceshedPath}
             />
           </div>
         </div>

--- a/frontend/src/edit/edit.jsx
+++ b/frontend/src/edit/edit.jsx
@@ -32,6 +32,7 @@ export default function EditMenu(props) {
     switchStudyArea,
     savedStudyAreas,
     setSelectedScenario,
+    setServiceshedPath,
   } = props;
 
   const [activeTab, setActiveTab] = useState('scenarios');
@@ -49,7 +50,10 @@ export default function EditMenu(props) {
     const data = {};
     scenarios.forEach((scenario, idx) => {
       if (Object.values(modelResults[idx])[0] !== 'InVEST result not found') {
-        data[scenario.name] = modelResults[idx];
+        data[scenario.name] = modelResults[idx]['results'];
+        if (modelResults[idx]['serviceshed']) {
+          setServiceshedPath(modelResults[idx]['serviceshed']);
+        }
       }
     });
     setResults(data);

--- a/frontend/src/map/map.jsx
+++ b/frontend/src/map/map.jsx
@@ -7,6 +7,7 @@ import { Vector as VectorLayer } from 'ol/layer';
 import VectorTileLayer from 'ol/layer/VectorTile';
 import VectorTileSource from 'ol/source/VectorTile';
 import { Vector as VectorSource } from 'ol/source';
+import GeoJSON from 'ol/format/GeoJSON';
 import MVT from 'ol/format/MVT';
 import WKT from 'ol/format/WKT';
 import Feature from 'ol/Feature';
@@ -44,9 +45,12 @@ import {
   hoveredFeatureStyle,
   patternSamplerBoxStyle,
   selectedFeatureStyle,
+  serviceshedStyle,
   studyAreaStyle,
   styleParcel,
 } from './styles';
+
+import { publicUrl } from '../utils';
 
 
 const BASE_LULC_URL = 'https://storage.googleapis.com/natcap-urban-online-datasets-public/NLCD_2016_epsg3857.tif'
@@ -161,6 +165,11 @@ scenarioLayerGroup.set('type', 'scenario-group');
 scenarioLayerGroup.set('title', 'Scenarios:'); // displays in LayerPanel
 scenarioLayerGroup.setZIndex(1);
 
+const serviceshedLayer = new VectorLayer({
+  style: serviceshedStyle
+});
+serviceshedLayer.setZIndex(3);
+
 // Set a default basemap to be visible
 satelliteLayer.setVisible(true);
 
@@ -176,6 +185,7 @@ const map = new Map({
     patternSamplerLayer,
     labelLayer,
     scenarioLayerGroup,
+    serviceshedLayer,
   ],
   view: new View({
     center: [-10964048.932711, 3429505.23069662], // San Antonio, TX EPSG:3857
@@ -199,6 +209,7 @@ export default function MapComponent(props) {
     setPatternSampleWKT,
     scenarios,
     selectedScenario,
+    serviceshedPath,
   } = props;
   const [layers, setLayers] = useState([]);
   const [showLayerControl, setShowLayerControl] = useState(false);
@@ -441,6 +452,21 @@ export default function MapComponent(props) {
       map.addLayer(scenarioLayerGroup);
     }
   }, [scenarios]);
+
+  useEffect(() => {
+    map.removeLayer(serviceshedLayer);
+    if (serviceshedPath) {
+      const source = new VectorSource({
+        format: new GeoJSON({
+          dataProjection: 'EPSG:3857'
+        }),
+        url: publicUrl(serviceshedPath),
+      });
+      console.log(source)
+      serviceshedLayer.setSource(source);
+      map.addLayer(serviceshedLayer);
+    }
+  }, [serviceshedPath]);
 
   // toggle pattern sampler visibility according to the pattern sampling mode
   useEffect(() => {

--- a/frontend/src/map/map.jsx
+++ b/frontend/src/map/map.jsx
@@ -462,7 +462,6 @@ export default function MapComponent(props) {
         }),
         url: publicUrl(serviceshedPath),
       });
-      console.log(source)
       serviceshedLayer.setSource(source);
       map.addLayer(serviceshedLayer);
     }

--- a/frontend/src/map/styles.js
+++ b/frontend/src/map/styles.js
@@ -46,6 +46,14 @@ export const patternSamplerBoxStyle = new Style({
   }),
 });
 
+export const serviceshedStyle = new Style({
+  stroke: new Stroke({
+    color: 'rgba(255, 255, 255, 0.8)',
+    width: 3,
+    lineDash: [5, 5],
+  })
+});
+
 // dynamic style function for parcels
 export function styleParcel(zoom) {
   const style = new Style({

--- a/server/sql_app/crud.py
+++ b/server/sql_app/crud.py
@@ -304,9 +304,9 @@ def get_invest(db: Session, scenario_id: int):
     return db.query(models.InvestResult).filter(
         models.InvestResult.scenario_id == scenario_id).all()
 
-def update_invest(db: Session, scenario_id: int, job_id: int, result: str, model_name: str):
+def update_invest(db: Session, scenario_id: int, job_id: int,
+                  result: str, model_name: str, serviceshed: str):
     """Update an invest result."""
-    # TODO: is job_id unique in InvestResult? Any need to use scenario_id?
     db_invest = db.query(models.InvestResult).filter(
         models.InvestResult.job_id == job_id,
         models.InvestResult.scenario_id == scenario_id).first()
@@ -314,6 +314,7 @@ def update_invest(db: Session, scenario_id: int, job_id: int, result: str, model
         raise HTTPException(status_code=404, detail="InvestResult not found")
     setattr(db_invest, 'result', result)
     setattr(db_invest, 'model_name', model_name)
+    setattr(db_invest, 'serviceshed', serviceshed)
 
     db.add(db_invest)
     db.commit()

--- a/server/sql_app/main.py
+++ b/server/sql_app/main.py
@@ -298,7 +298,8 @@ def worker_invest_response(
             db=db, scenario_id=invest_result.server_attrs['scenario_id'],
             job_id=invest_result.server_attrs['job_id'],
             result=invest_result.result['invest-result'],
-            model_name=invest_result.result['model'])
+            model_name=invest_result.result['model'],
+            serviceshed=invest_result.result['serviceshed'])
     else:
         # Update the job status in the DB to "failed"
         job_update = schemas.JobBase(
@@ -794,14 +795,19 @@ def get_invest_results(scenario_id: int, db: Session = Depends(get_db)):
         raise HTTPException(
             status_code=404, detail="InVEST result not found")
     invest_results = {}
+    serviceshed = ''  # For now, only one model has a serviceshed
     for row in invest_db_list:
         invest_results_path = row.result
         LOGGER.info(invest_results_path)
         # Load json from file
         with open(invest_results_path, 'r') as jfp:
             invest_results.update(json.loads(jfp.read()))
-        LOGGER.info(f"INVEST RESULT RESPONSE: {invest_results}")
-    return invest_results
+            if row.serviceshed:
+                serviceshed = row.serviceshed
+    return {
+        'results': invest_results,
+        'serviceshed': serviceshed
+    }
 
 
 ### Testing ideas from tutorial ###

--- a/server/sql_app/models.py
+++ b/server/sql_app/models.py
@@ -131,5 +131,6 @@ class InvestResult(Base):
     job_id = Column(Integer, ForeignKey("jobs.job_id"), primary_key=True)
     model_name = Column(String)
     result = Column(String)
+    serviceshed = Column(String)
 
     #scenario = relationship("Scenario", back_populates="invest_results")

--- a/server/sql_app/schemas.py
+++ b/server/sql_app/schemas.py
@@ -41,6 +41,7 @@ class InvestResult(BaseModel):
     job_id: int
     result: str = None
     model_name: str
+    serviceshed: str = None
 
     class Config:
         orm_mode = True


### PR DESCRIPTION
For now, only the urban-cooling model has a serviceshed, so there is only one serviceshed polygon per set of invest results. In the future, different invest models may have different servicesheds, but we're ignoring that for now.

FYI @dcdenu4 , you might have already discovered this, but if you want to run the app, you'll likely need to purge the `sql.db` and the `appdata/model_outputs` and `appdata/scenarios` folders as schemas and things have changed in this PR and the last one.