### PR TITLE
Run & Display Urban Nature Access results

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ local path which mounts in container | (bucket where source file can be found)
 - `appdata/invest-data/acs_tract_3857.gpkg` | (natcap-urban-online-datasets)
 - `appdata/invest-data/acs_tract_poverty.csv` | (natcap-urban-online-datasets)
 - `appdata/invest-data/acs_tract_race.csv` | (natcap-urban-online-datasets)
-- `appdata/invest-data/population_san_antonio_final.tif` | (natcap-urban-online-datasets)
+- `appdata/invest-data/population_san_antonio_updated_02_27.tif` | (natcap-urban-online-datasets)
 
 
 ## Necessary API tokens

--- a/README.md
+++ b/README.md
@@ -31,6 +31,8 @@ local path which mounts in container | (bucket where source file can be found)
 - `appdata/invest-data/acs_tract_3857.gpkg` | (natcap-urban-online-datasets)
 - `appdata/invest-data/acs_tract_poverty.csv` | (natcap-urban-online-datasets)
 - `appdata/invest-data/acs_tract_race.csv` | (natcap-urban-online-datasets)
+- `appdata/invest-data/population_san_antonio_final.tif` | (natcap-urban-online-datasets)
+
 
 ## Necessary API tokens
 Currently need to add a `.env` file to `frontend/` with necessary API tokens. Please reach out to repository maintainers to get access to these.

--- a/appdata/invest-data/biophysical_tables/urban_nature_access_nlcd_simple_nlud_trees.csv
+++ b/appdata/invest-data/biophysical_tables/urban_nature_access_nlcd_simple_nlud_trees.csv
@@ -1,2401 +1,2401 @@
-lucode,code,nlud_simple_class,nlud_simple_subclass,simple_nlud,nlcd,nlcd_lulc,nlcd_colors,tree,tree_canopy_cover,tree_colors,greenspace,search_radius_m
-0,001110,Waterbody,Natural,1,11,Open Water,#476BA0,0,none,#ffffff,0.0,2230.0
-1,001111,Waterbody,Natural,1,11,Open Water,#476BA0,1,low,#e5f5e0,0.0,2230.0
-2,001112,Waterbody,Natural,1,11,Open Water,#476BA0,2,medium,#a1d99b,0.0,2230.0
-3,001113,Waterbody,Natural,1,11,Open Water,#476BA0,3,high,#31a354,1.0,2230.0
-4,001120,Waterbody,Natural,1,12,Perennial Ice/Snow,#D1DDF9,0,none,#ffffff,0.0,2230.0
-5,001121,Waterbody,Natural,1,12,Perennial Ice/Snow,#D1DDF9,1,low,#e5f5e0,0.0,2230.0
-6,001122,Waterbody,Natural,1,12,Perennial Ice/Snow,#D1DDF9,2,medium,#a1d99b,0.0,2230.0
-7,001123,Waterbody,Natural,1,12,Perennial Ice/Snow,#D1DDF9,3,high,#31a354,1.0,2230.0
-8,001210,Waterbody,Natural,1,21,"Developed, Open Space",#DDC9C9,0,none,#ffffff,0.0,2230.0
-9,001211,Waterbody,Natural,1,21,"Developed, Open Space",#DDC9C9,1,low,#e5f5e0,0.0,2230.0
-10,001212,Waterbody,Natural,1,21,"Developed, Open Space",#DDC9C9,2,medium,#a1d99b,0.0,2230.0
-11,001213,Waterbody,Natural,1,21,"Developed, Open Space",#DDC9C9,3,high,#31a354,1.0,2230.0
-12,001220,Waterbody,Natural,1,22,"Developed, Low Intensity",#D89382,0,none,#ffffff,0.0,2230.0
-13,001221,Waterbody,Natural,1,22,"Developed, Low Intensity",#D89382,1,low,#e5f5e0,0.0,2230.0
-14,001222,Waterbody,Natural,1,22,"Developed, Low Intensity",#D89382,2,medium,#a1d99b,0.0,2230.0
-15,001223,Waterbody,Natural,1,22,"Developed, Low Intensity",#D89382,3,high,#31a354,1.0,2230.0
-16,001230,Waterbody,Natural,1,23,"Developed, Medium Intensity",#ED0000,0,none,#ffffff,0.0,2230.0
-17,001231,Waterbody,Natural,1,23,"Developed, Medium Intensity",#ED0000,1,low,#e5f5e0,0.0,2230.0
-18,001232,Waterbody,Natural,1,23,"Developed, Medium Intensity",#ED0000,2,medium,#a1d99b,0.0,2230.0
-19,001233,Waterbody,Natural,1,23,"Developed, Medium Intensity",#ED0000,3,high,#31a354,1.0,2230.0
-20,001240,Waterbody,Natural,1,24,"Developed, High Intensity",#AA0000,0,none,#ffffff,0.0,2230.0
-21,001241,Waterbody,Natural,1,24,"Developed, High Intensity",#AA0000,1,low,#e5f5e0,0.0,2230.0
-22,001242,Waterbody,Natural,1,24,"Developed, High Intensity",#AA0000,2,medium,#a1d99b,0.0,2230.0
-23,001243,Waterbody,Natural,1,24,"Developed, High Intensity",#AA0000,3,high,#31a354,1.0,2230.0
-24,001310,Waterbody,Natural,1,31,Barren Land (Rock/Sand/Clay),#B2ADA3,0,none,#ffffff,0.0,2230.0
-25,001311,Waterbody,Natural,1,31,Barren Land (Rock/Sand/Clay),#B2ADA3,1,low,#e5f5e0,0.0,2230.0
-26,001312,Waterbody,Natural,1,31,Barren Land (Rock/Sand/Clay),#B2ADA3,2,medium,#a1d99b,0.0,2230.0
-27,001313,Waterbody,Natural,1,31,Barren Land (Rock/Sand/Clay),#B2ADA3,3,high,#31a354,1.0,2230.0
-28,001410,Waterbody,Natural,1,41,Deciduous Forest,#68AA63,0,none,#ffffff,1.0,2230.0
-29,001411,Waterbody,Natural,1,41,Deciduous Forest,#68AA63,1,low,#e5f5e0,1.0,2230.0
-30,001412,Waterbody,Natural,1,41,Deciduous Forest,#68AA63,2,medium,#a1d99b,1.0,2230.0
-31,001413,Waterbody,Natural,1,41,Deciduous Forest,#68AA63,3,high,#31a354,1.0,2230.0
-32,001420,Waterbody,Natural,1,42,Evergreen Forest,#1C6330,0,none,#ffffff,1.0,2230.0
-33,001421,Waterbody,Natural,1,42,Evergreen Forest,#1C6330,1,low,#e5f5e0,1.0,2230.0
-34,001422,Waterbody,Natural,1,42,Evergreen Forest,#1C6330,2,medium,#a1d99b,1.0,2230.0
-35,001423,Waterbody,Natural,1,42,Evergreen Forest,#1C6330,3,high,#31a354,1.0,2230.0
-36,001430,Waterbody,Natural,1,43,Mixed Forest,#B5C98E,0,none,#ffffff,1.0,2230.0
-37,001431,Waterbody,Natural,1,43,Mixed Forest,#B5C98E,1,low,#e5f5e0,1.0,2230.0
-38,001432,Waterbody,Natural,1,43,Mixed Forest,#B5C98E,2,medium,#a1d99b,1.0,2230.0
-39,001433,Waterbody,Natural,1,43,Mixed Forest,#B5C98E,3,high,#31a354,1.0,2230.0
-40,001510,Waterbody,Natural,1,51,Dwarf Scrub,#A58C30,0,none,#ffffff,0.0,
-41,001511,Waterbody,Natural,1,51,Dwarf Scrub,#A58C30,1,low,#e5f5e0,0.0,
-42,001512,Waterbody,Natural,1,51,Dwarf Scrub,#A58C30,2,medium,#a1d99b,0.0,
-43,001513,Waterbody,Natural,1,51,Dwarf Scrub,#A58C30,3,high,#31a354,1.0,
-44,001520,Waterbody,Natural,1,52,Scrub/Shrub,#CCBA7C,0,none,#ffffff,1.0,2230.0
-45,001521,Waterbody,Natural,1,52,Scrub/Shrub,#CCBA7C,1,low,#e5f5e0,1.0,2230.0
-46,001522,Waterbody,Natural,1,52,Scrub/Shrub,#CCBA7C,2,medium,#a1d99b,1.0,2230.0
-47,001523,Waterbody,Natural,1,52,Scrub/Shrub,#CCBA7C,3,high,#31a354,1.0,2230.0
-48,001710,Waterbody,Natural,1,71,Grassland/Herbaceous,#E2E2C1,0,none,#ffffff,1.0,2230.0
-49,001711,Waterbody,Natural,1,71,Grassland/Herbaceous,#E2E2C1,1,low,#e5f5e0,1.0,2230.0
-50,001712,Waterbody,Natural,1,71,Grassland/Herbaceous,#E2E2C1,2,medium,#a1d99b,1.0,2230.0
-51,001713,Waterbody,Natural,1,71,Grassland/Herbaceous,#E2E2C1,3,high,#31a354,1.0,2230.0
-52,001720,Waterbody,Natural,1,72,Sedge/Herbaceuous,#C9C977,0,none,#ffffff,0.0,
-53,001721,Waterbody,Natural,1,72,Sedge/Herbaceuous,#C9C977,1,low,#e5f5e0,0.0,
-54,001722,Waterbody,Natural,1,72,Sedge/Herbaceuous,#C9C977,2,medium,#a1d99b,0.0,
-55,001723,Waterbody,Natural,1,72,Sedge/Herbaceuous,#C9C977,3,high,#31a354,1.0,
-56,001730,Waterbody,Natural,1,73,Lichens,#99C147,0,none,#ffffff,0.0,
-57,001731,Waterbody,Natural,1,73,Lichens,#99C147,1,low,#e5f5e0,0.0,
-58,001732,Waterbody,Natural,1,73,Lichens,#99C147,2,medium,#a1d99b,0.0,
-59,001733,Waterbody,Natural,1,73,Lichens,#99C147,3,high,#31a354,1.0,
-60,001740,Waterbody,Natural,1,74,Moss,#77AD93,0,none,#ffffff,0.0,
-61,001741,Waterbody,Natural,1,74,Moss,#77AD93,1,low,#e5f5e0,0.0,
-62,001742,Waterbody,Natural,1,74,Moss,#77AD93,2,medium,#a1d99b,0.0,
-63,001743,Waterbody,Natural,1,74,Moss,#77AD93,3,high,#31a354,1.0,
-64,001810,Waterbody,Natural,1,81,Pasture/Hay,#DBD83D,0,none,#ffffff,0.0,2230.0
-65,001811,Waterbody,Natural,1,81,Pasture/Hay,#DBD83D,1,low,#e5f5e0,0.0,2230.0
-66,001812,Waterbody,Natural,1,81,Pasture/Hay,#DBD83D,2,medium,#a1d99b,0.0,2230.0
-67,001813,Waterbody,Natural,1,81,Pasture/Hay,#DBD83D,3,high,#31a354,1.0,2230.0
-68,001820,Waterbody,Natural,1,82,Cultivated Crops,#AA7028,0,none,#ffffff,0.0,2230.0
-69,001821,Waterbody,Natural,1,82,Cultivated Crops,#AA7028,1,low,#e5f5e0,0.0,2230.0
-70,001822,Waterbody,Natural,1,82,Cultivated Crops,#AA7028,2,medium,#a1d99b,0.0,2230.0
-71,001823,Waterbody,Natural,1,82,Cultivated Crops,#AA7028,3,high,#31a354,1.0,2230.0
-72,001900,Waterbody,Natural,1,90,Woody Wetlands,#BAD8EA,0,none,#ffffff,1.0,2230.0
-73,001901,Waterbody,Natural,1,90,Woody Wetlands,#BAD8EA,1,low,#e5f5e0,1.0,2230.0
-74,001902,Waterbody,Natural,1,90,Woody Wetlands,#BAD8EA,2,medium,#a1d99b,1.0,2230.0
-75,001903,Waterbody,Natural,1,90,Woody Wetlands,#BAD8EA,3,high,#31a354,1.0,2230.0
-76,001950,Waterbody,Natural,1,95,Emergent Herbaceous Wetlands,#70A3BA,0,none,#ffffff,1.0,2230.0
-77,001951,Waterbody,Natural,1,95,Emergent Herbaceous Wetlands,#70A3BA,1,low,#e5f5e0,1.0,2230.0
-78,001952,Waterbody,Natural,1,95,Emergent Herbaceous Wetlands,#70A3BA,2,medium,#a1d99b,1.0,2230.0
-79,001953,Waterbody,Natural,1,95,Emergent Herbaceous Wetlands,#70A3BA,3,high,#31a354,1.0,2230.0
-80,002110,Waterbody,Wetland,2,11,Open Water,#476BA0,0,none,#ffffff,0.0,2230.0
-81,002111,Waterbody,Wetland,2,11,Open Water,#476BA0,1,low,#e5f5e0,0.0,2230.0
-82,002112,Waterbody,Wetland,2,11,Open Water,#476BA0,2,medium,#a1d99b,0.0,2230.0
-83,002113,Waterbody,Wetland,2,11,Open Water,#476BA0,3,high,#31a354,1.0,2230.0
-84,002120,Waterbody,Wetland,2,12,Perennial Ice/Snow,#D1DDF9,0,none,#ffffff,0.0,2230.0
-85,002121,Waterbody,Wetland,2,12,Perennial Ice/Snow,#D1DDF9,1,low,#e5f5e0,0.0,2230.0
-86,002122,Waterbody,Wetland,2,12,Perennial Ice/Snow,#D1DDF9,2,medium,#a1d99b,0.0,2230.0
-87,002123,Waterbody,Wetland,2,12,Perennial Ice/Snow,#D1DDF9,3,high,#31a354,1.0,2230.0
-88,002210,Waterbody,Wetland,2,21,"Developed, Open Space",#DDC9C9,0,none,#ffffff,0.0,2230.0
-89,002211,Waterbody,Wetland,2,21,"Developed, Open Space",#DDC9C9,1,low,#e5f5e0,0.0,2230.0
-90,002212,Waterbody,Wetland,2,21,"Developed, Open Space",#DDC9C9,2,medium,#a1d99b,0.0,2230.0
-91,002213,Waterbody,Wetland,2,21,"Developed, Open Space",#DDC9C9,3,high,#31a354,1.0,2230.0
-92,002220,Waterbody,Wetland,2,22,"Developed, Low Intensity",#D89382,0,none,#ffffff,0.0,2230.0
-93,002221,Waterbody,Wetland,2,22,"Developed, Low Intensity",#D89382,1,low,#e5f5e0,0.0,2230.0
-94,002222,Waterbody,Wetland,2,22,"Developed, Low Intensity",#D89382,2,medium,#a1d99b,0.0,2230.0
-95,002223,Waterbody,Wetland,2,22,"Developed, Low Intensity",#D89382,3,high,#31a354,1.0,2230.0
-96,002230,Waterbody,Wetland,2,23,"Developed, Medium Intensity",#ED0000,0,none,#ffffff,0.0,2230.0
-97,002231,Waterbody,Wetland,2,23,"Developed, Medium Intensity",#ED0000,1,low,#e5f5e0,0.0,2230.0
-98,002232,Waterbody,Wetland,2,23,"Developed, Medium Intensity",#ED0000,2,medium,#a1d99b,0.0,2230.0
-99,002233,Waterbody,Wetland,2,23,"Developed, Medium Intensity",#ED0000,3,high,#31a354,1.0,2230.0
-100,002240,Waterbody,Wetland,2,24,"Developed, High Intensity",#AA0000,0,none,#ffffff,0.0,2230.0
-101,002241,Waterbody,Wetland,2,24,"Developed, High Intensity",#AA0000,1,low,#e5f5e0,0.0,2230.0
-102,002242,Waterbody,Wetland,2,24,"Developed, High Intensity",#AA0000,2,medium,#a1d99b,0.0,2230.0
-103,002243,Waterbody,Wetland,2,24,"Developed, High Intensity",#AA0000,3,high,#31a354,1.0,2230.0
-104,002310,Waterbody,Wetland,2,31,Barren Land (Rock/Sand/Clay),#B2ADA3,0,none,#ffffff,0.0,2230.0
-105,002311,Waterbody,Wetland,2,31,Barren Land (Rock/Sand/Clay),#B2ADA3,1,low,#e5f5e0,0.0,2230.0
-106,002312,Waterbody,Wetland,2,31,Barren Land (Rock/Sand/Clay),#B2ADA3,2,medium,#a1d99b,0.0,2230.0
-107,002313,Waterbody,Wetland,2,31,Barren Land (Rock/Sand/Clay),#B2ADA3,3,high,#31a354,1.0,2230.0
-108,002410,Waterbody,Wetland,2,41,Deciduous Forest,#68AA63,0,none,#ffffff,1.0,2230.0
-109,002411,Waterbody,Wetland,2,41,Deciduous Forest,#68AA63,1,low,#e5f5e0,1.0,2230.0
-110,002412,Waterbody,Wetland,2,41,Deciduous Forest,#68AA63,2,medium,#a1d99b,1.0,2230.0
-111,002413,Waterbody,Wetland,2,41,Deciduous Forest,#68AA63,3,high,#31a354,1.0,2230.0
-112,002420,Waterbody,Wetland,2,42,Evergreen Forest,#1C6330,0,none,#ffffff,1.0,2230.0
-113,002421,Waterbody,Wetland,2,42,Evergreen Forest,#1C6330,1,low,#e5f5e0,1.0,2230.0
-114,002422,Waterbody,Wetland,2,42,Evergreen Forest,#1C6330,2,medium,#a1d99b,1.0,2230.0
-115,002423,Waterbody,Wetland,2,42,Evergreen Forest,#1C6330,3,high,#31a354,1.0,2230.0
-116,002430,Waterbody,Wetland,2,43,Mixed Forest,#B5C98E,0,none,#ffffff,1.0,2230.0
-117,002431,Waterbody,Wetland,2,43,Mixed Forest,#B5C98E,1,low,#e5f5e0,1.0,2230.0
-118,002432,Waterbody,Wetland,2,43,Mixed Forest,#B5C98E,2,medium,#a1d99b,1.0,2230.0
-119,002433,Waterbody,Wetland,2,43,Mixed Forest,#B5C98E,3,high,#31a354,1.0,2230.0
-120,002510,Waterbody,Wetland,2,51,Dwarf Scrub,#A58C30,0,none,#ffffff,0.0,
-121,002511,Waterbody,Wetland,2,51,Dwarf Scrub,#A58C30,1,low,#e5f5e0,0.0,
-122,002512,Waterbody,Wetland,2,51,Dwarf Scrub,#A58C30,2,medium,#a1d99b,0.0,
-123,002513,Waterbody,Wetland,2,51,Dwarf Scrub,#A58C30,3,high,#31a354,1.0,
-124,002520,Waterbody,Wetland,2,52,Scrub/Shrub,#CCBA7C,0,none,#ffffff,1.0,2230.0
-125,002521,Waterbody,Wetland,2,52,Scrub/Shrub,#CCBA7C,1,low,#e5f5e0,1.0,2230.0
-126,002522,Waterbody,Wetland,2,52,Scrub/Shrub,#CCBA7C,2,medium,#a1d99b,1.0,2230.0
-127,002523,Waterbody,Wetland,2,52,Scrub/Shrub,#CCBA7C,3,high,#31a354,1.0,2230.0
-128,002710,Waterbody,Wetland,2,71,Grassland/Herbaceous,#E2E2C1,0,none,#ffffff,1.0,2230.0
-129,002711,Waterbody,Wetland,2,71,Grassland/Herbaceous,#E2E2C1,1,low,#e5f5e0,1.0,2230.0
-130,002712,Waterbody,Wetland,2,71,Grassland/Herbaceous,#E2E2C1,2,medium,#a1d99b,1.0,2230.0
-131,002713,Waterbody,Wetland,2,71,Grassland/Herbaceous,#E2E2C1,3,high,#31a354,1.0,2230.0
-132,002720,Waterbody,Wetland,2,72,Sedge/Herbaceuous,#C9C977,0,none,#ffffff,0.0,
-133,002721,Waterbody,Wetland,2,72,Sedge/Herbaceuous,#C9C977,1,low,#e5f5e0,0.0,
-134,002722,Waterbody,Wetland,2,72,Sedge/Herbaceuous,#C9C977,2,medium,#a1d99b,0.0,
-135,002723,Waterbody,Wetland,2,72,Sedge/Herbaceuous,#C9C977,3,high,#31a354,1.0,
-136,002730,Waterbody,Wetland,2,73,Lichens,#99C147,0,none,#ffffff,0.0,
-137,002731,Waterbody,Wetland,2,73,Lichens,#99C147,1,low,#e5f5e0,0.0,
-138,002732,Waterbody,Wetland,2,73,Lichens,#99C147,2,medium,#a1d99b,0.0,
-139,002733,Waterbody,Wetland,2,73,Lichens,#99C147,3,high,#31a354,1.0,
-140,002740,Waterbody,Wetland,2,74,Moss,#77AD93,0,none,#ffffff,0.0,
-141,002741,Waterbody,Wetland,2,74,Moss,#77AD93,1,low,#e5f5e0,0.0,
-142,002742,Waterbody,Wetland,2,74,Moss,#77AD93,2,medium,#a1d99b,0.0,
-143,002743,Waterbody,Wetland,2,74,Moss,#77AD93,3,high,#31a354,1.0,
-144,002810,Waterbody,Wetland,2,81,Pasture/Hay,#DBD83D,0,none,#ffffff,0.0,2230.0
-145,002811,Waterbody,Wetland,2,81,Pasture/Hay,#DBD83D,1,low,#e5f5e0,0.0,2230.0
-146,002812,Waterbody,Wetland,2,81,Pasture/Hay,#DBD83D,2,medium,#a1d99b,0.0,2230.0
-147,002813,Waterbody,Wetland,2,81,Pasture/Hay,#DBD83D,3,high,#31a354,1.0,2230.0
-148,002820,Waterbody,Wetland,2,82,Cultivated Crops,#AA7028,0,none,#ffffff,0.0,2230.0
-149,002821,Waterbody,Wetland,2,82,Cultivated Crops,#AA7028,1,low,#e5f5e0,0.0,2230.0
-150,002822,Waterbody,Wetland,2,82,Cultivated Crops,#AA7028,2,medium,#a1d99b,0.0,2230.0
-151,002823,Waterbody,Wetland,2,82,Cultivated Crops,#AA7028,3,high,#31a354,1.0,2230.0
-152,002900,Waterbody,Wetland,2,90,Woody Wetlands,#BAD8EA,0,none,#ffffff,1.0,2230.0
-153,002901,Waterbody,Wetland,2,90,Woody Wetlands,#BAD8EA,1,low,#e5f5e0,1.0,2230.0
-154,002902,Waterbody,Wetland,2,90,Woody Wetlands,#BAD8EA,2,medium,#a1d99b,1.0,2230.0
-155,002903,Waterbody,Wetland,2,90,Woody Wetlands,#BAD8EA,3,high,#31a354,1.0,2230.0
-156,002950,Waterbody,Wetland,2,95,Emergent Herbaceous Wetlands,#70A3BA,0,none,#ffffff,1.0,2230.0
-157,002951,Waterbody,Wetland,2,95,Emergent Herbaceous Wetlands,#70A3BA,1,low,#e5f5e0,1.0,2230.0
-158,002952,Waterbody,Wetland,2,95,Emergent Herbaceous Wetlands,#70A3BA,2,medium,#a1d99b,1.0,2230.0
-159,002953,Waterbody,Wetland,2,95,Emergent Herbaceous Wetlands,#70A3BA,3,high,#31a354,1.0,2230.0
-160,003110,Waterbody,Artificial,3,11,Open Water,#476BA0,0,none,#ffffff,0.0,2230.0
-161,003111,Waterbody,Artificial,3,11,Open Water,#476BA0,1,low,#e5f5e0,0.0,2230.0
-162,003112,Waterbody,Artificial,3,11,Open Water,#476BA0,2,medium,#a1d99b,0.0,2230.0
-163,003113,Waterbody,Artificial,3,11,Open Water,#476BA0,3,high,#31a354,1.0,2230.0
-164,003120,Waterbody,Artificial,3,12,Perennial Ice/Snow,#D1DDF9,0,none,#ffffff,0.0,2230.0
-165,003121,Waterbody,Artificial,3,12,Perennial Ice/Snow,#D1DDF9,1,low,#e5f5e0,0.0,2230.0
-166,003122,Waterbody,Artificial,3,12,Perennial Ice/Snow,#D1DDF9,2,medium,#a1d99b,0.0,2230.0
-167,003123,Waterbody,Artificial,3,12,Perennial Ice/Snow,#D1DDF9,3,high,#31a354,1.0,2230.0
-168,003210,Waterbody,Artificial,3,21,"Developed, Open Space",#DDC9C9,0,none,#ffffff,0.0,2230.0
-169,003211,Waterbody,Artificial,3,21,"Developed, Open Space",#DDC9C9,1,low,#e5f5e0,0.0,2230.0
-170,003212,Waterbody,Artificial,3,21,"Developed, Open Space",#DDC9C9,2,medium,#a1d99b,0.0,2230.0
-171,003213,Waterbody,Artificial,3,21,"Developed, Open Space",#DDC9C9,3,high,#31a354,1.0,2230.0
-172,003220,Waterbody,Artificial,3,22,"Developed, Low Intensity",#D89382,0,none,#ffffff,0.0,2230.0
-173,003221,Waterbody,Artificial,3,22,"Developed, Low Intensity",#D89382,1,low,#e5f5e0,0.0,2230.0
-174,003222,Waterbody,Artificial,3,22,"Developed, Low Intensity",#D89382,2,medium,#a1d99b,0.0,2230.0
-175,003223,Waterbody,Artificial,3,22,"Developed, Low Intensity",#D89382,3,high,#31a354,1.0,2230.0
-176,003230,Waterbody,Artificial,3,23,"Developed, Medium Intensity",#ED0000,0,none,#ffffff,0.0,2230.0
-177,003231,Waterbody,Artificial,3,23,"Developed, Medium Intensity",#ED0000,1,low,#e5f5e0,0.0,2230.0
-178,003232,Waterbody,Artificial,3,23,"Developed, Medium Intensity",#ED0000,2,medium,#a1d99b,0.0,2230.0
-179,003233,Waterbody,Artificial,3,23,"Developed, Medium Intensity",#ED0000,3,high,#31a354,1.0,2230.0
-180,003240,Waterbody,Artificial,3,24,"Developed, High Intensity",#AA0000,0,none,#ffffff,0.0,2230.0
-181,003241,Waterbody,Artificial,3,24,"Developed, High Intensity",#AA0000,1,low,#e5f5e0,0.0,2230.0
-182,003242,Waterbody,Artificial,3,24,"Developed, High Intensity",#AA0000,2,medium,#a1d99b,0.0,2230.0
-183,003243,Waterbody,Artificial,3,24,"Developed, High Intensity",#AA0000,3,high,#31a354,1.0,2230.0
-184,003310,Waterbody,Artificial,3,31,Barren Land (Rock/Sand/Clay),#B2ADA3,0,none,#ffffff,0.0,2230.0
-185,003311,Waterbody,Artificial,3,31,Barren Land (Rock/Sand/Clay),#B2ADA3,1,low,#e5f5e0,0.0,2230.0
-186,003312,Waterbody,Artificial,3,31,Barren Land (Rock/Sand/Clay),#B2ADA3,2,medium,#a1d99b,0.0,2230.0
-187,003313,Waterbody,Artificial,3,31,Barren Land (Rock/Sand/Clay),#B2ADA3,3,high,#31a354,1.0,2230.0
-188,003410,Waterbody,Artificial,3,41,Deciduous Forest,#68AA63,0,none,#ffffff,1.0,2230.0
-189,003411,Waterbody,Artificial,3,41,Deciduous Forest,#68AA63,1,low,#e5f5e0,1.0,2230.0
-190,003412,Waterbody,Artificial,3,41,Deciduous Forest,#68AA63,2,medium,#a1d99b,1.0,2230.0
-191,003413,Waterbody,Artificial,3,41,Deciduous Forest,#68AA63,3,high,#31a354,1.0,2230.0
-192,003420,Waterbody,Artificial,3,42,Evergreen Forest,#1C6330,0,none,#ffffff,1.0,2230.0
-193,003421,Waterbody,Artificial,3,42,Evergreen Forest,#1C6330,1,low,#e5f5e0,1.0,2230.0
-194,003422,Waterbody,Artificial,3,42,Evergreen Forest,#1C6330,2,medium,#a1d99b,1.0,2230.0
-195,003423,Waterbody,Artificial,3,42,Evergreen Forest,#1C6330,3,high,#31a354,1.0,2230.0
-196,003430,Waterbody,Artificial,3,43,Mixed Forest,#B5C98E,0,none,#ffffff,1.0,2230.0
-197,003431,Waterbody,Artificial,3,43,Mixed Forest,#B5C98E,1,low,#e5f5e0,1.0,2230.0
-198,003432,Waterbody,Artificial,3,43,Mixed Forest,#B5C98E,2,medium,#a1d99b,1.0,2230.0
-199,003433,Waterbody,Artificial,3,43,Mixed Forest,#B5C98E,3,high,#31a354,1.0,2230.0
-200,003510,Waterbody,Artificial,3,51,Dwarf Scrub,#A58C30,0,none,#ffffff,0.0,
-201,003511,Waterbody,Artificial,3,51,Dwarf Scrub,#A58C30,1,low,#e5f5e0,0.0,
-202,003512,Waterbody,Artificial,3,51,Dwarf Scrub,#A58C30,2,medium,#a1d99b,0.0,
-203,003513,Waterbody,Artificial,3,51,Dwarf Scrub,#A58C30,3,high,#31a354,1.0,
-204,003520,Waterbody,Artificial,3,52,Scrub/Shrub,#CCBA7C,0,none,#ffffff,1.0,2230.0
-205,003521,Waterbody,Artificial,3,52,Scrub/Shrub,#CCBA7C,1,low,#e5f5e0,1.0,2230.0
-206,003522,Waterbody,Artificial,3,52,Scrub/Shrub,#CCBA7C,2,medium,#a1d99b,1.0,2230.0
-207,003523,Waterbody,Artificial,3,52,Scrub/Shrub,#CCBA7C,3,high,#31a354,1.0,2230.0
-208,003710,Waterbody,Artificial,3,71,Grassland/Herbaceous,#E2E2C1,0,none,#ffffff,1.0,2230.0
-209,003711,Waterbody,Artificial,3,71,Grassland/Herbaceous,#E2E2C1,1,low,#e5f5e0,1.0,2230.0
-210,003712,Waterbody,Artificial,3,71,Grassland/Herbaceous,#E2E2C1,2,medium,#a1d99b,1.0,2230.0
-211,003713,Waterbody,Artificial,3,71,Grassland/Herbaceous,#E2E2C1,3,high,#31a354,1.0,2230.0
-212,003720,Waterbody,Artificial,3,72,Sedge/Herbaceuous,#C9C977,0,none,#ffffff,0.0,
-213,003721,Waterbody,Artificial,3,72,Sedge/Herbaceuous,#C9C977,1,low,#e5f5e0,0.0,
-214,003722,Waterbody,Artificial,3,72,Sedge/Herbaceuous,#C9C977,2,medium,#a1d99b,0.0,
-215,003723,Waterbody,Artificial,3,72,Sedge/Herbaceuous,#C9C977,3,high,#31a354,1.0,
-216,003730,Waterbody,Artificial,3,73,Lichens,#99C147,0,none,#ffffff,0.0,
-217,003731,Waterbody,Artificial,3,73,Lichens,#99C147,1,low,#e5f5e0,0.0,
-218,003732,Waterbody,Artificial,3,73,Lichens,#99C147,2,medium,#a1d99b,0.0,
-219,003733,Waterbody,Artificial,3,73,Lichens,#99C147,3,high,#31a354,1.0,
-220,003740,Waterbody,Artificial,3,74,Moss,#77AD93,0,none,#ffffff,0.0,
-221,003741,Waterbody,Artificial,3,74,Moss,#77AD93,1,low,#e5f5e0,0.0,
-222,003742,Waterbody,Artificial,3,74,Moss,#77AD93,2,medium,#a1d99b,0.0,
-223,003743,Waterbody,Artificial,3,74,Moss,#77AD93,3,high,#31a354,1.0,
-224,003810,Waterbody,Artificial,3,81,Pasture/Hay,#DBD83D,0,none,#ffffff,0.0,2230.0
-225,003811,Waterbody,Artificial,3,81,Pasture/Hay,#DBD83D,1,low,#e5f5e0,0.0,2230.0
-226,003812,Waterbody,Artificial,3,81,Pasture/Hay,#DBD83D,2,medium,#a1d99b,0.0,2230.0
-227,003813,Waterbody,Artificial,3,81,Pasture/Hay,#DBD83D,3,high,#31a354,1.0,2230.0
-228,003820,Waterbody,Artificial,3,82,Cultivated Crops,#AA7028,0,none,#ffffff,0.0,2230.0
-229,003821,Waterbody,Artificial,3,82,Cultivated Crops,#AA7028,1,low,#e5f5e0,0.0,2230.0
-230,003822,Waterbody,Artificial,3,82,Cultivated Crops,#AA7028,2,medium,#a1d99b,0.0,2230.0
-231,003823,Waterbody,Artificial,3,82,Cultivated Crops,#AA7028,3,high,#31a354,1.0,2230.0
-232,003900,Waterbody,Artificial,3,90,Woody Wetlands,#BAD8EA,0,none,#ffffff,1.0,2230.0
-233,003901,Waterbody,Artificial,3,90,Woody Wetlands,#BAD8EA,1,low,#e5f5e0,1.0,2230.0
-234,003902,Waterbody,Artificial,3,90,Woody Wetlands,#BAD8EA,2,medium,#a1d99b,1.0,2230.0
-235,003903,Waterbody,Artificial,3,90,Woody Wetlands,#BAD8EA,3,high,#31a354,1.0,2230.0
-236,003950,Waterbody,Artificial,3,95,Emergent Herbaceous Wetlands,#70A3BA,0,none,#ffffff,1.0,2230.0
-237,003951,Waterbody,Artificial,3,95,Emergent Herbaceous Wetlands,#70A3BA,1,low,#e5f5e0,1.0,2230.0
-238,003952,Waterbody,Artificial,3,95,Emergent Herbaceous Wetlands,#70A3BA,2,medium,#a1d99b,1.0,2230.0
-239,003953,Waterbody,Artificial,3,95,Emergent Herbaceous Wetlands,#70A3BA,3,high,#31a354,1.0,2230.0
-240,004110,Waterbody,Perennial Ice/Snow,4,11,Open Water,#476BA0,0,none,#ffffff,0.0,2230.0
-241,004111,Waterbody,Perennial Ice/Snow,4,11,Open Water,#476BA0,1,low,#e5f5e0,0.0,2230.0
-242,004112,Waterbody,Perennial Ice/Snow,4,11,Open Water,#476BA0,2,medium,#a1d99b,0.0,2230.0
-243,004113,Waterbody,Perennial Ice/Snow,4,11,Open Water,#476BA0,3,high,#31a354,1.0,2230.0
-244,004120,Waterbody,Perennial Ice/Snow,4,12,Perennial Ice/Snow,#D1DDF9,0,none,#ffffff,0.0,2230.0
-245,004121,Waterbody,Perennial Ice/Snow,4,12,Perennial Ice/Snow,#D1DDF9,1,low,#e5f5e0,0.0,2230.0
-246,004122,Waterbody,Perennial Ice/Snow,4,12,Perennial Ice/Snow,#D1DDF9,2,medium,#a1d99b,0.0,2230.0
-247,004123,Waterbody,Perennial Ice/Snow,4,12,Perennial Ice/Snow,#D1DDF9,3,high,#31a354,1.0,2230.0
-248,004210,Waterbody,Perennial Ice/Snow,4,21,"Developed, Open Space",#DDC9C9,0,none,#ffffff,0.0,2230.0
-249,004211,Waterbody,Perennial Ice/Snow,4,21,"Developed, Open Space",#DDC9C9,1,low,#e5f5e0,0.0,2230.0
-250,004212,Waterbody,Perennial Ice/Snow,4,21,"Developed, Open Space",#DDC9C9,2,medium,#a1d99b,0.0,2230.0
-251,004213,Waterbody,Perennial Ice/Snow,4,21,"Developed, Open Space",#DDC9C9,3,high,#31a354,1.0,2230.0
-252,004220,Waterbody,Perennial Ice/Snow,4,22,"Developed, Low Intensity",#D89382,0,none,#ffffff,0.0,2230.0
-253,004221,Waterbody,Perennial Ice/Snow,4,22,"Developed, Low Intensity",#D89382,1,low,#e5f5e0,0.0,2230.0
-254,004222,Waterbody,Perennial Ice/Snow,4,22,"Developed, Low Intensity",#D89382,2,medium,#a1d99b,0.0,2230.0
-255,004223,Waterbody,Perennial Ice/Snow,4,22,"Developed, Low Intensity",#D89382,3,high,#31a354,1.0,2230.0
-256,004230,Waterbody,Perennial Ice/Snow,4,23,"Developed, Medium Intensity",#ED0000,0,none,#ffffff,0.0,2230.0
-257,004231,Waterbody,Perennial Ice/Snow,4,23,"Developed, Medium Intensity",#ED0000,1,low,#e5f5e0,0.0,2230.0
-258,004232,Waterbody,Perennial Ice/Snow,4,23,"Developed, Medium Intensity",#ED0000,2,medium,#a1d99b,0.0,2230.0
-259,004233,Waterbody,Perennial Ice/Snow,4,23,"Developed, Medium Intensity",#ED0000,3,high,#31a354,1.0,2230.0
-260,004240,Waterbody,Perennial Ice/Snow,4,24,"Developed, High Intensity",#AA0000,0,none,#ffffff,0.0,2230.0
-261,004241,Waterbody,Perennial Ice/Snow,4,24,"Developed, High Intensity",#AA0000,1,low,#e5f5e0,0.0,2230.0
-262,004242,Waterbody,Perennial Ice/Snow,4,24,"Developed, High Intensity",#AA0000,2,medium,#a1d99b,0.0,2230.0
-263,004243,Waterbody,Perennial Ice/Snow,4,24,"Developed, High Intensity",#AA0000,3,high,#31a354,1.0,2230.0
-264,004310,Waterbody,Perennial Ice/Snow,4,31,Barren Land (Rock/Sand/Clay),#B2ADA3,0,none,#ffffff,0.0,2230.0
-265,004311,Waterbody,Perennial Ice/Snow,4,31,Barren Land (Rock/Sand/Clay),#B2ADA3,1,low,#e5f5e0,0.0,2230.0
-266,004312,Waterbody,Perennial Ice/Snow,4,31,Barren Land (Rock/Sand/Clay),#B2ADA3,2,medium,#a1d99b,0.0,2230.0
-267,004313,Waterbody,Perennial Ice/Snow,4,31,Barren Land (Rock/Sand/Clay),#B2ADA3,3,high,#31a354,1.0,2230.0
-268,004410,Waterbody,Perennial Ice/Snow,4,41,Deciduous Forest,#68AA63,0,none,#ffffff,1.0,2230.0
-269,004411,Waterbody,Perennial Ice/Snow,4,41,Deciduous Forest,#68AA63,1,low,#e5f5e0,1.0,2230.0
-270,004412,Waterbody,Perennial Ice/Snow,4,41,Deciduous Forest,#68AA63,2,medium,#a1d99b,1.0,2230.0
-271,004413,Waterbody,Perennial Ice/Snow,4,41,Deciduous Forest,#68AA63,3,high,#31a354,1.0,2230.0
-272,004420,Waterbody,Perennial Ice/Snow,4,42,Evergreen Forest,#1C6330,0,none,#ffffff,1.0,2230.0
-273,004421,Waterbody,Perennial Ice/Snow,4,42,Evergreen Forest,#1C6330,1,low,#e5f5e0,1.0,2230.0
-274,004422,Waterbody,Perennial Ice/Snow,4,42,Evergreen Forest,#1C6330,2,medium,#a1d99b,1.0,2230.0
-275,004423,Waterbody,Perennial Ice/Snow,4,42,Evergreen Forest,#1C6330,3,high,#31a354,1.0,2230.0
-276,004430,Waterbody,Perennial Ice/Snow,4,43,Mixed Forest,#B5C98E,0,none,#ffffff,1.0,2230.0
-277,004431,Waterbody,Perennial Ice/Snow,4,43,Mixed Forest,#B5C98E,1,low,#e5f5e0,1.0,2230.0
-278,004432,Waterbody,Perennial Ice/Snow,4,43,Mixed Forest,#B5C98E,2,medium,#a1d99b,1.0,2230.0
-279,004433,Waterbody,Perennial Ice/Snow,4,43,Mixed Forest,#B5C98E,3,high,#31a354,1.0,2230.0
-280,004510,Waterbody,Perennial Ice/Snow,4,51,Dwarf Scrub,#A58C30,0,none,#ffffff,0.0,
-281,004511,Waterbody,Perennial Ice/Snow,4,51,Dwarf Scrub,#A58C30,1,low,#e5f5e0,0.0,
-282,004512,Waterbody,Perennial Ice/Snow,4,51,Dwarf Scrub,#A58C30,2,medium,#a1d99b,0.0,
-283,004513,Waterbody,Perennial Ice/Snow,4,51,Dwarf Scrub,#A58C30,3,high,#31a354,1.0,
-284,004520,Waterbody,Perennial Ice/Snow,4,52,Scrub/Shrub,#CCBA7C,0,none,#ffffff,1.0,2230.0
-285,004521,Waterbody,Perennial Ice/Snow,4,52,Scrub/Shrub,#CCBA7C,1,low,#e5f5e0,1.0,2230.0
-286,004522,Waterbody,Perennial Ice/Snow,4,52,Scrub/Shrub,#CCBA7C,2,medium,#a1d99b,1.0,2230.0
-287,004523,Waterbody,Perennial Ice/Snow,4,52,Scrub/Shrub,#CCBA7C,3,high,#31a354,1.0,2230.0
-288,004710,Waterbody,Perennial Ice/Snow,4,71,Grassland/Herbaceous,#E2E2C1,0,none,#ffffff,1.0,2230.0
-289,004711,Waterbody,Perennial Ice/Snow,4,71,Grassland/Herbaceous,#E2E2C1,1,low,#e5f5e0,1.0,2230.0
-290,004712,Waterbody,Perennial Ice/Snow,4,71,Grassland/Herbaceous,#E2E2C1,2,medium,#a1d99b,1.0,2230.0
-291,004713,Waterbody,Perennial Ice/Snow,4,71,Grassland/Herbaceous,#E2E2C1,3,high,#31a354,1.0,2230.0
-292,004720,Waterbody,Perennial Ice/Snow,4,72,Sedge/Herbaceuous,#C9C977,0,none,#ffffff,0.0,
-293,004721,Waterbody,Perennial Ice/Snow,4,72,Sedge/Herbaceuous,#C9C977,1,low,#e5f5e0,0.0,
-294,004722,Waterbody,Perennial Ice/Snow,4,72,Sedge/Herbaceuous,#C9C977,2,medium,#a1d99b,0.0,
-295,004723,Waterbody,Perennial Ice/Snow,4,72,Sedge/Herbaceuous,#C9C977,3,high,#31a354,1.0,
-296,004730,Waterbody,Perennial Ice/Snow,4,73,Lichens,#99C147,0,none,#ffffff,0.0,
-297,004731,Waterbody,Perennial Ice/Snow,4,73,Lichens,#99C147,1,low,#e5f5e0,0.0,
-298,004732,Waterbody,Perennial Ice/Snow,4,73,Lichens,#99C147,2,medium,#a1d99b,0.0,
-299,004733,Waterbody,Perennial Ice/Snow,4,73,Lichens,#99C147,3,high,#31a354,1.0,
-300,004740,Waterbody,Perennial Ice/Snow,4,74,Moss,#77AD93,0,none,#ffffff,0.0,
-301,004741,Waterbody,Perennial Ice/Snow,4,74,Moss,#77AD93,1,low,#e5f5e0,0.0,
-302,004742,Waterbody,Perennial Ice/Snow,4,74,Moss,#77AD93,2,medium,#a1d99b,0.0,
-303,004743,Waterbody,Perennial Ice/Snow,4,74,Moss,#77AD93,3,high,#31a354,1.0,
-304,004810,Waterbody,Perennial Ice/Snow,4,81,Pasture/Hay,#DBD83D,0,none,#ffffff,0.0,2230.0
-305,004811,Waterbody,Perennial Ice/Snow,4,81,Pasture/Hay,#DBD83D,1,low,#e5f5e0,0.0,2230.0
-306,004812,Waterbody,Perennial Ice/Snow,4,81,Pasture/Hay,#DBD83D,2,medium,#a1d99b,0.0,2230.0
-307,004813,Waterbody,Perennial Ice/Snow,4,81,Pasture/Hay,#DBD83D,3,high,#31a354,1.0,2230.0
-308,004820,Waterbody,Perennial Ice/Snow,4,82,Cultivated Crops,#AA7028,0,none,#ffffff,0.0,2230.0
-309,004821,Waterbody,Perennial Ice/Snow,4,82,Cultivated Crops,#AA7028,1,low,#e5f5e0,0.0,2230.0
-310,004822,Waterbody,Perennial Ice/Snow,4,82,Cultivated Crops,#AA7028,2,medium,#a1d99b,0.0,2230.0
-311,004823,Waterbody,Perennial Ice/Snow,4,82,Cultivated Crops,#AA7028,3,high,#31a354,1.0,2230.0
-312,004900,Waterbody,Perennial Ice/Snow,4,90,Woody Wetlands,#BAD8EA,0,none,#ffffff,1.0,2230.0
-313,004901,Waterbody,Perennial Ice/Snow,4,90,Woody Wetlands,#BAD8EA,1,low,#e5f5e0,1.0,2230.0
-314,004902,Waterbody,Perennial Ice/Snow,4,90,Woody Wetlands,#BAD8EA,2,medium,#a1d99b,1.0,2230.0
-315,004903,Waterbody,Perennial Ice/Snow,4,90,Woody Wetlands,#BAD8EA,3,high,#31a354,1.0,2230.0
-316,004950,Waterbody,Perennial Ice/Snow,4,95,Emergent Herbaceous Wetlands,#70A3BA,0,none,#ffffff,1.0,2230.0
-317,004951,Waterbody,Perennial Ice/Snow,4,95,Emergent Herbaceous Wetlands,#70A3BA,1,low,#e5f5e0,1.0,2230.0
-318,004952,Waterbody,Perennial Ice/Snow,4,95,Emergent Herbaceous Wetlands,#70A3BA,2,medium,#a1d99b,1.0,2230.0
-319,004953,Waterbody,Perennial Ice/Snow,4,95,Emergent Herbaceous Wetlands,#70A3BA,3,high,#31a354,1.0,2230.0
-320,011110,Residential,Dense urban,11,11,Open Water,#476BA0,0,none,#ffffff,0.0,2230.0
-321,011111,Residential,Dense urban,11,11,Open Water,#476BA0,1,low,#e5f5e0,0.0,2230.0
-322,011112,Residential,Dense urban,11,11,Open Water,#476BA0,2,medium,#a1d99b,0.0,2230.0
-323,011113,Residential,Dense urban,11,11,Open Water,#476BA0,3,high,#31a354,1.0,2230.0
-324,011120,Residential,Dense urban,11,12,Perennial Ice/Snow,#D1DDF9,0,none,#ffffff,0.0,2230.0
-325,011121,Residential,Dense urban,11,12,Perennial Ice/Snow,#D1DDF9,1,low,#e5f5e0,0.0,2230.0
-326,011122,Residential,Dense urban,11,12,Perennial Ice/Snow,#D1DDF9,2,medium,#a1d99b,0.0,2230.0
-327,011123,Residential,Dense urban,11,12,Perennial Ice/Snow,#D1DDF9,3,high,#31a354,1.0,2230.0
-328,011210,Residential,Dense urban,11,21,"Developed, Open Space",#DDC9C9,0,none,#ffffff,0.0,2230.0
-329,011211,Residential,Dense urban,11,21,"Developed, Open Space",#DDC9C9,1,low,#e5f5e0,0.0,2230.0
-330,011212,Residential,Dense urban,11,21,"Developed, Open Space",#DDC9C9,2,medium,#a1d99b,0.0,2230.0
-331,011213,Residential,Dense urban,11,21,"Developed, Open Space",#DDC9C9,3,high,#31a354,1.0,2230.0
-332,011220,Residential,Dense urban,11,22,"Developed, Low Intensity",#D89382,0,none,#ffffff,0.0,2230.0
-333,011221,Residential,Dense urban,11,22,"Developed, Low Intensity",#D89382,1,low,#e5f5e0,0.0,2230.0
-334,011222,Residential,Dense urban,11,22,"Developed, Low Intensity",#D89382,2,medium,#a1d99b,0.0,2230.0
-335,011223,Residential,Dense urban,11,22,"Developed, Low Intensity",#D89382,3,high,#31a354,1.0,2230.0
-336,011230,Residential,Dense urban,11,23,"Developed, Medium Intensity",#ED0000,0,none,#ffffff,0.0,2230.0
-337,011231,Residential,Dense urban,11,23,"Developed, Medium Intensity",#ED0000,1,low,#e5f5e0,0.0,2230.0
-338,011232,Residential,Dense urban,11,23,"Developed, Medium Intensity",#ED0000,2,medium,#a1d99b,0.0,2230.0
-339,011233,Residential,Dense urban,11,23,"Developed, Medium Intensity",#ED0000,3,high,#31a354,1.0,2230.0
-340,011240,Residential,Dense urban,11,24,"Developed, High Intensity",#AA0000,0,none,#ffffff,0.0,2230.0
-341,011241,Residential,Dense urban,11,24,"Developed, High Intensity",#AA0000,1,low,#e5f5e0,0.0,2230.0
-342,011242,Residential,Dense urban,11,24,"Developed, High Intensity",#AA0000,2,medium,#a1d99b,0.0,2230.0
-343,011243,Residential,Dense urban,11,24,"Developed, High Intensity",#AA0000,3,high,#31a354,1.0,2230.0
-344,011310,Residential,Dense urban,11,31,Barren Land (Rock/Sand/Clay),#B2ADA3,0,none,#ffffff,0.0,2230.0
-345,011311,Residential,Dense urban,11,31,Barren Land (Rock/Sand/Clay),#B2ADA3,1,low,#e5f5e0,0.0,2230.0
-346,011312,Residential,Dense urban,11,31,Barren Land (Rock/Sand/Clay),#B2ADA3,2,medium,#a1d99b,0.0,2230.0
-347,011313,Residential,Dense urban,11,31,Barren Land (Rock/Sand/Clay),#B2ADA3,3,high,#31a354,1.0,2230.0
-348,011410,Residential,Dense urban,11,41,Deciduous Forest,#68AA63,0,none,#ffffff,1.0,2230.0
-349,011411,Residential,Dense urban,11,41,Deciduous Forest,#68AA63,1,low,#e5f5e0,1.0,2230.0
-350,011412,Residential,Dense urban,11,41,Deciduous Forest,#68AA63,2,medium,#a1d99b,1.0,2230.0
-351,011413,Residential,Dense urban,11,41,Deciduous Forest,#68AA63,3,high,#31a354,1.0,2230.0
-352,011420,Residential,Dense urban,11,42,Evergreen Forest,#1C6330,0,none,#ffffff,1.0,2230.0
-353,011421,Residential,Dense urban,11,42,Evergreen Forest,#1C6330,1,low,#e5f5e0,1.0,2230.0
-354,011422,Residential,Dense urban,11,42,Evergreen Forest,#1C6330,2,medium,#a1d99b,1.0,2230.0
-355,011423,Residential,Dense urban,11,42,Evergreen Forest,#1C6330,3,high,#31a354,1.0,2230.0
-356,011430,Residential,Dense urban,11,43,Mixed Forest,#B5C98E,0,none,#ffffff,1.0,2230.0
-357,011431,Residential,Dense urban,11,43,Mixed Forest,#B5C98E,1,low,#e5f5e0,1.0,2230.0
-358,011432,Residential,Dense urban,11,43,Mixed Forest,#B5C98E,2,medium,#a1d99b,1.0,2230.0
-359,011433,Residential,Dense urban,11,43,Mixed Forest,#B5C98E,3,high,#31a354,1.0,2230.0
-360,011510,Residential,Dense urban,11,51,Dwarf Scrub,#A58C30,0,none,#ffffff,0.0,
-361,011511,Residential,Dense urban,11,51,Dwarf Scrub,#A58C30,1,low,#e5f5e0,0.0,
-362,011512,Residential,Dense urban,11,51,Dwarf Scrub,#A58C30,2,medium,#a1d99b,0.0,
-363,011513,Residential,Dense urban,11,51,Dwarf Scrub,#A58C30,3,high,#31a354,1.0,
-364,011520,Residential,Dense urban,11,52,Scrub/Shrub,#CCBA7C,0,none,#ffffff,1.0,2230.0
-365,011521,Residential,Dense urban,11,52,Scrub/Shrub,#CCBA7C,1,low,#e5f5e0,1.0,2230.0
-366,011522,Residential,Dense urban,11,52,Scrub/Shrub,#CCBA7C,2,medium,#a1d99b,1.0,2230.0
-367,011523,Residential,Dense urban,11,52,Scrub/Shrub,#CCBA7C,3,high,#31a354,1.0,2230.0
-368,011710,Residential,Dense urban,11,71,Grassland/Herbaceous,#E2E2C1,0,none,#ffffff,1.0,2230.0
-369,011711,Residential,Dense urban,11,71,Grassland/Herbaceous,#E2E2C1,1,low,#e5f5e0,1.0,2230.0
-370,011712,Residential,Dense urban,11,71,Grassland/Herbaceous,#E2E2C1,2,medium,#a1d99b,1.0,2230.0
-371,011713,Residential,Dense urban,11,71,Grassland/Herbaceous,#E2E2C1,3,high,#31a354,1.0,2230.0
-372,011720,Residential,Dense urban,11,72,Sedge/Herbaceuous,#C9C977,0,none,#ffffff,0.0,
-373,011721,Residential,Dense urban,11,72,Sedge/Herbaceuous,#C9C977,1,low,#e5f5e0,0.0,
-374,011722,Residential,Dense urban,11,72,Sedge/Herbaceuous,#C9C977,2,medium,#a1d99b,0.0,
-375,011723,Residential,Dense urban,11,72,Sedge/Herbaceuous,#C9C977,3,high,#31a354,1.0,
-376,011730,Residential,Dense urban,11,73,Lichens,#99C147,0,none,#ffffff,0.0,
-377,011731,Residential,Dense urban,11,73,Lichens,#99C147,1,low,#e5f5e0,0.0,
-378,011732,Residential,Dense urban,11,73,Lichens,#99C147,2,medium,#a1d99b,0.0,
-379,011733,Residential,Dense urban,11,73,Lichens,#99C147,3,high,#31a354,1.0,
-380,011740,Residential,Dense urban,11,74,Moss,#77AD93,0,none,#ffffff,0.0,
-381,011741,Residential,Dense urban,11,74,Moss,#77AD93,1,low,#e5f5e0,0.0,
-382,011742,Residential,Dense urban,11,74,Moss,#77AD93,2,medium,#a1d99b,0.0,
-383,011743,Residential,Dense urban,11,74,Moss,#77AD93,3,high,#31a354,1.0,
-384,011810,Residential,Dense urban,11,81,Pasture/Hay,#DBD83D,0,none,#ffffff,0.0,2230.0
-385,011811,Residential,Dense urban,11,81,Pasture/Hay,#DBD83D,1,low,#e5f5e0,0.0,2230.0
-386,011812,Residential,Dense urban,11,81,Pasture/Hay,#DBD83D,2,medium,#a1d99b,0.0,2230.0
-387,011813,Residential,Dense urban,11,81,Pasture/Hay,#DBD83D,3,high,#31a354,1.0,2230.0
-388,011820,Residential,Dense urban,11,82,Cultivated Crops,#AA7028,0,none,#ffffff,0.0,2230.0
-389,011821,Residential,Dense urban,11,82,Cultivated Crops,#AA7028,1,low,#e5f5e0,0.0,2230.0
-390,011822,Residential,Dense urban,11,82,Cultivated Crops,#AA7028,2,medium,#a1d99b,0.0,2230.0
-391,011823,Residential,Dense urban,11,82,Cultivated Crops,#AA7028,3,high,#31a354,1.0,2230.0
-392,011900,Residential,Dense urban,11,90,Woody Wetlands,#BAD8EA,0,none,#ffffff,1.0,2230.0
-393,011901,Residential,Dense urban,11,90,Woody Wetlands,#BAD8EA,1,low,#e5f5e0,1.0,2230.0
-394,011902,Residential,Dense urban,11,90,Woody Wetlands,#BAD8EA,2,medium,#a1d99b,1.0,2230.0
-395,011903,Residential,Dense urban,11,90,Woody Wetlands,#BAD8EA,3,high,#31a354,1.0,2230.0
-396,011950,Residential,Dense urban,11,95,Emergent Herbaceous Wetlands,#70A3BA,0,none,#ffffff,1.0,2230.0
-397,011951,Residential,Dense urban,11,95,Emergent Herbaceous Wetlands,#70A3BA,1,low,#e5f5e0,1.0,2230.0
-398,011952,Residential,Dense urban,11,95,Emergent Herbaceous Wetlands,#70A3BA,2,medium,#a1d99b,1.0,2230.0
-399,011953,Residential,Dense urban,11,95,Emergent Herbaceous Wetlands,#70A3BA,3,high,#31a354,1.0,2230.0
-400,012110,Residential,Urban,12,11,Open Water,#476BA0,0,none,#ffffff,0.0,2230.0
-401,012111,Residential,Urban,12,11,Open Water,#476BA0,1,low,#e5f5e0,0.0,2230.0
-402,012112,Residential,Urban,12,11,Open Water,#476BA0,2,medium,#a1d99b,0.0,2230.0
-403,012113,Residential,Urban,12,11,Open Water,#476BA0,3,high,#31a354,1.0,2230.0
-404,012120,Residential,Urban,12,12,Perennial Ice/Snow,#D1DDF9,0,none,#ffffff,0.0,2230.0
-405,012121,Residential,Urban,12,12,Perennial Ice/Snow,#D1DDF9,1,low,#e5f5e0,0.0,2230.0
-406,012122,Residential,Urban,12,12,Perennial Ice/Snow,#D1DDF9,2,medium,#a1d99b,0.0,2230.0
-407,012123,Residential,Urban,12,12,Perennial Ice/Snow,#D1DDF9,3,high,#31a354,1.0,2230.0
-408,012210,Residential,Urban,12,21,"Developed, Open Space",#DDC9C9,0,none,#ffffff,0.0,2230.0
-409,012211,Residential,Urban,12,21,"Developed, Open Space",#DDC9C9,1,low,#e5f5e0,0.0,2230.0
-410,012212,Residential,Urban,12,21,"Developed, Open Space",#DDC9C9,2,medium,#a1d99b,0.0,2230.0
-411,012213,Residential,Urban,12,21,"Developed, Open Space",#DDC9C9,3,high,#31a354,1.0,2230.0
-412,012220,Residential,Urban,12,22,"Developed, Low Intensity",#D89382,0,none,#ffffff,0.0,2230.0
-413,012221,Residential,Urban,12,22,"Developed, Low Intensity",#D89382,1,low,#e5f5e0,0.0,2230.0
-414,012222,Residential,Urban,12,22,"Developed, Low Intensity",#D89382,2,medium,#a1d99b,0.0,2230.0
-415,012223,Residential,Urban,12,22,"Developed, Low Intensity",#D89382,3,high,#31a354,1.0,2230.0
-416,012230,Residential,Urban,12,23,"Developed, Medium Intensity",#ED0000,0,none,#ffffff,0.0,2230.0
-417,012231,Residential,Urban,12,23,"Developed, Medium Intensity",#ED0000,1,low,#e5f5e0,0.0,2230.0
-418,012232,Residential,Urban,12,23,"Developed, Medium Intensity",#ED0000,2,medium,#a1d99b,0.0,2230.0
-419,012233,Residential,Urban,12,23,"Developed, Medium Intensity",#ED0000,3,high,#31a354,1.0,2230.0
-420,012240,Residential,Urban,12,24,"Developed, High Intensity",#AA0000,0,none,#ffffff,0.0,2230.0
-421,012241,Residential,Urban,12,24,"Developed, High Intensity",#AA0000,1,low,#e5f5e0,0.0,2230.0
-422,012242,Residential,Urban,12,24,"Developed, High Intensity",#AA0000,2,medium,#a1d99b,0.0,2230.0
-423,012243,Residential,Urban,12,24,"Developed, High Intensity",#AA0000,3,high,#31a354,1.0,2230.0
-424,012310,Residential,Urban,12,31,Barren Land (Rock/Sand/Clay),#B2ADA3,0,none,#ffffff,0.0,2230.0
-425,012311,Residential,Urban,12,31,Barren Land (Rock/Sand/Clay),#B2ADA3,1,low,#e5f5e0,0.0,2230.0
-426,012312,Residential,Urban,12,31,Barren Land (Rock/Sand/Clay),#B2ADA3,2,medium,#a1d99b,0.0,2230.0
-427,012313,Residential,Urban,12,31,Barren Land (Rock/Sand/Clay),#B2ADA3,3,high,#31a354,1.0,2230.0
-428,012410,Residential,Urban,12,41,Deciduous Forest,#68AA63,0,none,#ffffff,1.0,2230.0
-429,012411,Residential,Urban,12,41,Deciduous Forest,#68AA63,1,low,#e5f5e0,1.0,2230.0
-430,012412,Residential,Urban,12,41,Deciduous Forest,#68AA63,2,medium,#a1d99b,1.0,2230.0
-431,012413,Residential,Urban,12,41,Deciduous Forest,#68AA63,3,high,#31a354,1.0,2230.0
-432,012420,Residential,Urban,12,42,Evergreen Forest,#1C6330,0,none,#ffffff,1.0,2230.0
-433,012421,Residential,Urban,12,42,Evergreen Forest,#1C6330,1,low,#e5f5e0,1.0,2230.0
-434,012422,Residential,Urban,12,42,Evergreen Forest,#1C6330,2,medium,#a1d99b,1.0,2230.0
-435,012423,Residential,Urban,12,42,Evergreen Forest,#1C6330,3,high,#31a354,1.0,2230.0
-436,012430,Residential,Urban,12,43,Mixed Forest,#B5C98E,0,none,#ffffff,1.0,2230.0
-437,012431,Residential,Urban,12,43,Mixed Forest,#B5C98E,1,low,#e5f5e0,1.0,2230.0
-438,012432,Residential,Urban,12,43,Mixed Forest,#B5C98E,2,medium,#a1d99b,1.0,2230.0
-439,012433,Residential,Urban,12,43,Mixed Forest,#B5C98E,3,high,#31a354,1.0,2230.0
-440,012510,Residential,Urban,12,51,Dwarf Scrub,#A58C30,0,none,#ffffff,0.0,
-441,012511,Residential,Urban,12,51,Dwarf Scrub,#A58C30,1,low,#e5f5e0,0.0,
-442,012512,Residential,Urban,12,51,Dwarf Scrub,#A58C30,2,medium,#a1d99b,0.0,
-443,012513,Residential,Urban,12,51,Dwarf Scrub,#A58C30,3,high,#31a354,1.0,
-444,012520,Residential,Urban,12,52,Scrub/Shrub,#CCBA7C,0,none,#ffffff,1.0,2230.0
-445,012521,Residential,Urban,12,52,Scrub/Shrub,#CCBA7C,1,low,#e5f5e0,1.0,2230.0
-446,012522,Residential,Urban,12,52,Scrub/Shrub,#CCBA7C,2,medium,#a1d99b,1.0,2230.0
-447,012523,Residential,Urban,12,52,Scrub/Shrub,#CCBA7C,3,high,#31a354,1.0,2230.0
-448,012710,Residential,Urban,12,71,Grassland/Herbaceous,#E2E2C1,0,none,#ffffff,1.0,2230.0
-449,012711,Residential,Urban,12,71,Grassland/Herbaceous,#E2E2C1,1,low,#e5f5e0,1.0,2230.0
-450,012712,Residential,Urban,12,71,Grassland/Herbaceous,#E2E2C1,2,medium,#a1d99b,1.0,2230.0
-451,012713,Residential,Urban,12,71,Grassland/Herbaceous,#E2E2C1,3,high,#31a354,1.0,2230.0
-452,012720,Residential,Urban,12,72,Sedge/Herbaceuous,#C9C977,0,none,#ffffff,0.0,
-453,012721,Residential,Urban,12,72,Sedge/Herbaceuous,#C9C977,1,low,#e5f5e0,0.0,
-454,012722,Residential,Urban,12,72,Sedge/Herbaceuous,#C9C977,2,medium,#a1d99b,0.0,
-455,012723,Residential,Urban,12,72,Sedge/Herbaceuous,#C9C977,3,high,#31a354,1.0,
-456,012730,Residential,Urban,12,73,Lichens,#99C147,0,none,#ffffff,0.0,
-457,012731,Residential,Urban,12,73,Lichens,#99C147,1,low,#e5f5e0,0.0,
-458,012732,Residential,Urban,12,73,Lichens,#99C147,2,medium,#a1d99b,0.0,
-459,012733,Residential,Urban,12,73,Lichens,#99C147,3,high,#31a354,1.0,
-460,012740,Residential,Urban,12,74,Moss,#77AD93,0,none,#ffffff,0.0,
-461,012741,Residential,Urban,12,74,Moss,#77AD93,1,low,#e5f5e0,0.0,
-462,012742,Residential,Urban,12,74,Moss,#77AD93,2,medium,#a1d99b,0.0,
-463,012743,Residential,Urban,12,74,Moss,#77AD93,3,high,#31a354,1.0,
-464,012810,Residential,Urban,12,81,Pasture/Hay,#DBD83D,0,none,#ffffff,0.0,2230.0
-465,012811,Residential,Urban,12,81,Pasture/Hay,#DBD83D,1,low,#e5f5e0,0.0,2230.0
-466,012812,Residential,Urban,12,81,Pasture/Hay,#DBD83D,2,medium,#a1d99b,0.0,2230.0
-467,012813,Residential,Urban,12,81,Pasture/Hay,#DBD83D,3,high,#31a354,1.0,2230.0
-468,012820,Residential,Urban,12,82,Cultivated Crops,#AA7028,0,none,#ffffff,0.0,2230.0
-469,012821,Residential,Urban,12,82,Cultivated Crops,#AA7028,1,low,#e5f5e0,0.0,2230.0
-470,012822,Residential,Urban,12,82,Cultivated Crops,#AA7028,2,medium,#a1d99b,0.0,2230.0
-471,012823,Residential,Urban,12,82,Cultivated Crops,#AA7028,3,high,#31a354,1.0,2230.0
-472,012900,Residential,Urban,12,90,Woody Wetlands,#BAD8EA,0,none,#ffffff,1.0,2230.0
-473,012901,Residential,Urban,12,90,Woody Wetlands,#BAD8EA,1,low,#e5f5e0,1.0,2230.0
-474,012902,Residential,Urban,12,90,Woody Wetlands,#BAD8EA,2,medium,#a1d99b,1.0,2230.0
-475,012903,Residential,Urban,12,90,Woody Wetlands,#BAD8EA,3,high,#31a354,1.0,2230.0
-476,012950,Residential,Urban,12,95,Emergent Herbaceous Wetlands,#70A3BA,0,none,#ffffff,1.0,2230.0
-477,012951,Residential,Urban,12,95,Emergent Herbaceous Wetlands,#70A3BA,1,low,#e5f5e0,1.0,2230.0
-478,012952,Residential,Urban,12,95,Emergent Herbaceous Wetlands,#70A3BA,2,medium,#a1d99b,1.0,2230.0
-479,012953,Residential,Urban,12,95,Emergent Herbaceous Wetlands,#70A3BA,3,high,#31a354,1.0,2230.0
-480,013110,Residential,Suburban,13,11,Open Water,#476BA0,0,none,#ffffff,0.0,2230.0
-481,013111,Residential,Suburban,13,11,Open Water,#476BA0,1,low,#e5f5e0,0.0,2230.0
-482,013112,Residential,Suburban,13,11,Open Water,#476BA0,2,medium,#a1d99b,0.0,2230.0
-483,013113,Residential,Suburban,13,11,Open Water,#476BA0,3,high,#31a354,1.0,2230.0
-484,013120,Residential,Suburban,13,12,Perennial Ice/Snow,#D1DDF9,0,none,#ffffff,0.0,2230.0
-485,013121,Residential,Suburban,13,12,Perennial Ice/Snow,#D1DDF9,1,low,#e5f5e0,0.0,2230.0
-486,013122,Residential,Suburban,13,12,Perennial Ice/Snow,#D1DDF9,2,medium,#a1d99b,0.0,2230.0
-487,013123,Residential,Suburban,13,12,Perennial Ice/Snow,#D1DDF9,3,high,#31a354,1.0,2230.0
-488,013210,Residential,Suburban,13,21,"Developed, Open Space",#DDC9C9,0,none,#ffffff,0.0,2230.0
-489,013211,Residential,Suburban,13,21,"Developed, Open Space",#DDC9C9,1,low,#e5f5e0,0.0,2230.0
-490,013212,Residential,Suburban,13,21,"Developed, Open Space",#DDC9C9,2,medium,#a1d99b,0.0,2230.0
-491,013213,Residential,Suburban,13,21,"Developed, Open Space",#DDC9C9,3,high,#31a354,1.0,2230.0
-492,013220,Residential,Suburban,13,22,"Developed, Low Intensity",#D89382,0,none,#ffffff,0.0,2230.0
-493,013221,Residential,Suburban,13,22,"Developed, Low Intensity",#D89382,1,low,#e5f5e0,0.0,2230.0
-494,013222,Residential,Suburban,13,22,"Developed, Low Intensity",#D89382,2,medium,#a1d99b,0.0,2230.0
-495,013223,Residential,Suburban,13,22,"Developed, Low Intensity",#D89382,3,high,#31a354,1.0,2230.0
-496,013230,Residential,Suburban,13,23,"Developed, Medium Intensity",#ED0000,0,none,#ffffff,0.0,2230.0
-497,013231,Residential,Suburban,13,23,"Developed, Medium Intensity",#ED0000,1,low,#e5f5e0,0.0,2230.0
-498,013232,Residential,Suburban,13,23,"Developed, Medium Intensity",#ED0000,2,medium,#a1d99b,0.0,2230.0
-499,013233,Residential,Suburban,13,23,"Developed, Medium Intensity",#ED0000,3,high,#31a354,1.0,2230.0
-500,013240,Residential,Suburban,13,24,"Developed, High Intensity",#AA0000,0,none,#ffffff,0.0,2230.0
-501,013241,Residential,Suburban,13,24,"Developed, High Intensity",#AA0000,1,low,#e5f5e0,0.0,2230.0
-502,013242,Residential,Suburban,13,24,"Developed, High Intensity",#AA0000,2,medium,#a1d99b,0.0,2230.0
-503,013243,Residential,Suburban,13,24,"Developed, High Intensity",#AA0000,3,high,#31a354,1.0,2230.0
-504,013310,Residential,Suburban,13,31,Barren Land (Rock/Sand/Clay),#B2ADA3,0,none,#ffffff,0.0,2230.0
-505,013311,Residential,Suburban,13,31,Barren Land (Rock/Sand/Clay),#B2ADA3,1,low,#e5f5e0,0.0,2230.0
-506,013312,Residential,Suburban,13,31,Barren Land (Rock/Sand/Clay),#B2ADA3,2,medium,#a1d99b,0.0,2230.0
-507,013313,Residential,Suburban,13,31,Barren Land (Rock/Sand/Clay),#B2ADA3,3,high,#31a354,1.0,2230.0
-508,013410,Residential,Suburban,13,41,Deciduous Forest,#68AA63,0,none,#ffffff,1.0,2230.0
-509,013411,Residential,Suburban,13,41,Deciduous Forest,#68AA63,1,low,#e5f5e0,1.0,2230.0
-510,013412,Residential,Suburban,13,41,Deciduous Forest,#68AA63,2,medium,#a1d99b,1.0,2230.0
-511,013413,Residential,Suburban,13,41,Deciduous Forest,#68AA63,3,high,#31a354,1.0,2230.0
-512,013420,Residential,Suburban,13,42,Evergreen Forest,#1C6330,0,none,#ffffff,1.0,2230.0
-513,013421,Residential,Suburban,13,42,Evergreen Forest,#1C6330,1,low,#e5f5e0,1.0,2230.0
-514,013422,Residential,Suburban,13,42,Evergreen Forest,#1C6330,2,medium,#a1d99b,1.0,2230.0
-515,013423,Residential,Suburban,13,42,Evergreen Forest,#1C6330,3,high,#31a354,1.0,2230.0
-516,013430,Residential,Suburban,13,43,Mixed Forest,#B5C98E,0,none,#ffffff,1.0,2230.0
-517,013431,Residential,Suburban,13,43,Mixed Forest,#B5C98E,1,low,#e5f5e0,1.0,2230.0
-518,013432,Residential,Suburban,13,43,Mixed Forest,#B5C98E,2,medium,#a1d99b,1.0,2230.0
-519,013433,Residential,Suburban,13,43,Mixed Forest,#B5C98E,3,high,#31a354,1.0,2230.0
-520,013510,Residential,Suburban,13,51,Dwarf Scrub,#A58C30,0,none,#ffffff,0.0,
-521,013511,Residential,Suburban,13,51,Dwarf Scrub,#A58C30,1,low,#e5f5e0,0.0,
-522,013512,Residential,Suburban,13,51,Dwarf Scrub,#A58C30,2,medium,#a1d99b,0.0,
-523,013513,Residential,Suburban,13,51,Dwarf Scrub,#A58C30,3,high,#31a354,1.0,
-524,013520,Residential,Suburban,13,52,Scrub/Shrub,#CCBA7C,0,none,#ffffff,1.0,2230.0
-525,013521,Residential,Suburban,13,52,Scrub/Shrub,#CCBA7C,1,low,#e5f5e0,1.0,2230.0
-526,013522,Residential,Suburban,13,52,Scrub/Shrub,#CCBA7C,2,medium,#a1d99b,1.0,2230.0
-527,013523,Residential,Suburban,13,52,Scrub/Shrub,#CCBA7C,3,high,#31a354,1.0,2230.0
-528,013710,Residential,Suburban,13,71,Grassland/Herbaceous,#E2E2C1,0,none,#ffffff,1.0,2230.0
-529,013711,Residential,Suburban,13,71,Grassland/Herbaceous,#E2E2C1,1,low,#e5f5e0,1.0,2230.0
-530,013712,Residential,Suburban,13,71,Grassland/Herbaceous,#E2E2C1,2,medium,#a1d99b,1.0,2230.0
-531,013713,Residential,Suburban,13,71,Grassland/Herbaceous,#E2E2C1,3,high,#31a354,1.0,2230.0
-532,013720,Residential,Suburban,13,72,Sedge/Herbaceuous,#C9C977,0,none,#ffffff,0.0,
-533,013721,Residential,Suburban,13,72,Sedge/Herbaceuous,#C9C977,1,low,#e5f5e0,0.0,
-534,013722,Residential,Suburban,13,72,Sedge/Herbaceuous,#C9C977,2,medium,#a1d99b,0.0,
-535,013723,Residential,Suburban,13,72,Sedge/Herbaceuous,#C9C977,3,high,#31a354,1.0,
-536,013730,Residential,Suburban,13,73,Lichens,#99C147,0,none,#ffffff,0.0,
-537,013731,Residential,Suburban,13,73,Lichens,#99C147,1,low,#e5f5e0,0.0,
-538,013732,Residential,Suburban,13,73,Lichens,#99C147,2,medium,#a1d99b,0.0,
-539,013733,Residential,Suburban,13,73,Lichens,#99C147,3,high,#31a354,1.0,
-540,013740,Residential,Suburban,13,74,Moss,#77AD93,0,none,#ffffff,0.0,
-541,013741,Residential,Suburban,13,74,Moss,#77AD93,1,low,#e5f5e0,0.0,
-542,013742,Residential,Suburban,13,74,Moss,#77AD93,2,medium,#a1d99b,0.0,
-543,013743,Residential,Suburban,13,74,Moss,#77AD93,3,high,#31a354,1.0,
-544,013810,Residential,Suburban,13,81,Pasture/Hay,#DBD83D,0,none,#ffffff,0.0,2230.0
-545,013811,Residential,Suburban,13,81,Pasture/Hay,#DBD83D,1,low,#e5f5e0,0.0,2230.0
-546,013812,Residential,Suburban,13,81,Pasture/Hay,#DBD83D,2,medium,#a1d99b,0.0,2230.0
-547,013813,Residential,Suburban,13,81,Pasture/Hay,#DBD83D,3,high,#31a354,1.0,2230.0
-548,013820,Residential,Suburban,13,82,Cultivated Crops,#AA7028,0,none,#ffffff,0.0,2230.0
-549,013821,Residential,Suburban,13,82,Cultivated Crops,#AA7028,1,low,#e5f5e0,0.0,2230.0
-550,013822,Residential,Suburban,13,82,Cultivated Crops,#AA7028,2,medium,#a1d99b,0.0,2230.0
-551,013823,Residential,Suburban,13,82,Cultivated Crops,#AA7028,3,high,#31a354,1.0,2230.0
-552,013900,Residential,Suburban,13,90,Woody Wetlands,#BAD8EA,0,none,#ffffff,1.0,2230.0
-553,013901,Residential,Suburban,13,90,Woody Wetlands,#BAD8EA,1,low,#e5f5e0,1.0,2230.0
-554,013902,Residential,Suburban,13,90,Woody Wetlands,#BAD8EA,2,medium,#a1d99b,1.0,2230.0
-555,013903,Residential,Suburban,13,90,Woody Wetlands,#BAD8EA,3,high,#31a354,1.0,2230.0
-556,013950,Residential,Suburban,13,95,Emergent Herbaceous Wetlands,#70A3BA,0,none,#ffffff,1.0,2230.0
-557,013951,Residential,Suburban,13,95,Emergent Herbaceous Wetlands,#70A3BA,1,low,#e5f5e0,1.0,2230.0
-558,013952,Residential,Suburban,13,95,Emergent Herbaceous Wetlands,#70A3BA,2,medium,#a1d99b,1.0,2230.0
-559,013953,Residential,Suburban,13,95,Emergent Herbaceous Wetlands,#70A3BA,3,high,#31a354,1.0,2230.0
-560,014110,Residential,Exurban,14,11,Open Water,#476BA0,0,none,#ffffff,0.0,2230.0
-561,014111,Residential,Exurban,14,11,Open Water,#476BA0,1,low,#e5f5e0,0.0,2230.0
-562,014112,Residential,Exurban,14,11,Open Water,#476BA0,2,medium,#a1d99b,0.0,2230.0
-563,014113,Residential,Exurban,14,11,Open Water,#476BA0,3,high,#31a354,1.0,2230.0
-564,014120,Residential,Exurban,14,12,Perennial Ice/Snow,#D1DDF9,0,none,#ffffff,0.0,2230.0
-565,014121,Residential,Exurban,14,12,Perennial Ice/Snow,#D1DDF9,1,low,#e5f5e0,0.0,2230.0
-566,014122,Residential,Exurban,14,12,Perennial Ice/Snow,#D1DDF9,2,medium,#a1d99b,0.0,2230.0
-567,014123,Residential,Exurban,14,12,Perennial Ice/Snow,#D1DDF9,3,high,#31a354,1.0,2230.0
-568,014210,Residential,Exurban,14,21,"Developed, Open Space",#DDC9C9,0,none,#ffffff,0.0,2230.0
-569,014211,Residential,Exurban,14,21,"Developed, Open Space",#DDC9C9,1,low,#e5f5e0,0.0,2230.0
-570,014212,Residential,Exurban,14,21,"Developed, Open Space",#DDC9C9,2,medium,#a1d99b,0.0,2230.0
-571,014213,Residential,Exurban,14,21,"Developed, Open Space",#DDC9C9,3,high,#31a354,1.0,2230.0
-572,014220,Residential,Exurban,14,22,"Developed, Low Intensity",#D89382,0,none,#ffffff,0.0,2230.0
-573,014221,Residential,Exurban,14,22,"Developed, Low Intensity",#D89382,1,low,#e5f5e0,0.0,2230.0
-574,014222,Residential,Exurban,14,22,"Developed, Low Intensity",#D89382,2,medium,#a1d99b,0.0,2230.0
-575,014223,Residential,Exurban,14,22,"Developed, Low Intensity",#D89382,3,high,#31a354,1.0,2230.0
-576,014230,Residential,Exurban,14,23,"Developed, Medium Intensity",#ED0000,0,none,#ffffff,0.0,2230.0
-577,014231,Residential,Exurban,14,23,"Developed, Medium Intensity",#ED0000,1,low,#e5f5e0,0.0,2230.0
-578,014232,Residential,Exurban,14,23,"Developed, Medium Intensity",#ED0000,2,medium,#a1d99b,0.0,2230.0
-579,014233,Residential,Exurban,14,23,"Developed, Medium Intensity",#ED0000,3,high,#31a354,1.0,2230.0
-580,014240,Residential,Exurban,14,24,"Developed, High Intensity",#AA0000,0,none,#ffffff,0.0,2230.0
-581,014241,Residential,Exurban,14,24,"Developed, High Intensity",#AA0000,1,low,#e5f5e0,0.0,2230.0
-582,014242,Residential,Exurban,14,24,"Developed, High Intensity",#AA0000,2,medium,#a1d99b,0.0,2230.0
-583,014243,Residential,Exurban,14,24,"Developed, High Intensity",#AA0000,3,high,#31a354,1.0,2230.0
-584,014310,Residential,Exurban,14,31,Barren Land (Rock/Sand/Clay),#B2ADA3,0,none,#ffffff,0.0,2230.0
-585,014311,Residential,Exurban,14,31,Barren Land (Rock/Sand/Clay),#B2ADA3,1,low,#e5f5e0,0.0,2230.0
-586,014312,Residential,Exurban,14,31,Barren Land (Rock/Sand/Clay),#B2ADA3,2,medium,#a1d99b,0.0,2230.0
-587,014313,Residential,Exurban,14,31,Barren Land (Rock/Sand/Clay),#B2ADA3,3,high,#31a354,1.0,2230.0
-588,014410,Residential,Exurban,14,41,Deciduous Forest,#68AA63,0,none,#ffffff,1.0,2230.0
-589,014411,Residential,Exurban,14,41,Deciduous Forest,#68AA63,1,low,#e5f5e0,1.0,2230.0
-590,014412,Residential,Exurban,14,41,Deciduous Forest,#68AA63,2,medium,#a1d99b,1.0,2230.0
-591,014413,Residential,Exurban,14,41,Deciduous Forest,#68AA63,3,high,#31a354,1.0,2230.0
-592,014420,Residential,Exurban,14,42,Evergreen Forest,#1C6330,0,none,#ffffff,1.0,2230.0
-593,014421,Residential,Exurban,14,42,Evergreen Forest,#1C6330,1,low,#e5f5e0,1.0,2230.0
-594,014422,Residential,Exurban,14,42,Evergreen Forest,#1C6330,2,medium,#a1d99b,1.0,2230.0
-595,014423,Residential,Exurban,14,42,Evergreen Forest,#1C6330,3,high,#31a354,1.0,2230.0
-596,014430,Residential,Exurban,14,43,Mixed Forest,#B5C98E,0,none,#ffffff,1.0,2230.0
-597,014431,Residential,Exurban,14,43,Mixed Forest,#B5C98E,1,low,#e5f5e0,1.0,2230.0
-598,014432,Residential,Exurban,14,43,Mixed Forest,#B5C98E,2,medium,#a1d99b,1.0,2230.0
-599,014433,Residential,Exurban,14,43,Mixed Forest,#B5C98E,3,high,#31a354,1.0,2230.0
-600,014510,Residential,Exurban,14,51,Dwarf Scrub,#A58C30,0,none,#ffffff,0.0,
-601,014511,Residential,Exurban,14,51,Dwarf Scrub,#A58C30,1,low,#e5f5e0,0.0,
-602,014512,Residential,Exurban,14,51,Dwarf Scrub,#A58C30,2,medium,#a1d99b,0.0,
-603,014513,Residential,Exurban,14,51,Dwarf Scrub,#A58C30,3,high,#31a354,1.0,
-604,014520,Residential,Exurban,14,52,Scrub/Shrub,#CCBA7C,0,none,#ffffff,1.0,2230.0
-605,014521,Residential,Exurban,14,52,Scrub/Shrub,#CCBA7C,1,low,#e5f5e0,1.0,2230.0
-606,014522,Residential,Exurban,14,52,Scrub/Shrub,#CCBA7C,2,medium,#a1d99b,1.0,2230.0
-607,014523,Residential,Exurban,14,52,Scrub/Shrub,#CCBA7C,3,high,#31a354,1.0,2230.0
-608,014710,Residential,Exurban,14,71,Grassland/Herbaceous,#E2E2C1,0,none,#ffffff,1.0,2230.0
-609,014711,Residential,Exurban,14,71,Grassland/Herbaceous,#E2E2C1,1,low,#e5f5e0,1.0,2230.0
-610,014712,Residential,Exurban,14,71,Grassland/Herbaceous,#E2E2C1,2,medium,#a1d99b,1.0,2230.0
-611,014713,Residential,Exurban,14,71,Grassland/Herbaceous,#E2E2C1,3,high,#31a354,1.0,2230.0
-612,014720,Residential,Exurban,14,72,Sedge/Herbaceuous,#C9C977,0,none,#ffffff,0.0,
-613,014721,Residential,Exurban,14,72,Sedge/Herbaceuous,#C9C977,1,low,#e5f5e0,0.0,
-614,014722,Residential,Exurban,14,72,Sedge/Herbaceuous,#C9C977,2,medium,#a1d99b,0.0,
-615,014723,Residential,Exurban,14,72,Sedge/Herbaceuous,#C9C977,3,high,#31a354,1.0,
-616,014730,Residential,Exurban,14,73,Lichens,#99C147,0,none,#ffffff,0.0,
-617,014731,Residential,Exurban,14,73,Lichens,#99C147,1,low,#e5f5e0,0.0,
-618,014732,Residential,Exurban,14,73,Lichens,#99C147,2,medium,#a1d99b,0.0,
-619,014733,Residential,Exurban,14,73,Lichens,#99C147,3,high,#31a354,1.0,
-620,014740,Residential,Exurban,14,74,Moss,#77AD93,0,none,#ffffff,0.0,
-621,014741,Residential,Exurban,14,74,Moss,#77AD93,1,low,#e5f5e0,0.0,
-622,014742,Residential,Exurban,14,74,Moss,#77AD93,2,medium,#a1d99b,0.0,
-623,014743,Residential,Exurban,14,74,Moss,#77AD93,3,high,#31a354,1.0,
-624,014810,Residential,Exurban,14,81,Pasture/Hay,#DBD83D,0,none,#ffffff,0.0,2230.0
-625,014811,Residential,Exurban,14,81,Pasture/Hay,#DBD83D,1,low,#e5f5e0,0.0,2230.0
-626,014812,Residential,Exurban,14,81,Pasture/Hay,#DBD83D,2,medium,#a1d99b,0.0,2230.0
-627,014813,Residential,Exurban,14,81,Pasture/Hay,#DBD83D,3,high,#31a354,1.0,2230.0
-628,014820,Residential,Exurban,14,82,Cultivated Crops,#AA7028,0,none,#ffffff,0.0,2230.0
-629,014821,Residential,Exurban,14,82,Cultivated Crops,#AA7028,1,low,#e5f5e0,0.0,2230.0
-630,014822,Residential,Exurban,14,82,Cultivated Crops,#AA7028,2,medium,#a1d99b,0.0,2230.0
-631,014823,Residential,Exurban,14,82,Cultivated Crops,#AA7028,3,high,#31a354,1.0,2230.0
-632,014900,Residential,Exurban,14,90,Woody Wetlands,#BAD8EA,0,none,#ffffff,1.0,2230.0
-633,014901,Residential,Exurban,14,90,Woody Wetlands,#BAD8EA,1,low,#e5f5e0,1.0,2230.0
-634,014902,Residential,Exurban,14,90,Woody Wetlands,#BAD8EA,2,medium,#a1d99b,1.0,2230.0
-635,014903,Residential,Exurban,14,90,Woody Wetlands,#BAD8EA,3,high,#31a354,1.0,2230.0
-636,014950,Residential,Exurban,14,95,Emergent Herbaceous Wetlands,#70A3BA,0,none,#ffffff,1.0,2230.0
-637,014951,Residential,Exurban,14,95,Emergent Herbaceous Wetlands,#70A3BA,1,low,#e5f5e0,1.0,2230.0
-638,014952,Residential,Exurban,14,95,Emergent Herbaceous Wetlands,#70A3BA,2,medium,#a1d99b,1.0,2230.0
-639,014953,Residential,Exurban,14,95,Emergent Herbaceous Wetlands,#70A3BA,3,high,#31a354,1.0,2230.0
-640,015110,Residential,Rural,15,11,Open Water,#476BA0,0,none,#ffffff,0.0,2230.0
-641,015111,Residential,Rural,15,11,Open Water,#476BA0,1,low,#e5f5e0,0.0,2230.0
-642,015112,Residential,Rural,15,11,Open Water,#476BA0,2,medium,#a1d99b,0.0,2230.0
-643,015113,Residential,Rural,15,11,Open Water,#476BA0,3,high,#31a354,1.0,2230.0
-644,015120,Residential,Rural,15,12,Perennial Ice/Snow,#D1DDF9,0,none,#ffffff,0.0,2230.0
-645,015121,Residential,Rural,15,12,Perennial Ice/Snow,#D1DDF9,1,low,#e5f5e0,0.0,2230.0
-646,015122,Residential,Rural,15,12,Perennial Ice/Snow,#D1DDF9,2,medium,#a1d99b,0.0,2230.0
-647,015123,Residential,Rural,15,12,Perennial Ice/Snow,#D1DDF9,3,high,#31a354,1.0,2230.0
-648,015210,Residential,Rural,15,21,"Developed, Open Space",#DDC9C9,0,none,#ffffff,0.0,2230.0
-649,015211,Residential,Rural,15,21,"Developed, Open Space",#DDC9C9,1,low,#e5f5e0,0.0,2230.0
-650,015212,Residential,Rural,15,21,"Developed, Open Space",#DDC9C9,2,medium,#a1d99b,0.0,2230.0
-651,015213,Residential,Rural,15,21,"Developed, Open Space",#DDC9C9,3,high,#31a354,1.0,2230.0
-652,015220,Residential,Rural,15,22,"Developed, Low Intensity",#D89382,0,none,#ffffff,0.0,2230.0
-653,015221,Residential,Rural,15,22,"Developed, Low Intensity",#D89382,1,low,#e5f5e0,0.0,2230.0
-654,015222,Residential,Rural,15,22,"Developed, Low Intensity",#D89382,2,medium,#a1d99b,0.0,2230.0
-655,015223,Residential,Rural,15,22,"Developed, Low Intensity",#D89382,3,high,#31a354,1.0,2230.0
-656,015230,Residential,Rural,15,23,"Developed, Medium Intensity",#ED0000,0,none,#ffffff,0.0,2230.0
-657,015231,Residential,Rural,15,23,"Developed, Medium Intensity",#ED0000,1,low,#e5f5e0,0.0,2230.0
-658,015232,Residential,Rural,15,23,"Developed, Medium Intensity",#ED0000,2,medium,#a1d99b,0.0,2230.0
-659,015233,Residential,Rural,15,23,"Developed, Medium Intensity",#ED0000,3,high,#31a354,1.0,2230.0
-660,015240,Residential,Rural,15,24,"Developed, High Intensity",#AA0000,0,none,#ffffff,0.0,2230.0
-661,015241,Residential,Rural,15,24,"Developed, High Intensity",#AA0000,1,low,#e5f5e0,0.0,2230.0
-662,015242,Residential,Rural,15,24,"Developed, High Intensity",#AA0000,2,medium,#a1d99b,0.0,2230.0
-663,015243,Residential,Rural,15,24,"Developed, High Intensity",#AA0000,3,high,#31a354,1.0,2230.0
-664,015310,Residential,Rural,15,31,Barren Land (Rock/Sand/Clay),#B2ADA3,0,none,#ffffff,0.0,2230.0
-665,015311,Residential,Rural,15,31,Barren Land (Rock/Sand/Clay),#B2ADA3,1,low,#e5f5e0,0.0,2230.0
-666,015312,Residential,Rural,15,31,Barren Land (Rock/Sand/Clay),#B2ADA3,2,medium,#a1d99b,0.0,2230.0
-667,015313,Residential,Rural,15,31,Barren Land (Rock/Sand/Clay),#B2ADA3,3,high,#31a354,1.0,2230.0
-668,015410,Residential,Rural,15,41,Deciduous Forest,#68AA63,0,none,#ffffff,1.0,2230.0
-669,015411,Residential,Rural,15,41,Deciduous Forest,#68AA63,1,low,#e5f5e0,1.0,2230.0
-670,015412,Residential,Rural,15,41,Deciduous Forest,#68AA63,2,medium,#a1d99b,1.0,2230.0
-671,015413,Residential,Rural,15,41,Deciduous Forest,#68AA63,3,high,#31a354,1.0,2230.0
-672,015420,Residential,Rural,15,42,Evergreen Forest,#1C6330,0,none,#ffffff,1.0,2230.0
-673,015421,Residential,Rural,15,42,Evergreen Forest,#1C6330,1,low,#e5f5e0,1.0,2230.0
-674,015422,Residential,Rural,15,42,Evergreen Forest,#1C6330,2,medium,#a1d99b,1.0,2230.0
-675,015423,Residential,Rural,15,42,Evergreen Forest,#1C6330,3,high,#31a354,1.0,2230.0
-676,015430,Residential,Rural,15,43,Mixed Forest,#B5C98E,0,none,#ffffff,1.0,2230.0
-677,015431,Residential,Rural,15,43,Mixed Forest,#B5C98E,1,low,#e5f5e0,1.0,2230.0
-678,015432,Residential,Rural,15,43,Mixed Forest,#B5C98E,2,medium,#a1d99b,1.0,2230.0
-679,015433,Residential,Rural,15,43,Mixed Forest,#B5C98E,3,high,#31a354,1.0,2230.0
-680,015510,Residential,Rural,15,51,Dwarf Scrub,#A58C30,0,none,#ffffff,0.0,
-681,015511,Residential,Rural,15,51,Dwarf Scrub,#A58C30,1,low,#e5f5e0,0.0,
-682,015512,Residential,Rural,15,51,Dwarf Scrub,#A58C30,2,medium,#a1d99b,0.0,
-683,015513,Residential,Rural,15,51,Dwarf Scrub,#A58C30,3,high,#31a354,1.0,
-684,015520,Residential,Rural,15,52,Scrub/Shrub,#CCBA7C,0,none,#ffffff,1.0,2230.0
-685,015521,Residential,Rural,15,52,Scrub/Shrub,#CCBA7C,1,low,#e5f5e0,1.0,2230.0
-686,015522,Residential,Rural,15,52,Scrub/Shrub,#CCBA7C,2,medium,#a1d99b,1.0,2230.0
-687,015523,Residential,Rural,15,52,Scrub/Shrub,#CCBA7C,3,high,#31a354,1.0,2230.0
-688,015710,Residential,Rural,15,71,Grassland/Herbaceous,#E2E2C1,0,none,#ffffff,1.0,2230.0
-689,015711,Residential,Rural,15,71,Grassland/Herbaceous,#E2E2C1,1,low,#e5f5e0,1.0,2230.0
-690,015712,Residential,Rural,15,71,Grassland/Herbaceous,#E2E2C1,2,medium,#a1d99b,1.0,2230.0
-691,015713,Residential,Rural,15,71,Grassland/Herbaceous,#E2E2C1,3,high,#31a354,1.0,2230.0
-692,015720,Residential,Rural,15,72,Sedge/Herbaceuous,#C9C977,0,none,#ffffff,0.0,
-693,015721,Residential,Rural,15,72,Sedge/Herbaceuous,#C9C977,1,low,#e5f5e0,0.0,
-694,015722,Residential,Rural,15,72,Sedge/Herbaceuous,#C9C977,2,medium,#a1d99b,0.0,
-695,015723,Residential,Rural,15,72,Sedge/Herbaceuous,#C9C977,3,high,#31a354,1.0,
-696,015730,Residential,Rural,15,73,Lichens,#99C147,0,none,#ffffff,0.0,
-697,015731,Residential,Rural,15,73,Lichens,#99C147,1,low,#e5f5e0,0.0,
-698,015732,Residential,Rural,15,73,Lichens,#99C147,2,medium,#a1d99b,0.0,
-699,015733,Residential,Rural,15,73,Lichens,#99C147,3,high,#31a354,1.0,
-700,015740,Residential,Rural,15,74,Moss,#77AD93,0,none,#ffffff,0.0,
-701,015741,Residential,Rural,15,74,Moss,#77AD93,1,low,#e5f5e0,0.0,
-702,015742,Residential,Rural,15,74,Moss,#77AD93,2,medium,#a1d99b,0.0,
-703,015743,Residential,Rural,15,74,Moss,#77AD93,3,high,#31a354,1.0,
-704,015810,Residential,Rural,15,81,Pasture/Hay,#DBD83D,0,none,#ffffff,0.0,2230.0
-705,015811,Residential,Rural,15,81,Pasture/Hay,#DBD83D,1,low,#e5f5e0,0.0,2230.0
-706,015812,Residential,Rural,15,81,Pasture/Hay,#DBD83D,2,medium,#a1d99b,0.0,2230.0
-707,015813,Residential,Rural,15,81,Pasture/Hay,#DBD83D,3,high,#31a354,1.0,2230.0
-708,015820,Residential,Rural,15,82,Cultivated Crops,#AA7028,0,none,#ffffff,0.0,2230.0
-709,015821,Residential,Rural,15,82,Cultivated Crops,#AA7028,1,low,#e5f5e0,0.0,2230.0
-710,015822,Residential,Rural,15,82,Cultivated Crops,#AA7028,2,medium,#a1d99b,0.0,2230.0
-711,015823,Residential,Rural,15,82,Cultivated Crops,#AA7028,3,high,#31a354,1.0,2230.0
-712,015900,Residential,Rural,15,90,Woody Wetlands,#BAD8EA,0,none,#ffffff,1.0,2230.0
-713,015901,Residential,Rural,15,90,Woody Wetlands,#BAD8EA,1,low,#e5f5e0,1.0,2230.0
-714,015902,Residential,Rural,15,90,Woody Wetlands,#BAD8EA,2,medium,#a1d99b,1.0,2230.0
-715,015903,Residential,Rural,15,90,Woody Wetlands,#BAD8EA,3,high,#31a354,1.0,2230.0
-716,015950,Residential,Rural,15,95,Emergent Herbaceous Wetlands,#70A3BA,0,none,#ffffff,1.0,2230.0
-717,015951,Residential,Rural,15,95,Emergent Herbaceous Wetlands,#70A3BA,1,low,#e5f5e0,1.0,2230.0
-718,015952,Residential,Rural,15,95,Emergent Herbaceous Wetlands,#70A3BA,2,medium,#a1d99b,1.0,2230.0
-719,015953,Residential,Rural,15,95,Emergent Herbaceous Wetlands,#70A3BA,3,high,#31a354,1.0,2230.0
-720,020110,Commercial,,20,11,Open Water,#476BA0,0,none,#ffffff,0.0,2230.0
-721,020111,Commercial,,20,11,Open Water,#476BA0,1,low,#e5f5e0,0.0,2230.0
-722,020112,Commercial,,20,11,Open Water,#476BA0,2,medium,#a1d99b,0.0,2230.0
-723,020113,Commercial,,20,11,Open Water,#476BA0,3,high,#31a354,1.0,2230.0
-724,020120,Commercial,,20,12,Perennial Ice/Snow,#D1DDF9,0,none,#ffffff,0.0,2230.0
-725,020121,Commercial,,20,12,Perennial Ice/Snow,#D1DDF9,1,low,#e5f5e0,0.0,2230.0
-726,020122,Commercial,,20,12,Perennial Ice/Snow,#D1DDF9,2,medium,#a1d99b,0.0,2230.0
-727,020123,Commercial,,20,12,Perennial Ice/Snow,#D1DDF9,3,high,#31a354,1.0,2230.0
-728,020210,Commercial,,20,21,"Developed, Open Space",#DDC9C9,0,none,#ffffff,0.0,2230.0
-729,020211,Commercial,,20,21,"Developed, Open Space",#DDC9C9,1,low,#e5f5e0,0.0,2230.0
-730,020212,Commercial,,20,21,"Developed, Open Space",#DDC9C9,2,medium,#a1d99b,0.0,2230.0
-731,020213,Commercial,,20,21,"Developed, Open Space",#DDC9C9,3,high,#31a354,1.0,2230.0
-732,020220,Commercial,,20,22,"Developed, Low Intensity",#D89382,0,none,#ffffff,0.0,2230.0
-733,020221,Commercial,,20,22,"Developed, Low Intensity",#D89382,1,low,#e5f5e0,0.0,2230.0
-734,020222,Commercial,,20,22,"Developed, Low Intensity",#D89382,2,medium,#a1d99b,0.0,2230.0
-735,020223,Commercial,,20,22,"Developed, Low Intensity",#D89382,3,high,#31a354,1.0,2230.0
-736,020230,Commercial,,20,23,"Developed, Medium Intensity",#ED0000,0,none,#ffffff,0.0,2230.0
-737,020231,Commercial,,20,23,"Developed, Medium Intensity",#ED0000,1,low,#e5f5e0,0.0,2230.0
-738,020232,Commercial,,20,23,"Developed, Medium Intensity",#ED0000,2,medium,#a1d99b,0.0,2230.0
-739,020233,Commercial,,20,23,"Developed, Medium Intensity",#ED0000,3,high,#31a354,1.0,2230.0
-740,020240,Commercial,,20,24,"Developed, High Intensity",#AA0000,0,none,#ffffff,0.0,2230.0
-741,020241,Commercial,,20,24,"Developed, High Intensity",#AA0000,1,low,#e5f5e0,0.0,2230.0
-742,020242,Commercial,,20,24,"Developed, High Intensity",#AA0000,2,medium,#a1d99b,0.0,2230.0
-743,020243,Commercial,,20,24,"Developed, High Intensity",#AA0000,3,high,#31a354,1.0,2230.0
-744,020310,Commercial,,20,31,Barren Land (Rock/Sand/Clay),#B2ADA3,0,none,#ffffff,0.0,2230.0
-745,020311,Commercial,,20,31,Barren Land (Rock/Sand/Clay),#B2ADA3,1,low,#e5f5e0,0.0,2230.0
-746,020312,Commercial,,20,31,Barren Land (Rock/Sand/Clay),#B2ADA3,2,medium,#a1d99b,0.0,2230.0
-747,020313,Commercial,,20,31,Barren Land (Rock/Sand/Clay),#B2ADA3,3,high,#31a354,1.0,2230.0
-748,020410,Commercial,,20,41,Deciduous Forest,#68AA63,0,none,#ffffff,1.0,2230.0
-749,020411,Commercial,,20,41,Deciduous Forest,#68AA63,1,low,#e5f5e0,1.0,2230.0
-750,020412,Commercial,,20,41,Deciduous Forest,#68AA63,2,medium,#a1d99b,1.0,2230.0
-751,020413,Commercial,,20,41,Deciduous Forest,#68AA63,3,high,#31a354,1.0,2230.0
-752,020420,Commercial,,20,42,Evergreen Forest,#1C6330,0,none,#ffffff,1.0,2230.0
-753,020421,Commercial,,20,42,Evergreen Forest,#1C6330,1,low,#e5f5e0,1.0,2230.0
-754,020422,Commercial,,20,42,Evergreen Forest,#1C6330,2,medium,#a1d99b,1.0,2230.0
-755,020423,Commercial,,20,42,Evergreen Forest,#1C6330,3,high,#31a354,1.0,2230.0
-756,020430,Commercial,,20,43,Mixed Forest,#B5C98E,0,none,#ffffff,1.0,2230.0
-757,020431,Commercial,,20,43,Mixed Forest,#B5C98E,1,low,#e5f5e0,1.0,2230.0
-758,020432,Commercial,,20,43,Mixed Forest,#B5C98E,2,medium,#a1d99b,1.0,2230.0
-759,020433,Commercial,,20,43,Mixed Forest,#B5C98E,3,high,#31a354,1.0,2230.0
-760,020510,Commercial,,20,51,Dwarf Scrub,#A58C30,0,none,#ffffff,0.0,
-761,020511,Commercial,,20,51,Dwarf Scrub,#A58C30,1,low,#e5f5e0,0.0,
-762,020512,Commercial,,20,51,Dwarf Scrub,#A58C30,2,medium,#a1d99b,0.0,
-763,020513,Commercial,,20,51,Dwarf Scrub,#A58C30,3,high,#31a354,1.0,
-764,020520,Commercial,,20,52,Scrub/Shrub,#CCBA7C,0,none,#ffffff,1.0,2230.0
-765,020521,Commercial,,20,52,Scrub/Shrub,#CCBA7C,1,low,#e5f5e0,1.0,2230.0
-766,020522,Commercial,,20,52,Scrub/Shrub,#CCBA7C,2,medium,#a1d99b,1.0,2230.0
-767,020523,Commercial,,20,52,Scrub/Shrub,#CCBA7C,3,high,#31a354,1.0,2230.0
-768,020710,Commercial,,20,71,Grassland/Herbaceous,#E2E2C1,0,none,#ffffff,1.0,2230.0
-769,020711,Commercial,,20,71,Grassland/Herbaceous,#E2E2C1,1,low,#e5f5e0,1.0,2230.0
-770,020712,Commercial,,20,71,Grassland/Herbaceous,#E2E2C1,2,medium,#a1d99b,1.0,2230.0
-771,020713,Commercial,,20,71,Grassland/Herbaceous,#E2E2C1,3,high,#31a354,1.0,2230.0
-772,020720,Commercial,,20,72,Sedge/Herbaceuous,#C9C977,0,none,#ffffff,0.0,
-773,020721,Commercial,,20,72,Sedge/Herbaceuous,#C9C977,1,low,#e5f5e0,0.0,
-774,020722,Commercial,,20,72,Sedge/Herbaceuous,#C9C977,2,medium,#a1d99b,0.0,
-775,020723,Commercial,,20,72,Sedge/Herbaceuous,#C9C977,3,high,#31a354,1.0,
-776,020730,Commercial,,20,73,Lichens,#99C147,0,none,#ffffff,0.0,
-777,020731,Commercial,,20,73,Lichens,#99C147,1,low,#e5f5e0,0.0,
-778,020732,Commercial,,20,73,Lichens,#99C147,2,medium,#a1d99b,0.0,
-779,020733,Commercial,,20,73,Lichens,#99C147,3,high,#31a354,1.0,
-780,020740,Commercial,,20,74,Moss,#77AD93,0,none,#ffffff,0.0,
-781,020741,Commercial,,20,74,Moss,#77AD93,1,low,#e5f5e0,0.0,
-782,020742,Commercial,,20,74,Moss,#77AD93,2,medium,#a1d99b,0.0,
-783,020743,Commercial,,20,74,Moss,#77AD93,3,high,#31a354,1.0,
-784,020810,Commercial,,20,81,Pasture/Hay,#DBD83D,0,none,#ffffff,0.0,2230.0
-785,020811,Commercial,,20,81,Pasture/Hay,#DBD83D,1,low,#e5f5e0,0.0,2230.0
-786,020812,Commercial,,20,81,Pasture/Hay,#DBD83D,2,medium,#a1d99b,0.0,2230.0
-787,020813,Commercial,,20,81,Pasture/Hay,#DBD83D,3,high,#31a354,1.0,2230.0
-788,020820,Commercial,,20,82,Cultivated Crops,#AA7028,0,none,#ffffff,0.0,2230.0
-789,020821,Commercial,,20,82,Cultivated Crops,#AA7028,1,low,#e5f5e0,0.0,2230.0
-790,020822,Commercial,,20,82,Cultivated Crops,#AA7028,2,medium,#a1d99b,0.0,2230.0
-791,020823,Commercial,,20,82,Cultivated Crops,#AA7028,3,high,#31a354,1.0,2230.0
-792,020900,Commercial,,20,90,Woody Wetlands,#BAD8EA,0,none,#ffffff,1.0,2230.0
-793,020901,Commercial,,20,90,Woody Wetlands,#BAD8EA,1,low,#e5f5e0,1.0,2230.0
-794,020902,Commercial,,20,90,Woody Wetlands,#BAD8EA,2,medium,#a1d99b,1.0,2230.0
-795,020903,Commercial,,20,90,Woody Wetlands,#BAD8EA,3,high,#31a354,1.0,2230.0
-796,020950,Commercial,,20,95,Emergent Herbaceous Wetlands,#70A3BA,0,none,#ffffff,1.0,2230.0
-797,020951,Commercial,,20,95,Emergent Herbaceous Wetlands,#70A3BA,1,low,#e5f5e0,1.0,2230.0
-798,020952,Commercial,,20,95,Emergent Herbaceous Wetlands,#70A3BA,2,medium,#a1d99b,1.0,2230.0
-799,020953,Commercial,,20,95,Emergent Herbaceous Wetlands,#70A3BA,3,high,#31a354,1.0,2230.0
-800,030110,Industrial,,30,11,Open Water,#476BA0,0,none,#ffffff,0.0,2230.0
-801,030111,Industrial,,30,11,Open Water,#476BA0,1,low,#e5f5e0,0.0,2230.0
-802,030112,Industrial,,30,11,Open Water,#476BA0,2,medium,#a1d99b,0.0,2230.0
-803,030113,Industrial,,30,11,Open Water,#476BA0,3,high,#31a354,1.0,2230.0
-804,030120,Industrial,,30,12,Perennial Ice/Snow,#D1DDF9,0,none,#ffffff,0.0,2230.0
-805,030121,Industrial,,30,12,Perennial Ice/Snow,#D1DDF9,1,low,#e5f5e0,0.0,2230.0
-806,030122,Industrial,,30,12,Perennial Ice/Snow,#D1DDF9,2,medium,#a1d99b,0.0,2230.0
-807,030123,Industrial,,30,12,Perennial Ice/Snow,#D1DDF9,3,high,#31a354,1.0,2230.0
-808,030210,Industrial,,30,21,"Developed, Open Space",#DDC9C9,0,none,#ffffff,0.0,2230.0
-809,030211,Industrial,,30,21,"Developed, Open Space",#DDC9C9,1,low,#e5f5e0,0.0,2230.0
-810,030212,Industrial,,30,21,"Developed, Open Space",#DDC9C9,2,medium,#a1d99b,0.0,2230.0
-811,030213,Industrial,,30,21,"Developed, Open Space",#DDC9C9,3,high,#31a354,1.0,2230.0
-812,030220,Industrial,,30,22,"Developed, Low Intensity",#D89382,0,none,#ffffff,0.0,2230.0
-813,030221,Industrial,,30,22,"Developed, Low Intensity",#D89382,1,low,#e5f5e0,0.0,2230.0
-814,030222,Industrial,,30,22,"Developed, Low Intensity",#D89382,2,medium,#a1d99b,0.0,2230.0
-815,030223,Industrial,,30,22,"Developed, Low Intensity",#D89382,3,high,#31a354,1.0,2230.0
-816,030230,Industrial,,30,23,"Developed, Medium Intensity",#ED0000,0,none,#ffffff,0.0,2230.0
-817,030231,Industrial,,30,23,"Developed, Medium Intensity",#ED0000,1,low,#e5f5e0,0.0,2230.0
-818,030232,Industrial,,30,23,"Developed, Medium Intensity",#ED0000,2,medium,#a1d99b,0.0,2230.0
-819,030233,Industrial,,30,23,"Developed, Medium Intensity",#ED0000,3,high,#31a354,1.0,2230.0
-820,030240,Industrial,,30,24,"Developed, High Intensity",#AA0000,0,none,#ffffff,0.0,2230.0
-821,030241,Industrial,,30,24,"Developed, High Intensity",#AA0000,1,low,#e5f5e0,0.0,2230.0
-822,030242,Industrial,,30,24,"Developed, High Intensity",#AA0000,2,medium,#a1d99b,0.0,2230.0
-823,030243,Industrial,,30,24,"Developed, High Intensity",#AA0000,3,high,#31a354,1.0,2230.0
-824,030310,Industrial,,30,31,Barren Land (Rock/Sand/Clay),#B2ADA3,0,none,#ffffff,0.0,2230.0
-825,030311,Industrial,,30,31,Barren Land (Rock/Sand/Clay),#B2ADA3,1,low,#e5f5e0,0.0,2230.0
-826,030312,Industrial,,30,31,Barren Land (Rock/Sand/Clay),#B2ADA3,2,medium,#a1d99b,0.0,2230.0
-827,030313,Industrial,,30,31,Barren Land (Rock/Sand/Clay),#B2ADA3,3,high,#31a354,1.0,2230.0
-828,030410,Industrial,,30,41,Deciduous Forest,#68AA63,0,none,#ffffff,1.0,2230.0
-829,030411,Industrial,,30,41,Deciduous Forest,#68AA63,1,low,#e5f5e0,1.0,2230.0
-830,030412,Industrial,,30,41,Deciduous Forest,#68AA63,2,medium,#a1d99b,1.0,2230.0
-831,030413,Industrial,,30,41,Deciduous Forest,#68AA63,3,high,#31a354,1.0,2230.0
-832,030420,Industrial,,30,42,Evergreen Forest,#1C6330,0,none,#ffffff,1.0,2230.0
-833,030421,Industrial,,30,42,Evergreen Forest,#1C6330,1,low,#e5f5e0,1.0,2230.0
-834,030422,Industrial,,30,42,Evergreen Forest,#1C6330,2,medium,#a1d99b,1.0,2230.0
-835,030423,Industrial,,30,42,Evergreen Forest,#1C6330,3,high,#31a354,1.0,2230.0
-836,030430,Industrial,,30,43,Mixed Forest,#B5C98E,0,none,#ffffff,1.0,2230.0
-837,030431,Industrial,,30,43,Mixed Forest,#B5C98E,1,low,#e5f5e0,1.0,2230.0
-838,030432,Industrial,,30,43,Mixed Forest,#B5C98E,2,medium,#a1d99b,1.0,2230.0
-839,030433,Industrial,,30,43,Mixed Forest,#B5C98E,3,high,#31a354,1.0,2230.0
-840,030510,Industrial,,30,51,Dwarf Scrub,#A58C30,0,none,#ffffff,0.0,
-841,030511,Industrial,,30,51,Dwarf Scrub,#A58C30,1,low,#e5f5e0,0.0,
-842,030512,Industrial,,30,51,Dwarf Scrub,#A58C30,2,medium,#a1d99b,0.0,
-843,030513,Industrial,,30,51,Dwarf Scrub,#A58C30,3,high,#31a354,1.0,
-844,030520,Industrial,,30,52,Scrub/Shrub,#CCBA7C,0,none,#ffffff,1.0,2230.0
-845,030521,Industrial,,30,52,Scrub/Shrub,#CCBA7C,1,low,#e5f5e0,1.0,2230.0
-846,030522,Industrial,,30,52,Scrub/Shrub,#CCBA7C,2,medium,#a1d99b,1.0,2230.0
-847,030523,Industrial,,30,52,Scrub/Shrub,#CCBA7C,3,high,#31a354,1.0,2230.0
-848,030710,Industrial,,30,71,Grassland/Herbaceous,#E2E2C1,0,none,#ffffff,1.0,2230.0
-849,030711,Industrial,,30,71,Grassland/Herbaceous,#E2E2C1,1,low,#e5f5e0,1.0,2230.0
-850,030712,Industrial,,30,71,Grassland/Herbaceous,#E2E2C1,2,medium,#a1d99b,1.0,2230.0
-851,030713,Industrial,,30,71,Grassland/Herbaceous,#E2E2C1,3,high,#31a354,1.0,2230.0
-852,030720,Industrial,,30,72,Sedge/Herbaceuous,#C9C977,0,none,#ffffff,0.0,
-853,030721,Industrial,,30,72,Sedge/Herbaceuous,#C9C977,1,low,#e5f5e0,0.0,
-854,030722,Industrial,,30,72,Sedge/Herbaceuous,#C9C977,2,medium,#a1d99b,0.0,
-855,030723,Industrial,,30,72,Sedge/Herbaceuous,#C9C977,3,high,#31a354,1.0,
-856,030730,Industrial,,30,73,Lichens,#99C147,0,none,#ffffff,0.0,
-857,030731,Industrial,,30,73,Lichens,#99C147,1,low,#e5f5e0,0.0,
-858,030732,Industrial,,30,73,Lichens,#99C147,2,medium,#a1d99b,0.0,
-859,030733,Industrial,,30,73,Lichens,#99C147,3,high,#31a354,1.0,
-860,030740,Industrial,,30,74,Moss,#77AD93,0,none,#ffffff,0.0,
-861,030741,Industrial,,30,74,Moss,#77AD93,1,low,#e5f5e0,0.0,
-862,030742,Industrial,,30,74,Moss,#77AD93,2,medium,#a1d99b,0.0,
-863,030743,Industrial,,30,74,Moss,#77AD93,3,high,#31a354,1.0,
-864,030810,Industrial,,30,81,Pasture/Hay,#DBD83D,0,none,#ffffff,0.0,2230.0
-865,030811,Industrial,,30,81,Pasture/Hay,#DBD83D,1,low,#e5f5e0,0.0,2230.0
-866,030812,Industrial,,30,81,Pasture/Hay,#DBD83D,2,medium,#a1d99b,0.0,2230.0
-867,030813,Industrial,,30,81,Pasture/Hay,#DBD83D,3,high,#31a354,1.0,2230.0
-868,030820,Industrial,,30,82,Cultivated Crops,#AA7028,0,none,#ffffff,0.0,2230.0
-869,030821,Industrial,,30,82,Cultivated Crops,#AA7028,1,low,#e5f5e0,0.0,2230.0
-870,030822,Industrial,,30,82,Cultivated Crops,#AA7028,2,medium,#a1d99b,0.0,2230.0
-871,030823,Industrial,,30,82,Cultivated Crops,#AA7028,3,high,#31a354,1.0,2230.0
-872,030900,Industrial,,30,90,Woody Wetlands,#BAD8EA,0,none,#ffffff,1.0,2230.0
-873,030901,Industrial,,30,90,Woody Wetlands,#BAD8EA,1,low,#e5f5e0,1.0,2230.0
-874,030902,Industrial,,30,90,Woody Wetlands,#BAD8EA,2,medium,#a1d99b,1.0,2230.0
-875,030903,Industrial,,30,90,Woody Wetlands,#BAD8EA,3,high,#31a354,1.0,2230.0
-876,030950,Industrial,,30,95,Emergent Herbaceous Wetlands,#70A3BA,0,none,#ffffff,1.0,2230.0
-877,030951,Industrial,,30,95,Emergent Herbaceous Wetlands,#70A3BA,1,low,#e5f5e0,1.0,2230.0
-878,030952,Industrial,,30,95,Emergent Herbaceous Wetlands,#70A3BA,2,medium,#a1d99b,1.0,2230.0
-879,030953,Industrial,,30,95,Emergent Herbaceous Wetlands,#70A3BA,3,high,#31a354,1.0,2230.0
-880,040110,Institutional,,40,11,Open Water,#476BA0,0,none,#ffffff,0.0,2230.0
-881,040111,Institutional,,40,11,Open Water,#476BA0,1,low,#e5f5e0,0.0,2230.0
-882,040112,Institutional,,40,11,Open Water,#476BA0,2,medium,#a1d99b,0.0,2230.0
-883,040113,Institutional,,40,11,Open Water,#476BA0,3,high,#31a354,1.0,2230.0
-884,040120,Institutional,,40,12,Perennial Ice/Snow,#D1DDF9,0,none,#ffffff,0.0,2230.0
-885,040121,Institutional,,40,12,Perennial Ice/Snow,#D1DDF9,1,low,#e5f5e0,0.0,2230.0
-886,040122,Institutional,,40,12,Perennial Ice/Snow,#D1DDF9,2,medium,#a1d99b,0.0,2230.0
-887,040123,Institutional,,40,12,Perennial Ice/Snow,#D1DDF9,3,high,#31a354,1.0,2230.0
-888,040210,Institutional,,40,21,"Developed, Open Space",#DDC9C9,0,none,#ffffff,0.0,2230.0
-889,040211,Institutional,,40,21,"Developed, Open Space",#DDC9C9,1,low,#e5f5e0,0.0,2230.0
-890,040212,Institutional,,40,21,"Developed, Open Space",#DDC9C9,2,medium,#a1d99b,0.0,2230.0
-891,040213,Institutional,,40,21,"Developed, Open Space",#DDC9C9,3,high,#31a354,1.0,2230.0
-892,040220,Institutional,,40,22,"Developed, Low Intensity",#D89382,0,none,#ffffff,0.0,2230.0
-893,040221,Institutional,,40,22,"Developed, Low Intensity",#D89382,1,low,#e5f5e0,0.0,2230.0
-894,040222,Institutional,,40,22,"Developed, Low Intensity",#D89382,2,medium,#a1d99b,0.0,2230.0
-895,040223,Institutional,,40,22,"Developed, Low Intensity",#D89382,3,high,#31a354,1.0,2230.0
-896,040230,Institutional,,40,23,"Developed, Medium Intensity",#ED0000,0,none,#ffffff,0.0,2230.0
-897,040231,Institutional,,40,23,"Developed, Medium Intensity",#ED0000,1,low,#e5f5e0,0.0,2230.0
-898,040232,Institutional,,40,23,"Developed, Medium Intensity",#ED0000,2,medium,#a1d99b,0.0,2230.0
-899,040233,Institutional,,40,23,"Developed, Medium Intensity",#ED0000,3,high,#31a354,1.0,2230.0
-900,040240,Institutional,,40,24,"Developed, High Intensity",#AA0000,0,none,#ffffff,0.0,2230.0
-901,040241,Institutional,,40,24,"Developed, High Intensity",#AA0000,1,low,#e5f5e0,0.0,2230.0
-902,040242,Institutional,,40,24,"Developed, High Intensity",#AA0000,2,medium,#a1d99b,0.0,2230.0
-903,040243,Institutional,,40,24,"Developed, High Intensity",#AA0000,3,high,#31a354,1.0,2230.0
-904,040310,Institutional,,40,31,Barren Land (Rock/Sand/Clay),#B2ADA3,0,none,#ffffff,0.0,2230.0
-905,040311,Institutional,,40,31,Barren Land (Rock/Sand/Clay),#B2ADA3,1,low,#e5f5e0,0.0,2230.0
-906,040312,Institutional,,40,31,Barren Land (Rock/Sand/Clay),#B2ADA3,2,medium,#a1d99b,0.0,2230.0
-907,040313,Institutional,,40,31,Barren Land (Rock/Sand/Clay),#B2ADA3,3,high,#31a354,1.0,2230.0
-908,040410,Institutional,,40,41,Deciduous Forest,#68AA63,0,none,#ffffff,1.0,2230.0
-909,040411,Institutional,,40,41,Deciduous Forest,#68AA63,1,low,#e5f5e0,1.0,2230.0
-910,040412,Institutional,,40,41,Deciduous Forest,#68AA63,2,medium,#a1d99b,1.0,2230.0
-911,040413,Institutional,,40,41,Deciduous Forest,#68AA63,3,high,#31a354,1.0,2230.0
-912,040420,Institutional,,40,42,Evergreen Forest,#1C6330,0,none,#ffffff,1.0,2230.0
-913,040421,Institutional,,40,42,Evergreen Forest,#1C6330,1,low,#e5f5e0,1.0,2230.0
-914,040422,Institutional,,40,42,Evergreen Forest,#1C6330,2,medium,#a1d99b,1.0,2230.0
-915,040423,Institutional,,40,42,Evergreen Forest,#1C6330,3,high,#31a354,1.0,2230.0
-916,040430,Institutional,,40,43,Mixed Forest,#B5C98E,0,none,#ffffff,1.0,2230.0
-917,040431,Institutional,,40,43,Mixed Forest,#B5C98E,1,low,#e5f5e0,1.0,2230.0
-918,040432,Institutional,,40,43,Mixed Forest,#B5C98E,2,medium,#a1d99b,1.0,2230.0
-919,040433,Institutional,,40,43,Mixed Forest,#B5C98E,3,high,#31a354,1.0,2230.0
-920,040510,Institutional,,40,51,Dwarf Scrub,#A58C30,0,none,#ffffff,0.0,
-921,040511,Institutional,,40,51,Dwarf Scrub,#A58C30,1,low,#e5f5e0,0.0,
-922,040512,Institutional,,40,51,Dwarf Scrub,#A58C30,2,medium,#a1d99b,0.0,
-923,040513,Institutional,,40,51,Dwarf Scrub,#A58C30,3,high,#31a354,1.0,
-924,040520,Institutional,,40,52,Scrub/Shrub,#CCBA7C,0,none,#ffffff,1.0,2230.0
-925,040521,Institutional,,40,52,Scrub/Shrub,#CCBA7C,1,low,#e5f5e0,1.0,2230.0
-926,040522,Institutional,,40,52,Scrub/Shrub,#CCBA7C,2,medium,#a1d99b,1.0,2230.0
-927,040523,Institutional,,40,52,Scrub/Shrub,#CCBA7C,3,high,#31a354,1.0,2230.0
-928,040710,Institutional,,40,71,Grassland/Herbaceous,#E2E2C1,0,none,#ffffff,1.0,2230.0
-929,040711,Institutional,,40,71,Grassland/Herbaceous,#E2E2C1,1,low,#e5f5e0,1.0,2230.0
-930,040712,Institutional,,40,71,Grassland/Herbaceous,#E2E2C1,2,medium,#a1d99b,1.0,2230.0
-931,040713,Institutional,,40,71,Grassland/Herbaceous,#E2E2C1,3,high,#31a354,1.0,2230.0
-932,040720,Institutional,,40,72,Sedge/Herbaceuous,#C9C977,0,none,#ffffff,0.0,
-933,040721,Institutional,,40,72,Sedge/Herbaceuous,#C9C977,1,low,#e5f5e0,0.0,
-934,040722,Institutional,,40,72,Sedge/Herbaceuous,#C9C977,2,medium,#a1d99b,0.0,
-935,040723,Institutional,,40,72,Sedge/Herbaceuous,#C9C977,3,high,#31a354,1.0,
-936,040730,Institutional,,40,73,Lichens,#99C147,0,none,#ffffff,0.0,
-937,040731,Institutional,,40,73,Lichens,#99C147,1,low,#e5f5e0,0.0,
-938,040732,Institutional,,40,73,Lichens,#99C147,2,medium,#a1d99b,0.0,
-939,040733,Institutional,,40,73,Lichens,#99C147,3,high,#31a354,1.0,
-940,040740,Institutional,,40,74,Moss,#77AD93,0,none,#ffffff,0.0,
-941,040741,Institutional,,40,74,Moss,#77AD93,1,low,#e5f5e0,0.0,
-942,040742,Institutional,,40,74,Moss,#77AD93,2,medium,#a1d99b,0.0,
-943,040743,Institutional,,40,74,Moss,#77AD93,3,high,#31a354,1.0,
-944,040810,Institutional,,40,81,Pasture/Hay,#DBD83D,0,none,#ffffff,0.0,2230.0
-945,040811,Institutional,,40,81,Pasture/Hay,#DBD83D,1,low,#e5f5e0,0.0,2230.0
-946,040812,Institutional,,40,81,Pasture/Hay,#DBD83D,2,medium,#a1d99b,0.0,2230.0
-947,040813,Institutional,,40,81,Pasture/Hay,#DBD83D,3,high,#31a354,1.0,2230.0
-948,040820,Institutional,,40,82,Cultivated Crops,#AA7028,0,none,#ffffff,0.0,2230.0
-949,040821,Institutional,,40,82,Cultivated Crops,#AA7028,1,low,#e5f5e0,0.0,2230.0
-950,040822,Institutional,,40,82,Cultivated Crops,#AA7028,2,medium,#a1d99b,0.0,2230.0
-951,040823,Institutional,,40,82,Cultivated Crops,#AA7028,3,high,#31a354,1.0,2230.0
-952,040900,Institutional,,40,90,Woody Wetlands,#BAD8EA,0,none,#ffffff,1.0,2230.0
-953,040901,Institutional,,40,90,Woody Wetlands,#BAD8EA,1,low,#e5f5e0,1.0,2230.0
-954,040902,Institutional,,40,90,Woody Wetlands,#BAD8EA,2,medium,#a1d99b,1.0,2230.0
-955,040903,Institutional,,40,90,Woody Wetlands,#BAD8EA,3,high,#31a354,1.0,2230.0
-956,040950,Institutional,,40,95,Emergent Herbaceous Wetlands,#70A3BA,0,none,#ffffff,1.0,2230.0
-957,040951,Institutional,,40,95,Emergent Herbaceous Wetlands,#70A3BA,1,low,#e5f5e0,1.0,2230.0
-958,040952,Institutional,,40,95,Emergent Herbaceous Wetlands,#70A3BA,2,medium,#a1d99b,1.0,2230.0
-959,040953,Institutional,,40,95,Emergent Herbaceous Wetlands,#70A3BA,3,high,#31a354,1.0,2230.0
-960,051110,Transportation,Airport,51,11,Open Water,#476BA0,0,none,#ffffff,0.0,2230.0
-961,051111,Transportation,Airport,51,11,Open Water,#476BA0,1,low,#e5f5e0,0.0,2230.0
-962,051112,Transportation,Airport,51,11,Open Water,#476BA0,2,medium,#a1d99b,0.0,2230.0
-963,051113,Transportation,Airport,51,11,Open Water,#476BA0,3,high,#31a354,1.0,2230.0
-964,051120,Transportation,Airport,51,12,Perennial Ice/Snow,#D1DDF9,0,none,#ffffff,0.0,2230.0
-965,051121,Transportation,Airport,51,12,Perennial Ice/Snow,#D1DDF9,1,low,#e5f5e0,0.0,2230.0
-966,051122,Transportation,Airport,51,12,Perennial Ice/Snow,#D1DDF9,2,medium,#a1d99b,0.0,2230.0
-967,051123,Transportation,Airport,51,12,Perennial Ice/Snow,#D1DDF9,3,high,#31a354,1.0,2230.0
-968,051210,Transportation,Airport,51,21,"Developed, Open Space",#DDC9C9,0,none,#ffffff,0.0,2230.0
-969,051211,Transportation,Airport,51,21,"Developed, Open Space",#DDC9C9,1,low,#e5f5e0,0.0,2230.0
-970,051212,Transportation,Airport,51,21,"Developed, Open Space",#DDC9C9,2,medium,#a1d99b,0.0,2230.0
-971,051213,Transportation,Airport,51,21,"Developed, Open Space",#DDC9C9,3,high,#31a354,1.0,2230.0
-972,051220,Transportation,Airport,51,22,"Developed, Low Intensity",#D89382,0,none,#ffffff,0.0,2230.0
-973,051221,Transportation,Airport,51,22,"Developed, Low Intensity",#D89382,1,low,#e5f5e0,0.0,2230.0
-974,051222,Transportation,Airport,51,22,"Developed, Low Intensity",#D89382,2,medium,#a1d99b,0.0,2230.0
-975,051223,Transportation,Airport,51,22,"Developed, Low Intensity",#D89382,3,high,#31a354,1.0,2230.0
-976,051230,Transportation,Airport,51,23,"Developed, Medium Intensity",#ED0000,0,none,#ffffff,0.0,2230.0
-977,051231,Transportation,Airport,51,23,"Developed, Medium Intensity",#ED0000,1,low,#e5f5e0,0.0,2230.0
-978,051232,Transportation,Airport,51,23,"Developed, Medium Intensity",#ED0000,2,medium,#a1d99b,0.0,2230.0
-979,051233,Transportation,Airport,51,23,"Developed, Medium Intensity",#ED0000,3,high,#31a354,1.0,2230.0
-980,051240,Transportation,Airport,51,24,"Developed, High Intensity",#AA0000,0,none,#ffffff,0.0,2230.0
-981,051241,Transportation,Airport,51,24,"Developed, High Intensity",#AA0000,1,low,#e5f5e0,0.0,2230.0
-982,051242,Transportation,Airport,51,24,"Developed, High Intensity",#AA0000,2,medium,#a1d99b,0.0,2230.0
-983,051243,Transportation,Airport,51,24,"Developed, High Intensity",#AA0000,3,high,#31a354,1.0,2230.0
-984,051310,Transportation,Airport,51,31,Barren Land (Rock/Sand/Clay),#B2ADA3,0,none,#ffffff,0.0,2230.0
-985,051311,Transportation,Airport,51,31,Barren Land (Rock/Sand/Clay),#B2ADA3,1,low,#e5f5e0,0.0,2230.0
-986,051312,Transportation,Airport,51,31,Barren Land (Rock/Sand/Clay),#B2ADA3,2,medium,#a1d99b,0.0,2230.0
-987,051313,Transportation,Airport,51,31,Barren Land (Rock/Sand/Clay),#B2ADA3,3,high,#31a354,1.0,2230.0
-988,051410,Transportation,Airport,51,41,Deciduous Forest,#68AA63,0,none,#ffffff,1.0,2230.0
-989,051411,Transportation,Airport,51,41,Deciduous Forest,#68AA63,1,low,#e5f5e0,1.0,2230.0
-990,051412,Transportation,Airport,51,41,Deciduous Forest,#68AA63,2,medium,#a1d99b,1.0,2230.0
-991,051413,Transportation,Airport,51,41,Deciduous Forest,#68AA63,3,high,#31a354,1.0,2230.0
-992,051420,Transportation,Airport,51,42,Evergreen Forest,#1C6330,0,none,#ffffff,1.0,2230.0
-993,051421,Transportation,Airport,51,42,Evergreen Forest,#1C6330,1,low,#e5f5e0,1.0,2230.0
-994,051422,Transportation,Airport,51,42,Evergreen Forest,#1C6330,2,medium,#a1d99b,1.0,2230.0
-995,051423,Transportation,Airport,51,42,Evergreen Forest,#1C6330,3,high,#31a354,1.0,2230.0
-996,051430,Transportation,Airport,51,43,Mixed Forest,#B5C98E,0,none,#ffffff,1.0,2230.0
-997,051431,Transportation,Airport,51,43,Mixed Forest,#B5C98E,1,low,#e5f5e0,1.0,2230.0
-998,051432,Transportation,Airport,51,43,Mixed Forest,#B5C98E,2,medium,#a1d99b,1.0,2230.0
-999,051433,Transportation,Airport,51,43,Mixed Forest,#B5C98E,3,high,#31a354,1.0,2230.0
-1000,051510,Transportation,Airport,51,51,Dwarf Scrub,#A58C30,0,none,#ffffff,0.0,
-1001,051511,Transportation,Airport,51,51,Dwarf Scrub,#A58C30,1,low,#e5f5e0,0.0,
-1002,051512,Transportation,Airport,51,51,Dwarf Scrub,#A58C30,2,medium,#a1d99b,0.0,
-1003,051513,Transportation,Airport,51,51,Dwarf Scrub,#A58C30,3,high,#31a354,1.0,
-1004,051520,Transportation,Airport,51,52,Scrub/Shrub,#CCBA7C,0,none,#ffffff,1.0,2230.0
-1005,051521,Transportation,Airport,51,52,Scrub/Shrub,#CCBA7C,1,low,#e5f5e0,1.0,2230.0
-1006,051522,Transportation,Airport,51,52,Scrub/Shrub,#CCBA7C,2,medium,#a1d99b,1.0,2230.0
-1007,051523,Transportation,Airport,51,52,Scrub/Shrub,#CCBA7C,3,high,#31a354,1.0,2230.0
-1008,051710,Transportation,Airport,51,71,Grassland/Herbaceous,#E2E2C1,0,none,#ffffff,1.0,2230.0
-1009,051711,Transportation,Airport,51,71,Grassland/Herbaceous,#E2E2C1,1,low,#e5f5e0,1.0,2230.0
-1010,051712,Transportation,Airport,51,71,Grassland/Herbaceous,#E2E2C1,2,medium,#a1d99b,1.0,2230.0
-1011,051713,Transportation,Airport,51,71,Grassland/Herbaceous,#E2E2C1,3,high,#31a354,1.0,2230.0
-1012,051720,Transportation,Airport,51,72,Sedge/Herbaceuous,#C9C977,0,none,#ffffff,0.0,
-1013,051721,Transportation,Airport,51,72,Sedge/Herbaceuous,#C9C977,1,low,#e5f5e0,0.0,
-1014,051722,Transportation,Airport,51,72,Sedge/Herbaceuous,#C9C977,2,medium,#a1d99b,0.0,
-1015,051723,Transportation,Airport,51,72,Sedge/Herbaceuous,#C9C977,3,high,#31a354,1.0,
-1016,051730,Transportation,Airport,51,73,Lichens,#99C147,0,none,#ffffff,0.0,
-1017,051731,Transportation,Airport,51,73,Lichens,#99C147,1,low,#e5f5e0,0.0,
-1018,051732,Transportation,Airport,51,73,Lichens,#99C147,2,medium,#a1d99b,0.0,
-1019,051733,Transportation,Airport,51,73,Lichens,#99C147,3,high,#31a354,1.0,
-1020,051740,Transportation,Airport,51,74,Moss,#77AD93,0,none,#ffffff,0.0,
-1021,051741,Transportation,Airport,51,74,Moss,#77AD93,1,low,#e5f5e0,0.0,
-1022,051742,Transportation,Airport,51,74,Moss,#77AD93,2,medium,#a1d99b,0.0,
-1023,051743,Transportation,Airport,51,74,Moss,#77AD93,3,high,#31a354,1.0,
-1024,051810,Transportation,Airport,51,81,Pasture/Hay,#DBD83D,0,none,#ffffff,0.0,2230.0
-1025,051811,Transportation,Airport,51,81,Pasture/Hay,#DBD83D,1,low,#e5f5e0,0.0,2230.0
-1026,051812,Transportation,Airport,51,81,Pasture/Hay,#DBD83D,2,medium,#a1d99b,0.0,2230.0
-1027,051813,Transportation,Airport,51,81,Pasture/Hay,#DBD83D,3,high,#31a354,1.0,2230.0
-1028,051820,Transportation,Airport,51,82,Cultivated Crops,#AA7028,0,none,#ffffff,0.0,2230.0
-1029,051821,Transportation,Airport,51,82,Cultivated Crops,#AA7028,1,low,#e5f5e0,0.0,2230.0
-1030,051822,Transportation,Airport,51,82,Cultivated Crops,#AA7028,2,medium,#a1d99b,0.0,2230.0
-1031,051823,Transportation,Airport,51,82,Cultivated Crops,#AA7028,3,high,#31a354,1.0,2230.0
-1032,051900,Transportation,Airport,51,90,Woody Wetlands,#BAD8EA,0,none,#ffffff,1.0,2230.0
-1033,051901,Transportation,Airport,51,90,Woody Wetlands,#BAD8EA,1,low,#e5f5e0,1.0,2230.0
-1034,051902,Transportation,Airport,51,90,Woody Wetlands,#BAD8EA,2,medium,#a1d99b,1.0,2230.0
-1035,051903,Transportation,Airport,51,90,Woody Wetlands,#BAD8EA,3,high,#31a354,1.0,2230.0
-1036,051950,Transportation,Airport,51,95,Emergent Herbaceous Wetlands,#70A3BA,0,none,#ffffff,1.0,2230.0
-1037,051951,Transportation,Airport,51,95,Emergent Herbaceous Wetlands,#70A3BA,1,low,#e5f5e0,1.0,2230.0
-1038,051952,Transportation,Airport,51,95,Emergent Herbaceous Wetlands,#70A3BA,2,medium,#a1d99b,1.0,2230.0
-1039,051953,Transportation,Airport,51,95,Emergent Herbaceous Wetlands,#70A3BA,3,high,#31a354,1.0,2230.0
-1040,052110,Transportation,Road and Rail,52,11,Open Water,#476BA0,0,none,#ffffff,0.0,2230.0
-1041,052111,Transportation,Road and Rail,52,11,Open Water,#476BA0,1,low,#e5f5e0,0.0,2230.0
-1042,052112,Transportation,Road and Rail,52,11,Open Water,#476BA0,2,medium,#a1d99b,0.0,2230.0
-1043,052113,Transportation,Road and Rail,52,11,Open Water,#476BA0,3,high,#31a354,1.0,2230.0
-1044,052120,Transportation,Road and Rail,52,12,Perennial Ice/Snow,#D1DDF9,0,none,#ffffff,0.0,2230.0
-1045,052121,Transportation,Road and Rail,52,12,Perennial Ice/Snow,#D1DDF9,1,low,#e5f5e0,0.0,2230.0
-1046,052122,Transportation,Road and Rail,52,12,Perennial Ice/Snow,#D1DDF9,2,medium,#a1d99b,0.0,2230.0
-1047,052123,Transportation,Road and Rail,52,12,Perennial Ice/Snow,#D1DDF9,3,high,#31a354,1.0,2230.0
-1048,052210,Transportation,Road and Rail,52,21,"Developed, Open Space",#DDC9C9,0,none,#ffffff,0.0,2230.0
-1049,052211,Transportation,Road and Rail,52,21,"Developed, Open Space",#DDC9C9,1,low,#e5f5e0,0.0,2230.0
-1050,052212,Transportation,Road and Rail,52,21,"Developed, Open Space",#DDC9C9,2,medium,#a1d99b,0.0,2230.0
-1051,052213,Transportation,Road and Rail,52,21,"Developed, Open Space",#DDC9C9,3,high,#31a354,1.0,2230.0
-1052,052220,Transportation,Road and Rail,52,22,"Developed, Low Intensity",#D89382,0,none,#ffffff,0.0,2230.0
-1053,052221,Transportation,Road and Rail,52,22,"Developed, Low Intensity",#D89382,1,low,#e5f5e0,0.0,2230.0
-1054,052222,Transportation,Road and Rail,52,22,"Developed, Low Intensity",#D89382,2,medium,#a1d99b,0.0,2230.0
-1055,052223,Transportation,Road and Rail,52,22,"Developed, Low Intensity",#D89382,3,high,#31a354,1.0,2230.0
-1056,052230,Transportation,Road and Rail,52,23,"Developed, Medium Intensity",#ED0000,0,none,#ffffff,0.0,2230.0
-1057,052231,Transportation,Road and Rail,52,23,"Developed, Medium Intensity",#ED0000,1,low,#e5f5e0,0.0,2230.0
-1058,052232,Transportation,Road and Rail,52,23,"Developed, Medium Intensity",#ED0000,2,medium,#a1d99b,0.0,2230.0
-1059,052233,Transportation,Road and Rail,52,23,"Developed, Medium Intensity",#ED0000,3,high,#31a354,1.0,2230.0
-1060,052240,Transportation,Road and Rail,52,24,"Developed, High Intensity",#AA0000,0,none,#ffffff,0.0,2230.0
-1061,052241,Transportation,Road and Rail,52,24,"Developed, High Intensity",#AA0000,1,low,#e5f5e0,0.0,2230.0
-1062,052242,Transportation,Road and Rail,52,24,"Developed, High Intensity",#AA0000,2,medium,#a1d99b,0.0,2230.0
-1063,052243,Transportation,Road and Rail,52,24,"Developed, High Intensity",#AA0000,3,high,#31a354,1.0,2230.0
-1064,052310,Transportation,Road and Rail,52,31,Barren Land (Rock/Sand/Clay),#B2ADA3,0,none,#ffffff,0.0,2230.0
-1065,052311,Transportation,Road and Rail,52,31,Barren Land (Rock/Sand/Clay),#B2ADA3,1,low,#e5f5e0,0.0,2230.0
-1066,052312,Transportation,Road and Rail,52,31,Barren Land (Rock/Sand/Clay),#B2ADA3,2,medium,#a1d99b,0.0,2230.0
-1067,052313,Transportation,Road and Rail,52,31,Barren Land (Rock/Sand/Clay),#B2ADA3,3,high,#31a354,1.0,2230.0
-1068,052410,Transportation,Road and Rail,52,41,Deciduous Forest,#68AA63,0,none,#ffffff,1.0,2230.0
-1069,052411,Transportation,Road and Rail,52,41,Deciduous Forest,#68AA63,1,low,#e5f5e0,1.0,2230.0
-1070,052412,Transportation,Road and Rail,52,41,Deciduous Forest,#68AA63,2,medium,#a1d99b,1.0,2230.0
-1071,052413,Transportation,Road and Rail,52,41,Deciduous Forest,#68AA63,3,high,#31a354,1.0,2230.0
-1072,052420,Transportation,Road and Rail,52,42,Evergreen Forest,#1C6330,0,none,#ffffff,1.0,2230.0
-1073,052421,Transportation,Road and Rail,52,42,Evergreen Forest,#1C6330,1,low,#e5f5e0,1.0,2230.0
-1074,052422,Transportation,Road and Rail,52,42,Evergreen Forest,#1C6330,2,medium,#a1d99b,1.0,2230.0
-1075,052423,Transportation,Road and Rail,52,42,Evergreen Forest,#1C6330,3,high,#31a354,1.0,2230.0
-1076,052430,Transportation,Road and Rail,52,43,Mixed Forest,#B5C98E,0,none,#ffffff,1.0,2230.0
-1077,052431,Transportation,Road and Rail,52,43,Mixed Forest,#B5C98E,1,low,#e5f5e0,1.0,2230.0
-1078,052432,Transportation,Road and Rail,52,43,Mixed Forest,#B5C98E,2,medium,#a1d99b,1.0,2230.0
-1079,052433,Transportation,Road and Rail,52,43,Mixed Forest,#B5C98E,3,high,#31a354,1.0,2230.0
-1080,052510,Transportation,Road and Rail,52,51,Dwarf Scrub,#A58C30,0,none,#ffffff,0.0,
-1081,052511,Transportation,Road and Rail,52,51,Dwarf Scrub,#A58C30,1,low,#e5f5e0,0.0,
-1082,052512,Transportation,Road and Rail,52,51,Dwarf Scrub,#A58C30,2,medium,#a1d99b,0.0,
-1083,052513,Transportation,Road and Rail,52,51,Dwarf Scrub,#A58C30,3,high,#31a354,1.0,
-1084,052520,Transportation,Road and Rail,52,52,Scrub/Shrub,#CCBA7C,0,none,#ffffff,1.0,2230.0
-1085,052521,Transportation,Road and Rail,52,52,Scrub/Shrub,#CCBA7C,1,low,#e5f5e0,1.0,2230.0
-1086,052522,Transportation,Road and Rail,52,52,Scrub/Shrub,#CCBA7C,2,medium,#a1d99b,1.0,2230.0
-1087,052523,Transportation,Road and Rail,52,52,Scrub/Shrub,#CCBA7C,3,high,#31a354,1.0,2230.0
-1088,052710,Transportation,Road and Rail,52,71,Grassland/Herbaceous,#E2E2C1,0,none,#ffffff,1.0,2230.0
-1089,052711,Transportation,Road and Rail,52,71,Grassland/Herbaceous,#E2E2C1,1,low,#e5f5e0,1.0,2230.0
-1090,052712,Transportation,Road and Rail,52,71,Grassland/Herbaceous,#E2E2C1,2,medium,#a1d99b,1.0,2230.0
-1091,052713,Transportation,Road and Rail,52,71,Grassland/Herbaceous,#E2E2C1,3,high,#31a354,1.0,2230.0
-1092,052720,Transportation,Road and Rail,52,72,Sedge/Herbaceuous,#C9C977,0,none,#ffffff,0.0,
-1093,052721,Transportation,Road and Rail,52,72,Sedge/Herbaceuous,#C9C977,1,low,#e5f5e0,0.0,
-1094,052722,Transportation,Road and Rail,52,72,Sedge/Herbaceuous,#C9C977,2,medium,#a1d99b,0.0,
-1095,052723,Transportation,Road and Rail,52,72,Sedge/Herbaceuous,#C9C977,3,high,#31a354,1.0,
-1096,052730,Transportation,Road and Rail,52,73,Lichens,#99C147,0,none,#ffffff,0.0,
-1097,052731,Transportation,Road and Rail,52,73,Lichens,#99C147,1,low,#e5f5e0,0.0,
-1098,052732,Transportation,Road and Rail,52,73,Lichens,#99C147,2,medium,#a1d99b,0.0,
-1099,052733,Transportation,Road and Rail,52,73,Lichens,#99C147,3,high,#31a354,1.0,
-1100,052740,Transportation,Road and Rail,52,74,Moss,#77AD93,0,none,#ffffff,0.0,
-1101,052741,Transportation,Road and Rail,52,74,Moss,#77AD93,1,low,#e5f5e0,0.0,
-1102,052742,Transportation,Road and Rail,52,74,Moss,#77AD93,2,medium,#a1d99b,0.0,
-1103,052743,Transportation,Road and Rail,52,74,Moss,#77AD93,3,high,#31a354,1.0,
-1104,052810,Transportation,Road and Rail,52,81,Pasture/Hay,#DBD83D,0,none,#ffffff,0.0,2230.0
-1105,052811,Transportation,Road and Rail,52,81,Pasture/Hay,#DBD83D,1,low,#e5f5e0,0.0,2230.0
-1106,052812,Transportation,Road and Rail,52,81,Pasture/Hay,#DBD83D,2,medium,#a1d99b,0.0,2230.0
-1107,052813,Transportation,Road and Rail,52,81,Pasture/Hay,#DBD83D,3,high,#31a354,1.0,2230.0
-1108,052820,Transportation,Road and Rail,52,82,Cultivated Crops,#AA7028,0,none,#ffffff,0.0,2230.0
-1109,052821,Transportation,Road and Rail,52,82,Cultivated Crops,#AA7028,1,low,#e5f5e0,0.0,2230.0
-1110,052822,Transportation,Road and Rail,52,82,Cultivated Crops,#AA7028,2,medium,#a1d99b,0.0,2230.0
-1111,052823,Transportation,Road and Rail,52,82,Cultivated Crops,#AA7028,3,high,#31a354,1.0,2230.0
-1112,052900,Transportation,Road and Rail,52,90,Woody Wetlands,#BAD8EA,0,none,#ffffff,1.0,2230.0
-1113,052901,Transportation,Road and Rail,52,90,Woody Wetlands,#BAD8EA,1,low,#e5f5e0,1.0,2230.0
-1114,052902,Transportation,Road and Rail,52,90,Woody Wetlands,#BAD8EA,2,medium,#a1d99b,1.0,2230.0
-1115,052903,Transportation,Road and Rail,52,90,Woody Wetlands,#BAD8EA,3,high,#31a354,1.0,2230.0
-1116,052950,Transportation,Road and Rail,52,95,Emergent Herbaceous Wetlands,#70A3BA,0,none,#ffffff,1.0,2230.0
-1117,052951,Transportation,Road and Rail,52,95,Emergent Herbaceous Wetlands,#70A3BA,1,low,#e5f5e0,1.0,2230.0
-1118,052952,Transportation,Road and Rail,52,95,Emergent Herbaceous Wetlands,#70A3BA,2,medium,#a1d99b,1.0,2230.0
-1119,052953,Transportation,Road and Rail,52,95,Emergent Herbaceous Wetlands,#70A3BA,3,high,#31a354,1.0,2230.0
-1120,053110,Transportation,Other,53,11,Open Water,#476BA0,0,none,#ffffff,0.0,2230.0
-1121,053111,Transportation,Other,53,11,Open Water,#476BA0,1,low,#e5f5e0,0.0,2230.0
-1122,053112,Transportation,Other,53,11,Open Water,#476BA0,2,medium,#a1d99b,0.0,2230.0
-1123,053113,Transportation,Other,53,11,Open Water,#476BA0,3,high,#31a354,1.0,2230.0
-1124,053120,Transportation,Other,53,12,Perennial Ice/Snow,#D1DDF9,0,none,#ffffff,0.0,2230.0
-1125,053121,Transportation,Other,53,12,Perennial Ice/Snow,#D1DDF9,1,low,#e5f5e0,0.0,2230.0
-1126,053122,Transportation,Other,53,12,Perennial Ice/Snow,#D1DDF9,2,medium,#a1d99b,0.0,2230.0
-1127,053123,Transportation,Other,53,12,Perennial Ice/Snow,#D1DDF9,3,high,#31a354,1.0,2230.0
-1128,053210,Transportation,Other,53,21,"Developed, Open Space",#DDC9C9,0,none,#ffffff,0.0,2230.0
-1129,053211,Transportation,Other,53,21,"Developed, Open Space",#DDC9C9,1,low,#e5f5e0,0.0,2230.0
-1130,053212,Transportation,Other,53,21,"Developed, Open Space",#DDC9C9,2,medium,#a1d99b,0.0,2230.0
-1131,053213,Transportation,Other,53,21,"Developed, Open Space",#DDC9C9,3,high,#31a354,1.0,2230.0
-1132,053220,Transportation,Other,53,22,"Developed, Low Intensity",#D89382,0,none,#ffffff,0.0,2230.0
-1133,053221,Transportation,Other,53,22,"Developed, Low Intensity",#D89382,1,low,#e5f5e0,0.0,2230.0
-1134,053222,Transportation,Other,53,22,"Developed, Low Intensity",#D89382,2,medium,#a1d99b,0.0,2230.0
-1135,053223,Transportation,Other,53,22,"Developed, Low Intensity",#D89382,3,high,#31a354,1.0,2230.0
-1136,053230,Transportation,Other,53,23,"Developed, Medium Intensity",#ED0000,0,none,#ffffff,0.0,2230.0
-1137,053231,Transportation,Other,53,23,"Developed, Medium Intensity",#ED0000,1,low,#e5f5e0,0.0,2230.0
-1138,053232,Transportation,Other,53,23,"Developed, Medium Intensity",#ED0000,2,medium,#a1d99b,0.0,2230.0
-1139,053233,Transportation,Other,53,23,"Developed, Medium Intensity",#ED0000,3,high,#31a354,1.0,2230.0
-1140,053240,Transportation,Other,53,24,"Developed, High Intensity",#AA0000,0,none,#ffffff,0.0,2230.0
-1141,053241,Transportation,Other,53,24,"Developed, High Intensity",#AA0000,1,low,#e5f5e0,0.0,2230.0
-1142,053242,Transportation,Other,53,24,"Developed, High Intensity",#AA0000,2,medium,#a1d99b,0.0,2230.0
-1143,053243,Transportation,Other,53,24,"Developed, High Intensity",#AA0000,3,high,#31a354,1.0,2230.0
-1144,053310,Transportation,Other,53,31,Barren Land (Rock/Sand/Clay),#B2ADA3,0,none,#ffffff,0.0,2230.0
-1145,053311,Transportation,Other,53,31,Barren Land (Rock/Sand/Clay),#B2ADA3,1,low,#e5f5e0,0.0,2230.0
-1146,053312,Transportation,Other,53,31,Barren Land (Rock/Sand/Clay),#B2ADA3,2,medium,#a1d99b,0.0,2230.0
-1147,053313,Transportation,Other,53,31,Barren Land (Rock/Sand/Clay),#B2ADA3,3,high,#31a354,1.0,2230.0
-1148,053410,Transportation,Other,53,41,Deciduous Forest,#68AA63,0,none,#ffffff,1.0,2230.0
-1149,053411,Transportation,Other,53,41,Deciduous Forest,#68AA63,1,low,#e5f5e0,1.0,2230.0
-1150,053412,Transportation,Other,53,41,Deciduous Forest,#68AA63,2,medium,#a1d99b,1.0,2230.0
-1151,053413,Transportation,Other,53,41,Deciduous Forest,#68AA63,3,high,#31a354,1.0,2230.0
-1152,053420,Transportation,Other,53,42,Evergreen Forest,#1C6330,0,none,#ffffff,1.0,2230.0
-1153,053421,Transportation,Other,53,42,Evergreen Forest,#1C6330,1,low,#e5f5e0,1.0,2230.0
-1154,053422,Transportation,Other,53,42,Evergreen Forest,#1C6330,2,medium,#a1d99b,1.0,2230.0
-1155,053423,Transportation,Other,53,42,Evergreen Forest,#1C6330,3,high,#31a354,1.0,2230.0
-1156,053430,Transportation,Other,53,43,Mixed Forest,#B5C98E,0,none,#ffffff,1.0,2230.0
-1157,053431,Transportation,Other,53,43,Mixed Forest,#B5C98E,1,low,#e5f5e0,1.0,2230.0
-1158,053432,Transportation,Other,53,43,Mixed Forest,#B5C98E,2,medium,#a1d99b,1.0,2230.0
-1159,053433,Transportation,Other,53,43,Mixed Forest,#B5C98E,3,high,#31a354,1.0,2230.0
-1160,053510,Transportation,Other,53,51,Dwarf Scrub,#A58C30,0,none,#ffffff,0.0,
-1161,053511,Transportation,Other,53,51,Dwarf Scrub,#A58C30,1,low,#e5f5e0,0.0,
-1162,053512,Transportation,Other,53,51,Dwarf Scrub,#A58C30,2,medium,#a1d99b,0.0,
-1163,053513,Transportation,Other,53,51,Dwarf Scrub,#A58C30,3,high,#31a354,1.0,
-1164,053520,Transportation,Other,53,52,Scrub/Shrub,#CCBA7C,0,none,#ffffff,1.0,2230.0
-1165,053521,Transportation,Other,53,52,Scrub/Shrub,#CCBA7C,1,low,#e5f5e0,1.0,2230.0
-1166,053522,Transportation,Other,53,52,Scrub/Shrub,#CCBA7C,2,medium,#a1d99b,1.0,2230.0
-1167,053523,Transportation,Other,53,52,Scrub/Shrub,#CCBA7C,3,high,#31a354,1.0,2230.0
-1168,053710,Transportation,Other,53,71,Grassland/Herbaceous,#E2E2C1,0,none,#ffffff,1.0,2230.0
-1169,053711,Transportation,Other,53,71,Grassland/Herbaceous,#E2E2C1,1,low,#e5f5e0,1.0,2230.0
-1170,053712,Transportation,Other,53,71,Grassland/Herbaceous,#E2E2C1,2,medium,#a1d99b,1.0,2230.0
-1171,053713,Transportation,Other,53,71,Grassland/Herbaceous,#E2E2C1,3,high,#31a354,1.0,2230.0
-1172,053720,Transportation,Other,53,72,Sedge/Herbaceuous,#C9C977,0,none,#ffffff,0.0,
-1173,053721,Transportation,Other,53,72,Sedge/Herbaceuous,#C9C977,1,low,#e5f5e0,0.0,
-1174,053722,Transportation,Other,53,72,Sedge/Herbaceuous,#C9C977,2,medium,#a1d99b,0.0,
-1175,053723,Transportation,Other,53,72,Sedge/Herbaceuous,#C9C977,3,high,#31a354,1.0,
-1176,053730,Transportation,Other,53,73,Lichens,#99C147,0,none,#ffffff,0.0,
-1177,053731,Transportation,Other,53,73,Lichens,#99C147,1,low,#e5f5e0,0.0,
-1178,053732,Transportation,Other,53,73,Lichens,#99C147,2,medium,#a1d99b,0.0,
-1179,053733,Transportation,Other,53,73,Lichens,#99C147,3,high,#31a354,1.0,
-1180,053740,Transportation,Other,53,74,Moss,#77AD93,0,none,#ffffff,0.0,
-1181,053741,Transportation,Other,53,74,Moss,#77AD93,1,low,#e5f5e0,0.0,
-1182,053742,Transportation,Other,53,74,Moss,#77AD93,2,medium,#a1d99b,0.0,
-1183,053743,Transportation,Other,53,74,Moss,#77AD93,3,high,#31a354,1.0,
-1184,053810,Transportation,Other,53,81,Pasture/Hay,#DBD83D,0,none,#ffffff,0.0,2230.0
-1185,053811,Transportation,Other,53,81,Pasture/Hay,#DBD83D,1,low,#e5f5e0,0.0,2230.0
-1186,053812,Transportation,Other,53,81,Pasture/Hay,#DBD83D,2,medium,#a1d99b,0.0,2230.0
-1187,053813,Transportation,Other,53,81,Pasture/Hay,#DBD83D,3,high,#31a354,1.0,2230.0
-1188,053820,Transportation,Other,53,82,Cultivated Crops,#AA7028,0,none,#ffffff,0.0,2230.0
-1189,053821,Transportation,Other,53,82,Cultivated Crops,#AA7028,1,low,#e5f5e0,0.0,2230.0
-1190,053822,Transportation,Other,53,82,Cultivated Crops,#AA7028,2,medium,#a1d99b,0.0,2230.0
-1191,053823,Transportation,Other,53,82,Cultivated Crops,#AA7028,3,high,#31a354,1.0,2230.0
-1192,053900,Transportation,Other,53,90,Woody Wetlands,#BAD8EA,0,none,#ffffff,1.0,2230.0
-1193,053901,Transportation,Other,53,90,Woody Wetlands,#BAD8EA,1,low,#e5f5e0,1.0,2230.0
-1194,053902,Transportation,Other,53,90,Woody Wetlands,#BAD8EA,2,medium,#a1d99b,1.0,2230.0
-1195,053903,Transportation,Other,53,90,Woody Wetlands,#BAD8EA,3,high,#31a354,1.0,2230.0
-1196,053950,Transportation,Other,53,95,Emergent Herbaceous Wetlands,#70A3BA,0,none,#ffffff,1.0,2230.0
-1197,053951,Transportation,Other,53,95,Emergent Herbaceous Wetlands,#70A3BA,1,low,#e5f5e0,1.0,2230.0
-1198,053952,Transportation,Other,53,95,Emergent Herbaceous Wetlands,#70A3BA,2,medium,#a1d99b,1.0,2230.0
-1199,053953,Transportation,Other,53,95,Emergent Herbaceous Wetlands,#70A3BA,3,high,#31a354,1.0,2230.0
-1200,060110,Other Development,,60,11,Open Water,#476BA0,0,none,#ffffff,0.0,2230.0
-1201,060111,Other Development,,60,11,Open Water,#476BA0,1,low,#e5f5e0,0.0,2230.0
-1202,060112,Other Development,,60,11,Open Water,#476BA0,2,medium,#a1d99b,0.0,2230.0
-1203,060113,Other Development,,60,11,Open Water,#476BA0,3,high,#31a354,1.0,2230.0
-1204,060120,Other Development,,60,12,Perennial Ice/Snow,#D1DDF9,0,none,#ffffff,0.0,2230.0
-1205,060121,Other Development,,60,12,Perennial Ice/Snow,#D1DDF9,1,low,#e5f5e0,0.0,2230.0
-1206,060122,Other Development,,60,12,Perennial Ice/Snow,#D1DDF9,2,medium,#a1d99b,0.0,2230.0
-1207,060123,Other Development,,60,12,Perennial Ice/Snow,#D1DDF9,3,high,#31a354,1.0,2230.0
-1208,060210,Other Development,,60,21,"Developed, Open Space",#DDC9C9,0,none,#ffffff,0.0,2230.0
-1209,060211,Other Development,,60,21,"Developed, Open Space",#DDC9C9,1,low,#e5f5e0,0.0,2230.0
-1210,060212,Other Development,,60,21,"Developed, Open Space",#DDC9C9,2,medium,#a1d99b,0.0,2230.0
-1211,060213,Other Development,,60,21,"Developed, Open Space",#DDC9C9,3,high,#31a354,1.0,2230.0
-1212,060220,Other Development,,60,22,"Developed, Low Intensity",#D89382,0,none,#ffffff,0.0,2230.0
-1213,060221,Other Development,,60,22,"Developed, Low Intensity",#D89382,1,low,#e5f5e0,0.0,2230.0
-1214,060222,Other Development,,60,22,"Developed, Low Intensity",#D89382,2,medium,#a1d99b,0.0,2230.0
-1215,060223,Other Development,,60,22,"Developed, Low Intensity",#D89382,3,high,#31a354,1.0,2230.0
-1216,060230,Other Development,,60,23,"Developed, Medium Intensity",#ED0000,0,none,#ffffff,0.0,2230.0
-1217,060231,Other Development,,60,23,"Developed, Medium Intensity",#ED0000,1,low,#e5f5e0,0.0,2230.0
-1218,060232,Other Development,,60,23,"Developed, Medium Intensity",#ED0000,2,medium,#a1d99b,0.0,2230.0
-1219,060233,Other Development,,60,23,"Developed, Medium Intensity",#ED0000,3,high,#31a354,1.0,2230.0
-1220,060240,Other Development,,60,24,"Developed, High Intensity",#AA0000,0,none,#ffffff,0.0,2230.0
-1221,060241,Other Development,,60,24,"Developed, High Intensity",#AA0000,1,low,#e5f5e0,0.0,2230.0
-1222,060242,Other Development,,60,24,"Developed, High Intensity",#AA0000,2,medium,#a1d99b,0.0,2230.0
-1223,060243,Other Development,,60,24,"Developed, High Intensity",#AA0000,3,high,#31a354,1.0,2230.0
-1224,060310,Other Development,,60,31,Barren Land (Rock/Sand/Clay),#B2ADA3,0,none,#ffffff,0.0,2230.0
-1225,060311,Other Development,,60,31,Barren Land (Rock/Sand/Clay),#B2ADA3,1,low,#e5f5e0,0.0,2230.0
-1226,060312,Other Development,,60,31,Barren Land (Rock/Sand/Clay),#B2ADA3,2,medium,#a1d99b,0.0,2230.0
-1227,060313,Other Development,,60,31,Barren Land (Rock/Sand/Clay),#B2ADA3,3,high,#31a354,1.0,2230.0
-1228,060410,Other Development,,60,41,Deciduous Forest,#68AA63,0,none,#ffffff,1.0,2230.0
-1229,060411,Other Development,,60,41,Deciduous Forest,#68AA63,1,low,#e5f5e0,1.0,2230.0
-1230,060412,Other Development,,60,41,Deciduous Forest,#68AA63,2,medium,#a1d99b,1.0,2230.0
-1231,060413,Other Development,,60,41,Deciduous Forest,#68AA63,3,high,#31a354,1.0,2230.0
-1232,060420,Other Development,,60,42,Evergreen Forest,#1C6330,0,none,#ffffff,1.0,2230.0
-1233,060421,Other Development,,60,42,Evergreen Forest,#1C6330,1,low,#e5f5e0,1.0,2230.0
-1234,060422,Other Development,,60,42,Evergreen Forest,#1C6330,2,medium,#a1d99b,1.0,2230.0
-1235,060423,Other Development,,60,42,Evergreen Forest,#1C6330,3,high,#31a354,1.0,2230.0
-1236,060430,Other Development,,60,43,Mixed Forest,#B5C98E,0,none,#ffffff,1.0,2230.0
-1237,060431,Other Development,,60,43,Mixed Forest,#B5C98E,1,low,#e5f5e0,1.0,2230.0
-1238,060432,Other Development,,60,43,Mixed Forest,#B5C98E,2,medium,#a1d99b,1.0,2230.0
-1239,060433,Other Development,,60,43,Mixed Forest,#B5C98E,3,high,#31a354,1.0,2230.0
-1240,060510,Other Development,,60,51,Dwarf Scrub,#A58C30,0,none,#ffffff,0.0,
-1241,060511,Other Development,,60,51,Dwarf Scrub,#A58C30,1,low,#e5f5e0,0.0,
-1242,060512,Other Development,,60,51,Dwarf Scrub,#A58C30,2,medium,#a1d99b,0.0,
-1243,060513,Other Development,,60,51,Dwarf Scrub,#A58C30,3,high,#31a354,1.0,
-1244,060520,Other Development,,60,52,Scrub/Shrub,#CCBA7C,0,none,#ffffff,1.0,2230.0
-1245,060521,Other Development,,60,52,Scrub/Shrub,#CCBA7C,1,low,#e5f5e0,1.0,2230.0
-1246,060522,Other Development,,60,52,Scrub/Shrub,#CCBA7C,2,medium,#a1d99b,1.0,2230.0
-1247,060523,Other Development,,60,52,Scrub/Shrub,#CCBA7C,3,high,#31a354,1.0,2230.0
-1248,060710,Other Development,,60,71,Grassland/Herbaceous,#E2E2C1,0,none,#ffffff,1.0,2230.0
-1249,060711,Other Development,,60,71,Grassland/Herbaceous,#E2E2C1,1,low,#e5f5e0,1.0,2230.0
-1250,060712,Other Development,,60,71,Grassland/Herbaceous,#E2E2C1,2,medium,#a1d99b,1.0,2230.0
-1251,060713,Other Development,,60,71,Grassland/Herbaceous,#E2E2C1,3,high,#31a354,1.0,2230.0
-1252,060720,Other Development,,60,72,Sedge/Herbaceuous,#C9C977,0,none,#ffffff,0.0,
-1253,060721,Other Development,,60,72,Sedge/Herbaceuous,#C9C977,1,low,#e5f5e0,0.0,
-1254,060722,Other Development,,60,72,Sedge/Herbaceuous,#C9C977,2,medium,#a1d99b,0.0,
-1255,060723,Other Development,,60,72,Sedge/Herbaceuous,#C9C977,3,high,#31a354,1.0,
-1256,060730,Other Development,,60,73,Lichens,#99C147,0,none,#ffffff,0.0,
-1257,060731,Other Development,,60,73,Lichens,#99C147,1,low,#e5f5e0,0.0,
-1258,060732,Other Development,,60,73,Lichens,#99C147,2,medium,#a1d99b,0.0,
-1259,060733,Other Development,,60,73,Lichens,#99C147,3,high,#31a354,1.0,
-1260,060740,Other Development,,60,74,Moss,#77AD93,0,none,#ffffff,0.0,
-1261,060741,Other Development,,60,74,Moss,#77AD93,1,low,#e5f5e0,0.0,
-1262,060742,Other Development,,60,74,Moss,#77AD93,2,medium,#a1d99b,0.0,
-1263,060743,Other Development,,60,74,Moss,#77AD93,3,high,#31a354,1.0,
-1264,060810,Other Development,,60,81,Pasture/Hay,#DBD83D,0,none,#ffffff,0.0,2230.0
-1265,060811,Other Development,,60,81,Pasture/Hay,#DBD83D,1,low,#e5f5e0,0.0,2230.0
-1266,060812,Other Development,,60,81,Pasture/Hay,#DBD83D,2,medium,#a1d99b,0.0,2230.0
-1267,060813,Other Development,,60,81,Pasture/Hay,#DBD83D,3,high,#31a354,1.0,2230.0
-1268,060820,Other Development,,60,82,Cultivated Crops,#AA7028,0,none,#ffffff,0.0,2230.0
-1269,060821,Other Development,,60,82,Cultivated Crops,#AA7028,1,low,#e5f5e0,0.0,2230.0
-1270,060822,Other Development,,60,82,Cultivated Crops,#AA7028,2,medium,#a1d99b,0.0,2230.0
-1271,060823,Other Development,,60,82,Cultivated Crops,#AA7028,3,high,#31a354,1.0,2230.0
-1272,060900,Other Development,,60,90,Woody Wetlands,#BAD8EA,0,none,#ffffff,1.0,2230.0
-1273,060901,Other Development,,60,90,Woody Wetlands,#BAD8EA,1,low,#e5f5e0,1.0,2230.0
-1274,060902,Other Development,,60,90,Woody Wetlands,#BAD8EA,2,medium,#a1d99b,1.0,2230.0
-1275,060903,Other Development,,60,90,Woody Wetlands,#BAD8EA,3,high,#31a354,1.0,2230.0
-1276,060950,Other Development,,60,95,Emergent Herbaceous Wetlands,#70A3BA,0,none,#ffffff,1.0,2230.0
-1277,060951,Other Development,,60,95,Emergent Herbaceous Wetlands,#70A3BA,1,low,#e5f5e0,1.0,2230.0
-1278,060952,Other Development,,60,95,Emergent Herbaceous Wetlands,#70A3BA,2,medium,#a1d99b,1.0,2230.0
-1279,060953,Other Development,,60,95,Emergent Herbaceous Wetlands,#70A3BA,3,high,#31a354,1.0,2230.0
-1280,070110,Agriculture,,70,11,Open Water,#476BA0,0,none,#ffffff,0.0,2230.0
-1281,070111,Agriculture,,70,11,Open Water,#476BA0,1,low,#e5f5e0,0.0,2230.0
-1282,070112,Agriculture,,70,11,Open Water,#476BA0,2,medium,#a1d99b,0.0,2230.0
-1283,070113,Agriculture,,70,11,Open Water,#476BA0,3,high,#31a354,1.0,2230.0
-1284,070120,Agriculture,,70,12,Perennial Ice/Snow,#D1DDF9,0,none,#ffffff,0.0,2230.0
-1285,070121,Agriculture,,70,12,Perennial Ice/Snow,#D1DDF9,1,low,#e5f5e0,0.0,2230.0
-1286,070122,Agriculture,,70,12,Perennial Ice/Snow,#D1DDF9,2,medium,#a1d99b,0.0,2230.0
-1287,070123,Agriculture,,70,12,Perennial Ice/Snow,#D1DDF9,3,high,#31a354,1.0,2230.0
-1288,070210,Agriculture,,70,21,"Developed, Open Space",#DDC9C9,0,none,#ffffff,0.0,2230.0
-1289,070211,Agriculture,,70,21,"Developed, Open Space",#DDC9C9,1,low,#e5f5e0,0.0,2230.0
-1290,070212,Agriculture,,70,21,"Developed, Open Space",#DDC9C9,2,medium,#a1d99b,0.0,2230.0
-1291,070213,Agriculture,,70,21,"Developed, Open Space",#DDC9C9,3,high,#31a354,1.0,2230.0
-1292,070220,Agriculture,,70,22,"Developed, Low Intensity",#D89382,0,none,#ffffff,0.0,2230.0
-1293,070221,Agriculture,,70,22,"Developed, Low Intensity",#D89382,1,low,#e5f5e0,0.0,2230.0
-1294,070222,Agriculture,,70,22,"Developed, Low Intensity",#D89382,2,medium,#a1d99b,0.0,2230.0
-1295,070223,Agriculture,,70,22,"Developed, Low Intensity",#D89382,3,high,#31a354,1.0,2230.0
-1296,070230,Agriculture,,70,23,"Developed, Medium Intensity",#ED0000,0,none,#ffffff,0.0,2230.0
-1297,070231,Agriculture,,70,23,"Developed, Medium Intensity",#ED0000,1,low,#e5f5e0,0.0,2230.0
-1298,070232,Agriculture,,70,23,"Developed, Medium Intensity",#ED0000,2,medium,#a1d99b,0.0,2230.0
-1299,070233,Agriculture,,70,23,"Developed, Medium Intensity",#ED0000,3,high,#31a354,1.0,2230.0
-1300,070240,Agriculture,,70,24,"Developed, High Intensity",#AA0000,0,none,#ffffff,0.0,2230.0
-1301,070241,Agriculture,,70,24,"Developed, High Intensity",#AA0000,1,low,#e5f5e0,0.0,2230.0
-1302,070242,Agriculture,,70,24,"Developed, High Intensity",#AA0000,2,medium,#a1d99b,0.0,2230.0
-1303,070243,Agriculture,,70,24,"Developed, High Intensity",#AA0000,3,high,#31a354,1.0,2230.0
-1304,070310,Agriculture,,70,31,Barren Land (Rock/Sand/Clay),#B2ADA3,0,none,#ffffff,0.0,2230.0
-1305,070311,Agriculture,,70,31,Barren Land (Rock/Sand/Clay),#B2ADA3,1,low,#e5f5e0,0.0,2230.0
-1306,070312,Agriculture,,70,31,Barren Land (Rock/Sand/Clay),#B2ADA3,2,medium,#a1d99b,0.0,2230.0
-1307,070313,Agriculture,,70,31,Barren Land (Rock/Sand/Clay),#B2ADA3,3,high,#31a354,1.0,2230.0
-1308,070410,Agriculture,,70,41,Deciduous Forest,#68AA63,0,none,#ffffff,1.0,2230.0
-1309,070411,Agriculture,,70,41,Deciduous Forest,#68AA63,1,low,#e5f5e0,1.0,2230.0
-1310,070412,Agriculture,,70,41,Deciduous Forest,#68AA63,2,medium,#a1d99b,1.0,2230.0
-1311,070413,Agriculture,,70,41,Deciduous Forest,#68AA63,3,high,#31a354,1.0,2230.0
-1312,070420,Agriculture,,70,42,Evergreen Forest,#1C6330,0,none,#ffffff,1.0,2230.0
-1313,070421,Agriculture,,70,42,Evergreen Forest,#1C6330,1,low,#e5f5e0,1.0,2230.0
-1314,070422,Agriculture,,70,42,Evergreen Forest,#1C6330,2,medium,#a1d99b,1.0,2230.0
-1315,070423,Agriculture,,70,42,Evergreen Forest,#1C6330,3,high,#31a354,1.0,2230.0
-1316,070430,Agriculture,,70,43,Mixed Forest,#B5C98E,0,none,#ffffff,1.0,2230.0
-1317,070431,Agriculture,,70,43,Mixed Forest,#B5C98E,1,low,#e5f5e0,1.0,2230.0
-1318,070432,Agriculture,,70,43,Mixed Forest,#B5C98E,2,medium,#a1d99b,1.0,2230.0
-1319,070433,Agriculture,,70,43,Mixed Forest,#B5C98E,3,high,#31a354,1.0,2230.0
-1320,070510,Agriculture,,70,51,Dwarf Scrub,#A58C30,0,none,#ffffff,0.0,
-1321,070511,Agriculture,,70,51,Dwarf Scrub,#A58C30,1,low,#e5f5e0,0.0,
-1322,070512,Agriculture,,70,51,Dwarf Scrub,#A58C30,2,medium,#a1d99b,0.0,
-1323,070513,Agriculture,,70,51,Dwarf Scrub,#A58C30,3,high,#31a354,1.0,
-1324,070520,Agriculture,,70,52,Scrub/Shrub,#CCBA7C,0,none,#ffffff,1.0,2230.0
-1325,070521,Agriculture,,70,52,Scrub/Shrub,#CCBA7C,1,low,#e5f5e0,1.0,2230.0
-1326,070522,Agriculture,,70,52,Scrub/Shrub,#CCBA7C,2,medium,#a1d99b,1.0,2230.0
-1327,070523,Agriculture,,70,52,Scrub/Shrub,#CCBA7C,3,high,#31a354,1.0,2230.0
-1328,070710,Agriculture,,70,71,Grassland/Herbaceous,#E2E2C1,0,none,#ffffff,1.0,2230.0
-1329,070711,Agriculture,,70,71,Grassland/Herbaceous,#E2E2C1,1,low,#e5f5e0,1.0,2230.0
-1330,070712,Agriculture,,70,71,Grassland/Herbaceous,#E2E2C1,2,medium,#a1d99b,1.0,2230.0
-1331,070713,Agriculture,,70,71,Grassland/Herbaceous,#E2E2C1,3,high,#31a354,1.0,2230.0
-1332,070720,Agriculture,,70,72,Sedge/Herbaceuous,#C9C977,0,none,#ffffff,0.0,
-1333,070721,Agriculture,,70,72,Sedge/Herbaceuous,#C9C977,1,low,#e5f5e0,0.0,
-1334,070722,Agriculture,,70,72,Sedge/Herbaceuous,#C9C977,2,medium,#a1d99b,0.0,
-1335,070723,Agriculture,,70,72,Sedge/Herbaceuous,#C9C977,3,high,#31a354,1.0,
-1336,070730,Agriculture,,70,73,Lichens,#99C147,0,none,#ffffff,0.0,
-1337,070731,Agriculture,,70,73,Lichens,#99C147,1,low,#e5f5e0,0.0,
-1338,070732,Agriculture,,70,73,Lichens,#99C147,2,medium,#a1d99b,0.0,
-1339,070733,Agriculture,,70,73,Lichens,#99C147,3,high,#31a354,1.0,
-1340,070740,Agriculture,,70,74,Moss,#77AD93,0,none,#ffffff,0.0,
-1341,070741,Agriculture,,70,74,Moss,#77AD93,1,low,#e5f5e0,0.0,
-1342,070742,Agriculture,,70,74,Moss,#77AD93,2,medium,#a1d99b,0.0,
-1343,070743,Agriculture,,70,74,Moss,#77AD93,3,high,#31a354,1.0,
-1344,070810,Agriculture,,70,81,Pasture/Hay,#DBD83D,0,none,#ffffff,0.0,2230.0
-1345,070811,Agriculture,,70,81,Pasture/Hay,#DBD83D,1,low,#e5f5e0,0.0,2230.0
-1346,070812,Agriculture,,70,81,Pasture/Hay,#DBD83D,2,medium,#a1d99b,0.0,2230.0
-1347,070813,Agriculture,,70,81,Pasture/Hay,#DBD83D,3,high,#31a354,1.0,2230.0
-1348,070820,Agriculture,,70,82,Cultivated Crops,#AA7028,0,none,#ffffff,0.0,2230.0
-1349,070821,Agriculture,,70,82,Cultivated Crops,#AA7028,1,low,#e5f5e0,0.0,2230.0
-1350,070822,Agriculture,,70,82,Cultivated Crops,#AA7028,2,medium,#a1d99b,0.0,2230.0
-1351,070823,Agriculture,,70,82,Cultivated Crops,#AA7028,3,high,#31a354,1.0,2230.0
-1352,070900,Agriculture,,70,90,Woody Wetlands,#BAD8EA,0,none,#ffffff,1.0,2230.0
-1353,070901,Agriculture,,70,90,Woody Wetlands,#BAD8EA,1,low,#e5f5e0,1.0,2230.0
-1354,070902,Agriculture,,70,90,Woody Wetlands,#BAD8EA,2,medium,#a1d99b,1.0,2230.0
-1355,070903,Agriculture,,70,90,Woody Wetlands,#BAD8EA,3,high,#31a354,1.0,2230.0
-1356,070950,Agriculture,,70,95,Emergent Herbaceous Wetlands,#70A3BA,0,none,#ffffff,1.0,2230.0
-1357,070951,Agriculture,,70,95,Emergent Herbaceous Wetlands,#70A3BA,1,low,#e5f5e0,1.0,2230.0
-1358,070952,Agriculture,,70,95,Emergent Herbaceous Wetlands,#70A3BA,2,medium,#a1d99b,1.0,2230.0
-1359,070953,Agriculture,,70,95,Emergent Herbaceous Wetlands,#70A3BA,3,high,#31a354,1.0,2230.0
-1360,080110,Rangeland,,80,11,Open Water,#476BA0,0,none,#ffffff,0.0,2230.0
-1361,080111,Rangeland,,80,11,Open Water,#476BA0,1,low,#e5f5e0,0.0,2230.0
-1362,080112,Rangeland,,80,11,Open Water,#476BA0,2,medium,#a1d99b,0.0,2230.0
-1363,080113,Rangeland,,80,11,Open Water,#476BA0,3,high,#31a354,1.0,2230.0
-1364,080120,Rangeland,,80,12,Perennial Ice/Snow,#D1DDF9,0,none,#ffffff,0.0,2230.0
-1365,080121,Rangeland,,80,12,Perennial Ice/Snow,#D1DDF9,1,low,#e5f5e0,0.0,2230.0
-1366,080122,Rangeland,,80,12,Perennial Ice/Snow,#D1DDF9,2,medium,#a1d99b,0.0,2230.0
-1367,080123,Rangeland,,80,12,Perennial Ice/Snow,#D1DDF9,3,high,#31a354,1.0,2230.0
-1368,080210,Rangeland,,80,21,"Developed, Open Space",#DDC9C9,0,none,#ffffff,0.0,2230.0
-1369,080211,Rangeland,,80,21,"Developed, Open Space",#DDC9C9,1,low,#e5f5e0,0.0,2230.0
-1370,080212,Rangeland,,80,21,"Developed, Open Space",#DDC9C9,2,medium,#a1d99b,0.0,2230.0
-1371,080213,Rangeland,,80,21,"Developed, Open Space",#DDC9C9,3,high,#31a354,1.0,2230.0
-1372,080220,Rangeland,,80,22,"Developed, Low Intensity",#D89382,0,none,#ffffff,0.0,2230.0
-1373,080221,Rangeland,,80,22,"Developed, Low Intensity",#D89382,1,low,#e5f5e0,0.0,2230.0
-1374,080222,Rangeland,,80,22,"Developed, Low Intensity",#D89382,2,medium,#a1d99b,0.0,2230.0
-1375,080223,Rangeland,,80,22,"Developed, Low Intensity",#D89382,3,high,#31a354,1.0,2230.0
-1376,080230,Rangeland,,80,23,"Developed, Medium Intensity",#ED0000,0,none,#ffffff,0.0,2230.0
-1377,080231,Rangeland,,80,23,"Developed, Medium Intensity",#ED0000,1,low,#e5f5e0,0.0,2230.0
-1378,080232,Rangeland,,80,23,"Developed, Medium Intensity",#ED0000,2,medium,#a1d99b,0.0,2230.0
-1379,080233,Rangeland,,80,23,"Developed, Medium Intensity",#ED0000,3,high,#31a354,1.0,2230.0
-1380,080240,Rangeland,,80,24,"Developed, High Intensity",#AA0000,0,none,#ffffff,0.0,2230.0
-1381,080241,Rangeland,,80,24,"Developed, High Intensity",#AA0000,1,low,#e5f5e0,0.0,2230.0
-1382,080242,Rangeland,,80,24,"Developed, High Intensity",#AA0000,2,medium,#a1d99b,0.0,2230.0
-1383,080243,Rangeland,,80,24,"Developed, High Intensity",#AA0000,3,high,#31a354,1.0,2230.0
-1384,080310,Rangeland,,80,31,Barren Land (Rock/Sand/Clay),#B2ADA3,0,none,#ffffff,0.0,2230.0
-1385,080311,Rangeland,,80,31,Barren Land (Rock/Sand/Clay),#B2ADA3,1,low,#e5f5e0,0.0,2230.0
-1386,080312,Rangeland,,80,31,Barren Land (Rock/Sand/Clay),#B2ADA3,2,medium,#a1d99b,0.0,2230.0
-1387,080313,Rangeland,,80,31,Barren Land (Rock/Sand/Clay),#B2ADA3,3,high,#31a354,1.0,2230.0
-1388,080410,Rangeland,,80,41,Deciduous Forest,#68AA63,0,none,#ffffff,1.0,2230.0
-1389,080411,Rangeland,,80,41,Deciduous Forest,#68AA63,1,low,#e5f5e0,1.0,2230.0
-1390,080412,Rangeland,,80,41,Deciduous Forest,#68AA63,2,medium,#a1d99b,1.0,2230.0
-1391,080413,Rangeland,,80,41,Deciduous Forest,#68AA63,3,high,#31a354,1.0,2230.0
-1392,080420,Rangeland,,80,42,Evergreen Forest,#1C6330,0,none,#ffffff,1.0,2230.0
-1393,080421,Rangeland,,80,42,Evergreen Forest,#1C6330,1,low,#e5f5e0,1.0,2230.0
-1394,080422,Rangeland,,80,42,Evergreen Forest,#1C6330,2,medium,#a1d99b,1.0,2230.0
-1395,080423,Rangeland,,80,42,Evergreen Forest,#1C6330,3,high,#31a354,1.0,2230.0
-1396,080430,Rangeland,,80,43,Mixed Forest,#B5C98E,0,none,#ffffff,1.0,2230.0
-1397,080431,Rangeland,,80,43,Mixed Forest,#B5C98E,1,low,#e5f5e0,1.0,2230.0
-1398,080432,Rangeland,,80,43,Mixed Forest,#B5C98E,2,medium,#a1d99b,1.0,2230.0
-1399,080433,Rangeland,,80,43,Mixed Forest,#B5C98E,3,high,#31a354,1.0,2230.0
-1400,080510,Rangeland,,80,51,Dwarf Scrub,#A58C30,0,none,#ffffff,0.0,
-1401,080511,Rangeland,,80,51,Dwarf Scrub,#A58C30,1,low,#e5f5e0,0.0,
-1402,080512,Rangeland,,80,51,Dwarf Scrub,#A58C30,2,medium,#a1d99b,0.0,
-1403,080513,Rangeland,,80,51,Dwarf Scrub,#A58C30,3,high,#31a354,1.0,
-1404,080520,Rangeland,,80,52,Scrub/Shrub,#CCBA7C,0,none,#ffffff,1.0,2230.0
-1405,080521,Rangeland,,80,52,Scrub/Shrub,#CCBA7C,1,low,#e5f5e0,1.0,2230.0
-1406,080522,Rangeland,,80,52,Scrub/Shrub,#CCBA7C,2,medium,#a1d99b,1.0,2230.0
-1407,080523,Rangeland,,80,52,Scrub/Shrub,#CCBA7C,3,high,#31a354,1.0,2230.0
-1408,080710,Rangeland,,80,71,Grassland/Herbaceous,#E2E2C1,0,none,#ffffff,1.0,2230.0
-1409,080711,Rangeland,,80,71,Grassland/Herbaceous,#E2E2C1,1,low,#e5f5e0,1.0,2230.0
-1410,080712,Rangeland,,80,71,Grassland/Herbaceous,#E2E2C1,2,medium,#a1d99b,1.0,2230.0
-1411,080713,Rangeland,,80,71,Grassland/Herbaceous,#E2E2C1,3,high,#31a354,1.0,2230.0
-1412,080720,Rangeland,,80,72,Sedge/Herbaceuous,#C9C977,0,none,#ffffff,0.0,
-1413,080721,Rangeland,,80,72,Sedge/Herbaceuous,#C9C977,1,low,#e5f5e0,0.0,
-1414,080722,Rangeland,,80,72,Sedge/Herbaceuous,#C9C977,2,medium,#a1d99b,0.0,
-1415,080723,Rangeland,,80,72,Sedge/Herbaceuous,#C9C977,3,high,#31a354,1.0,
-1416,080730,Rangeland,,80,73,Lichens,#99C147,0,none,#ffffff,0.0,
-1417,080731,Rangeland,,80,73,Lichens,#99C147,1,low,#e5f5e0,0.0,
-1418,080732,Rangeland,,80,73,Lichens,#99C147,2,medium,#a1d99b,0.0,
-1419,080733,Rangeland,,80,73,Lichens,#99C147,3,high,#31a354,1.0,
-1420,080740,Rangeland,,80,74,Moss,#77AD93,0,none,#ffffff,0.0,
-1421,080741,Rangeland,,80,74,Moss,#77AD93,1,low,#e5f5e0,0.0,
-1422,080742,Rangeland,,80,74,Moss,#77AD93,2,medium,#a1d99b,0.0,
-1423,080743,Rangeland,,80,74,Moss,#77AD93,3,high,#31a354,1.0,
-1424,080810,Rangeland,,80,81,Pasture/Hay,#DBD83D,0,none,#ffffff,0.0,2230.0
-1425,080811,Rangeland,,80,81,Pasture/Hay,#DBD83D,1,low,#e5f5e0,0.0,2230.0
-1426,080812,Rangeland,,80,81,Pasture/Hay,#DBD83D,2,medium,#a1d99b,0.0,2230.0
-1427,080813,Rangeland,,80,81,Pasture/Hay,#DBD83D,3,high,#31a354,1.0,2230.0
-1428,080820,Rangeland,,80,82,Cultivated Crops,#AA7028,0,none,#ffffff,0.0,2230.0
-1429,080821,Rangeland,,80,82,Cultivated Crops,#AA7028,1,low,#e5f5e0,0.0,2230.0
-1430,080822,Rangeland,,80,82,Cultivated Crops,#AA7028,2,medium,#a1d99b,0.0,2230.0
-1431,080823,Rangeland,,80,82,Cultivated Crops,#AA7028,3,high,#31a354,1.0,2230.0
-1432,080900,Rangeland,,80,90,Woody Wetlands,#BAD8EA,0,none,#ffffff,1.0,2230.0
-1433,080901,Rangeland,,80,90,Woody Wetlands,#BAD8EA,1,low,#e5f5e0,1.0,2230.0
-1434,080902,Rangeland,,80,90,Woody Wetlands,#BAD8EA,2,medium,#a1d99b,1.0,2230.0
-1435,080903,Rangeland,,80,90,Woody Wetlands,#BAD8EA,3,high,#31a354,1.0,2230.0
-1436,080950,Rangeland,,80,95,Emergent Herbaceous Wetlands,#70A3BA,0,none,#ffffff,1.0,2230.0
-1437,080951,Rangeland,,80,95,Emergent Herbaceous Wetlands,#70A3BA,1,low,#e5f5e0,1.0,2230.0
-1438,080952,Rangeland,,80,95,Emergent Herbaceous Wetlands,#70A3BA,2,medium,#a1d99b,1.0,2230.0
-1439,080953,Rangeland,,80,95,Emergent Herbaceous Wetlands,#70A3BA,3,high,#31a354,1.0,2230.0
-1440,090110,Extractive/Mining,,90,11,Open Water,#476BA0,0,none,#ffffff,0.0,2230.0
-1441,090111,Extractive/Mining,,90,11,Open Water,#476BA0,1,low,#e5f5e0,0.0,2230.0
-1442,090112,Extractive/Mining,,90,11,Open Water,#476BA0,2,medium,#a1d99b,0.0,2230.0
-1443,090113,Extractive/Mining,,90,11,Open Water,#476BA0,3,high,#31a354,1.0,2230.0
-1444,090120,Extractive/Mining,,90,12,Perennial Ice/Snow,#D1DDF9,0,none,#ffffff,0.0,2230.0
-1445,090121,Extractive/Mining,,90,12,Perennial Ice/Snow,#D1DDF9,1,low,#e5f5e0,0.0,2230.0
-1446,090122,Extractive/Mining,,90,12,Perennial Ice/Snow,#D1DDF9,2,medium,#a1d99b,0.0,2230.0
-1447,090123,Extractive/Mining,,90,12,Perennial Ice/Snow,#D1DDF9,3,high,#31a354,1.0,2230.0
-1448,090210,Extractive/Mining,,90,21,"Developed, Open Space",#DDC9C9,0,none,#ffffff,0.0,2230.0
-1449,090211,Extractive/Mining,,90,21,"Developed, Open Space",#DDC9C9,1,low,#e5f5e0,0.0,2230.0
-1450,090212,Extractive/Mining,,90,21,"Developed, Open Space",#DDC9C9,2,medium,#a1d99b,0.0,2230.0
-1451,090213,Extractive/Mining,,90,21,"Developed, Open Space",#DDC9C9,3,high,#31a354,1.0,2230.0
-1452,090220,Extractive/Mining,,90,22,"Developed, Low Intensity",#D89382,0,none,#ffffff,0.0,2230.0
-1453,090221,Extractive/Mining,,90,22,"Developed, Low Intensity",#D89382,1,low,#e5f5e0,0.0,2230.0
-1454,090222,Extractive/Mining,,90,22,"Developed, Low Intensity",#D89382,2,medium,#a1d99b,0.0,2230.0
-1455,090223,Extractive/Mining,,90,22,"Developed, Low Intensity",#D89382,3,high,#31a354,1.0,2230.0
-1456,090230,Extractive/Mining,,90,23,"Developed, Medium Intensity",#ED0000,0,none,#ffffff,0.0,2230.0
-1457,090231,Extractive/Mining,,90,23,"Developed, Medium Intensity",#ED0000,1,low,#e5f5e0,0.0,2230.0
-1458,090232,Extractive/Mining,,90,23,"Developed, Medium Intensity",#ED0000,2,medium,#a1d99b,0.0,2230.0
-1459,090233,Extractive/Mining,,90,23,"Developed, Medium Intensity",#ED0000,3,high,#31a354,1.0,2230.0
-1460,090240,Extractive/Mining,,90,24,"Developed, High Intensity",#AA0000,0,none,#ffffff,0.0,2230.0
-1461,090241,Extractive/Mining,,90,24,"Developed, High Intensity",#AA0000,1,low,#e5f5e0,0.0,2230.0
-1462,090242,Extractive/Mining,,90,24,"Developed, High Intensity",#AA0000,2,medium,#a1d99b,0.0,2230.0
-1463,090243,Extractive/Mining,,90,24,"Developed, High Intensity",#AA0000,3,high,#31a354,1.0,2230.0
-1464,090310,Extractive/Mining,,90,31,Barren Land (Rock/Sand/Clay),#B2ADA3,0,none,#ffffff,0.0,2230.0
-1465,090311,Extractive/Mining,,90,31,Barren Land (Rock/Sand/Clay),#B2ADA3,1,low,#e5f5e0,0.0,2230.0
-1466,090312,Extractive/Mining,,90,31,Barren Land (Rock/Sand/Clay),#B2ADA3,2,medium,#a1d99b,0.0,2230.0
-1467,090313,Extractive/Mining,,90,31,Barren Land (Rock/Sand/Clay),#B2ADA3,3,high,#31a354,1.0,2230.0
-1468,090410,Extractive/Mining,,90,41,Deciduous Forest,#68AA63,0,none,#ffffff,1.0,2230.0
-1469,090411,Extractive/Mining,,90,41,Deciduous Forest,#68AA63,1,low,#e5f5e0,1.0,2230.0
-1470,090412,Extractive/Mining,,90,41,Deciduous Forest,#68AA63,2,medium,#a1d99b,1.0,2230.0
-1471,090413,Extractive/Mining,,90,41,Deciduous Forest,#68AA63,3,high,#31a354,1.0,2230.0
-1472,090420,Extractive/Mining,,90,42,Evergreen Forest,#1C6330,0,none,#ffffff,1.0,2230.0
-1473,090421,Extractive/Mining,,90,42,Evergreen Forest,#1C6330,1,low,#e5f5e0,1.0,2230.0
-1474,090422,Extractive/Mining,,90,42,Evergreen Forest,#1C6330,2,medium,#a1d99b,1.0,2230.0
-1475,090423,Extractive/Mining,,90,42,Evergreen Forest,#1C6330,3,high,#31a354,1.0,2230.0
-1476,090430,Extractive/Mining,,90,43,Mixed Forest,#B5C98E,0,none,#ffffff,1.0,2230.0
-1477,090431,Extractive/Mining,,90,43,Mixed Forest,#B5C98E,1,low,#e5f5e0,1.0,2230.0
-1478,090432,Extractive/Mining,,90,43,Mixed Forest,#B5C98E,2,medium,#a1d99b,1.0,2230.0
-1479,090433,Extractive/Mining,,90,43,Mixed Forest,#B5C98E,3,high,#31a354,1.0,2230.0
-1480,090510,Extractive/Mining,,90,51,Dwarf Scrub,#A58C30,0,none,#ffffff,0.0,
-1481,090511,Extractive/Mining,,90,51,Dwarf Scrub,#A58C30,1,low,#e5f5e0,0.0,
-1482,090512,Extractive/Mining,,90,51,Dwarf Scrub,#A58C30,2,medium,#a1d99b,0.0,
-1483,090513,Extractive/Mining,,90,51,Dwarf Scrub,#A58C30,3,high,#31a354,1.0,
-1484,090520,Extractive/Mining,,90,52,Scrub/Shrub,#CCBA7C,0,none,#ffffff,1.0,2230.0
-1485,090521,Extractive/Mining,,90,52,Scrub/Shrub,#CCBA7C,1,low,#e5f5e0,1.0,2230.0
-1486,090522,Extractive/Mining,,90,52,Scrub/Shrub,#CCBA7C,2,medium,#a1d99b,1.0,2230.0
-1487,090523,Extractive/Mining,,90,52,Scrub/Shrub,#CCBA7C,3,high,#31a354,1.0,2230.0
-1488,090710,Extractive/Mining,,90,71,Grassland/Herbaceous,#E2E2C1,0,none,#ffffff,1.0,2230.0
-1489,090711,Extractive/Mining,,90,71,Grassland/Herbaceous,#E2E2C1,1,low,#e5f5e0,1.0,2230.0
-1490,090712,Extractive/Mining,,90,71,Grassland/Herbaceous,#E2E2C1,2,medium,#a1d99b,1.0,2230.0
-1491,090713,Extractive/Mining,,90,71,Grassland/Herbaceous,#E2E2C1,3,high,#31a354,1.0,2230.0
-1492,090720,Extractive/Mining,,90,72,Sedge/Herbaceuous,#C9C977,0,none,#ffffff,0.0,
-1493,090721,Extractive/Mining,,90,72,Sedge/Herbaceuous,#C9C977,1,low,#e5f5e0,0.0,
-1494,090722,Extractive/Mining,,90,72,Sedge/Herbaceuous,#C9C977,2,medium,#a1d99b,0.0,
-1495,090723,Extractive/Mining,,90,72,Sedge/Herbaceuous,#C9C977,3,high,#31a354,1.0,
-1496,090730,Extractive/Mining,,90,73,Lichens,#99C147,0,none,#ffffff,0.0,
-1497,090731,Extractive/Mining,,90,73,Lichens,#99C147,1,low,#e5f5e0,0.0,
-1498,090732,Extractive/Mining,,90,73,Lichens,#99C147,2,medium,#a1d99b,0.0,
-1499,090733,Extractive/Mining,,90,73,Lichens,#99C147,3,high,#31a354,1.0,
-1500,090740,Extractive/Mining,,90,74,Moss,#77AD93,0,none,#ffffff,0.0,
-1501,090741,Extractive/Mining,,90,74,Moss,#77AD93,1,low,#e5f5e0,0.0,
-1502,090742,Extractive/Mining,,90,74,Moss,#77AD93,2,medium,#a1d99b,0.0,
-1503,090743,Extractive/Mining,,90,74,Moss,#77AD93,3,high,#31a354,1.0,
-1504,090810,Extractive/Mining,,90,81,Pasture/Hay,#DBD83D,0,none,#ffffff,0.0,2230.0
-1505,090811,Extractive/Mining,,90,81,Pasture/Hay,#DBD83D,1,low,#e5f5e0,0.0,2230.0
-1506,090812,Extractive/Mining,,90,81,Pasture/Hay,#DBD83D,2,medium,#a1d99b,0.0,2230.0
-1507,090813,Extractive/Mining,,90,81,Pasture/Hay,#DBD83D,3,high,#31a354,1.0,2230.0
-1508,090820,Extractive/Mining,,90,82,Cultivated Crops,#AA7028,0,none,#ffffff,0.0,2230.0
-1509,090821,Extractive/Mining,,90,82,Cultivated Crops,#AA7028,1,low,#e5f5e0,0.0,2230.0
-1510,090822,Extractive/Mining,,90,82,Cultivated Crops,#AA7028,2,medium,#a1d99b,0.0,2230.0
-1511,090823,Extractive/Mining,,90,82,Cultivated Crops,#AA7028,3,high,#31a354,1.0,2230.0
-1512,090900,Extractive/Mining,,90,90,Woody Wetlands,#BAD8EA,0,none,#ffffff,1.0,2230.0
-1513,090901,Extractive/Mining,,90,90,Woody Wetlands,#BAD8EA,1,low,#e5f5e0,1.0,2230.0
-1514,090902,Extractive/Mining,,90,90,Woody Wetlands,#BAD8EA,2,medium,#a1d99b,1.0,2230.0
-1515,090903,Extractive/Mining,,90,90,Woody Wetlands,#BAD8EA,3,high,#31a354,1.0,2230.0
-1516,090950,Extractive/Mining,,90,95,Emergent Herbaceous Wetlands,#70A3BA,0,none,#ffffff,1.0,2230.0
-1517,090951,Extractive/Mining,,90,95,Emergent Herbaceous Wetlands,#70A3BA,1,low,#e5f5e0,1.0,2230.0
-1518,090952,Extractive/Mining,,90,95,Emergent Herbaceous Wetlands,#70A3BA,2,medium,#a1d99b,1.0,2230.0
-1519,090953,Extractive/Mining,,90,95,Emergent Herbaceous Wetlands,#70A3BA,3,high,#31a354,1.0,2230.0
-1520,100110,Timber,,100,11,Open Water,#476BA0,0,none,#ffffff,0.0,2230.0
-1521,100111,Timber,,100,11,Open Water,#476BA0,1,low,#e5f5e0,0.0,2230.0
-1522,100112,Timber,,100,11,Open Water,#476BA0,2,medium,#a1d99b,0.0,2230.0
-1523,100113,Timber,,100,11,Open Water,#476BA0,3,high,#31a354,1.0,2230.0
-1524,100120,Timber,,100,12,Perennial Ice/Snow,#D1DDF9,0,none,#ffffff,0.0,2230.0
-1525,100121,Timber,,100,12,Perennial Ice/Snow,#D1DDF9,1,low,#e5f5e0,0.0,2230.0
-1526,100122,Timber,,100,12,Perennial Ice/Snow,#D1DDF9,2,medium,#a1d99b,0.0,2230.0
-1527,100123,Timber,,100,12,Perennial Ice/Snow,#D1DDF9,3,high,#31a354,1.0,2230.0
-1528,100210,Timber,,100,21,"Developed, Open Space",#DDC9C9,0,none,#ffffff,0.0,2230.0
-1529,100211,Timber,,100,21,"Developed, Open Space",#DDC9C9,1,low,#e5f5e0,0.0,2230.0
-1530,100212,Timber,,100,21,"Developed, Open Space",#DDC9C9,2,medium,#a1d99b,0.0,2230.0
-1531,100213,Timber,,100,21,"Developed, Open Space",#DDC9C9,3,high,#31a354,1.0,2230.0
-1532,100220,Timber,,100,22,"Developed, Low Intensity",#D89382,0,none,#ffffff,0.0,2230.0
-1533,100221,Timber,,100,22,"Developed, Low Intensity",#D89382,1,low,#e5f5e0,0.0,2230.0
-1534,100222,Timber,,100,22,"Developed, Low Intensity",#D89382,2,medium,#a1d99b,0.0,2230.0
-1535,100223,Timber,,100,22,"Developed, Low Intensity",#D89382,3,high,#31a354,1.0,2230.0
-1536,100230,Timber,,100,23,"Developed, Medium Intensity",#ED0000,0,none,#ffffff,0.0,2230.0
-1537,100231,Timber,,100,23,"Developed, Medium Intensity",#ED0000,1,low,#e5f5e0,0.0,2230.0
-1538,100232,Timber,,100,23,"Developed, Medium Intensity",#ED0000,2,medium,#a1d99b,0.0,2230.0
-1539,100233,Timber,,100,23,"Developed, Medium Intensity",#ED0000,3,high,#31a354,1.0,2230.0
-1540,100240,Timber,,100,24,"Developed, High Intensity",#AA0000,0,none,#ffffff,0.0,2230.0
-1541,100241,Timber,,100,24,"Developed, High Intensity",#AA0000,1,low,#e5f5e0,0.0,2230.0
-1542,100242,Timber,,100,24,"Developed, High Intensity",#AA0000,2,medium,#a1d99b,0.0,2230.0
-1543,100243,Timber,,100,24,"Developed, High Intensity",#AA0000,3,high,#31a354,1.0,2230.0
-1544,100310,Timber,,100,31,Barren Land (Rock/Sand/Clay),#B2ADA3,0,none,#ffffff,0.0,2230.0
-1545,100311,Timber,,100,31,Barren Land (Rock/Sand/Clay),#B2ADA3,1,low,#e5f5e0,0.0,2230.0
-1546,100312,Timber,,100,31,Barren Land (Rock/Sand/Clay),#B2ADA3,2,medium,#a1d99b,0.0,2230.0
-1547,100313,Timber,,100,31,Barren Land (Rock/Sand/Clay),#B2ADA3,3,high,#31a354,1.0,2230.0
-1548,100410,Timber,,100,41,Deciduous Forest,#68AA63,0,none,#ffffff,1.0,2230.0
-1549,100411,Timber,,100,41,Deciduous Forest,#68AA63,1,low,#e5f5e0,1.0,2230.0
-1550,100412,Timber,,100,41,Deciduous Forest,#68AA63,2,medium,#a1d99b,1.0,2230.0
-1551,100413,Timber,,100,41,Deciduous Forest,#68AA63,3,high,#31a354,1.0,2230.0
-1552,100420,Timber,,100,42,Evergreen Forest,#1C6330,0,none,#ffffff,1.0,2230.0
-1553,100421,Timber,,100,42,Evergreen Forest,#1C6330,1,low,#e5f5e0,1.0,2230.0
-1554,100422,Timber,,100,42,Evergreen Forest,#1C6330,2,medium,#a1d99b,1.0,2230.0
-1555,100423,Timber,,100,42,Evergreen Forest,#1C6330,3,high,#31a354,1.0,2230.0
-1556,100430,Timber,,100,43,Mixed Forest,#B5C98E,0,none,#ffffff,1.0,2230.0
-1557,100431,Timber,,100,43,Mixed Forest,#B5C98E,1,low,#e5f5e0,1.0,2230.0
-1558,100432,Timber,,100,43,Mixed Forest,#B5C98E,2,medium,#a1d99b,1.0,2230.0
-1559,100433,Timber,,100,43,Mixed Forest,#B5C98E,3,high,#31a354,1.0,2230.0
-1560,100510,Timber,,100,51,Dwarf Scrub,#A58C30,0,none,#ffffff,0.0,
-1561,100511,Timber,,100,51,Dwarf Scrub,#A58C30,1,low,#e5f5e0,0.0,
-1562,100512,Timber,,100,51,Dwarf Scrub,#A58C30,2,medium,#a1d99b,0.0,
-1563,100513,Timber,,100,51,Dwarf Scrub,#A58C30,3,high,#31a354,1.0,
-1564,100520,Timber,,100,52,Scrub/Shrub,#CCBA7C,0,none,#ffffff,1.0,2230.0
-1565,100521,Timber,,100,52,Scrub/Shrub,#CCBA7C,1,low,#e5f5e0,1.0,2230.0
-1566,100522,Timber,,100,52,Scrub/Shrub,#CCBA7C,2,medium,#a1d99b,1.0,2230.0
-1567,100523,Timber,,100,52,Scrub/Shrub,#CCBA7C,3,high,#31a354,1.0,2230.0
-1568,100710,Timber,,100,71,Grassland/Herbaceous,#E2E2C1,0,none,#ffffff,1.0,2230.0
-1569,100711,Timber,,100,71,Grassland/Herbaceous,#E2E2C1,1,low,#e5f5e0,1.0,2230.0
-1570,100712,Timber,,100,71,Grassland/Herbaceous,#E2E2C1,2,medium,#a1d99b,1.0,2230.0
-1571,100713,Timber,,100,71,Grassland/Herbaceous,#E2E2C1,3,high,#31a354,1.0,2230.0
-1572,100720,Timber,,100,72,Sedge/Herbaceuous,#C9C977,0,none,#ffffff,0.0,
-1573,100721,Timber,,100,72,Sedge/Herbaceuous,#C9C977,1,low,#e5f5e0,0.0,
-1574,100722,Timber,,100,72,Sedge/Herbaceuous,#C9C977,2,medium,#a1d99b,0.0,
-1575,100723,Timber,,100,72,Sedge/Herbaceuous,#C9C977,3,high,#31a354,1.0,
-1576,100730,Timber,,100,73,Lichens,#99C147,0,none,#ffffff,0.0,
-1577,100731,Timber,,100,73,Lichens,#99C147,1,low,#e5f5e0,0.0,
-1578,100732,Timber,,100,73,Lichens,#99C147,2,medium,#a1d99b,0.0,
-1579,100733,Timber,,100,73,Lichens,#99C147,3,high,#31a354,1.0,
-1580,100740,Timber,,100,74,Moss,#77AD93,0,none,#ffffff,0.0,
-1581,100741,Timber,,100,74,Moss,#77AD93,1,low,#e5f5e0,0.0,
-1582,100742,Timber,,100,74,Moss,#77AD93,2,medium,#a1d99b,0.0,
-1583,100743,Timber,,100,74,Moss,#77AD93,3,high,#31a354,1.0,
-1584,100810,Timber,,100,81,Pasture/Hay,#DBD83D,0,none,#ffffff,0.0,2230.0
-1585,100811,Timber,,100,81,Pasture/Hay,#DBD83D,1,low,#e5f5e0,0.0,2230.0
-1586,100812,Timber,,100,81,Pasture/Hay,#DBD83D,2,medium,#a1d99b,0.0,2230.0
-1587,100813,Timber,,100,81,Pasture/Hay,#DBD83D,3,high,#31a354,1.0,2230.0
-1588,100820,Timber,,100,82,Cultivated Crops,#AA7028,0,none,#ffffff,0.0,2230.0
-1589,100821,Timber,,100,82,Cultivated Crops,#AA7028,1,low,#e5f5e0,0.0,2230.0
-1590,100822,Timber,,100,82,Cultivated Crops,#AA7028,2,medium,#a1d99b,0.0,2230.0
-1591,100823,Timber,,100,82,Cultivated Crops,#AA7028,3,high,#31a354,1.0,2230.0
-1592,100900,Timber,,100,90,Woody Wetlands,#BAD8EA,0,none,#ffffff,1.0,2230.0
-1593,100901,Timber,,100,90,Woody Wetlands,#BAD8EA,1,low,#e5f5e0,1.0,2230.0
-1594,100902,Timber,,100,90,Woody Wetlands,#BAD8EA,2,medium,#a1d99b,1.0,2230.0
-1595,100903,Timber,,100,90,Woody Wetlands,#BAD8EA,3,high,#31a354,1.0,2230.0
-1596,100950,Timber,,100,95,Emergent Herbaceous Wetlands,#70A3BA,0,none,#ffffff,1.0,2230.0
-1597,100951,Timber,,100,95,Emergent Herbaceous Wetlands,#70A3BA,1,low,#e5f5e0,1.0,2230.0
-1598,100952,Timber,,100,95,Emergent Herbaceous Wetlands,#70A3BA,2,medium,#a1d99b,1.0,2230.0
-1599,100953,Timber,,100,95,Emergent Herbaceous Wetlands,#70A3BA,3,high,#31a354,1.0,2230.0
-1600,110110,Barren,,110,11,Open Water,#476BA0,0,none,#ffffff,0.0,2230.0
-1601,110111,Barren,,110,11,Open Water,#476BA0,1,low,#e5f5e0,0.0,2230.0
-1602,110112,Barren,,110,11,Open Water,#476BA0,2,medium,#a1d99b,0.0,2230.0
-1603,110113,Barren,,110,11,Open Water,#476BA0,3,high,#31a354,1.0,2230.0
-1604,110120,Barren,,110,12,Perennial Ice/Snow,#D1DDF9,0,none,#ffffff,0.0,2230.0
-1605,110121,Barren,,110,12,Perennial Ice/Snow,#D1DDF9,1,low,#e5f5e0,0.0,2230.0
-1606,110122,Barren,,110,12,Perennial Ice/Snow,#D1DDF9,2,medium,#a1d99b,0.0,2230.0
-1607,110123,Barren,,110,12,Perennial Ice/Snow,#D1DDF9,3,high,#31a354,1.0,2230.0
-1608,110210,Barren,,110,21,"Developed, Open Space",#DDC9C9,0,none,#ffffff,0.0,2230.0
-1609,110211,Barren,,110,21,"Developed, Open Space",#DDC9C9,1,low,#e5f5e0,0.0,2230.0
-1610,110212,Barren,,110,21,"Developed, Open Space",#DDC9C9,2,medium,#a1d99b,0.0,2230.0
-1611,110213,Barren,,110,21,"Developed, Open Space",#DDC9C9,3,high,#31a354,1.0,2230.0
-1612,110220,Barren,,110,22,"Developed, Low Intensity",#D89382,0,none,#ffffff,0.0,2230.0
-1613,110221,Barren,,110,22,"Developed, Low Intensity",#D89382,1,low,#e5f5e0,0.0,2230.0
-1614,110222,Barren,,110,22,"Developed, Low Intensity",#D89382,2,medium,#a1d99b,0.0,2230.0
-1615,110223,Barren,,110,22,"Developed, Low Intensity",#D89382,3,high,#31a354,1.0,2230.0
-1616,110230,Barren,,110,23,"Developed, Medium Intensity",#ED0000,0,none,#ffffff,0.0,2230.0
-1617,110231,Barren,,110,23,"Developed, Medium Intensity",#ED0000,1,low,#e5f5e0,0.0,2230.0
-1618,110232,Barren,,110,23,"Developed, Medium Intensity",#ED0000,2,medium,#a1d99b,0.0,2230.0
-1619,110233,Barren,,110,23,"Developed, Medium Intensity",#ED0000,3,high,#31a354,1.0,2230.0
-1620,110240,Barren,,110,24,"Developed, High Intensity",#AA0000,0,none,#ffffff,0.0,2230.0
-1621,110241,Barren,,110,24,"Developed, High Intensity",#AA0000,1,low,#e5f5e0,0.0,2230.0
-1622,110242,Barren,,110,24,"Developed, High Intensity",#AA0000,2,medium,#a1d99b,0.0,2230.0
-1623,110243,Barren,,110,24,"Developed, High Intensity",#AA0000,3,high,#31a354,1.0,2230.0
-1624,110310,Barren,,110,31,Barren Land (Rock/Sand/Clay),#B2ADA3,0,none,#ffffff,0.0,2230.0
-1625,110311,Barren,,110,31,Barren Land (Rock/Sand/Clay),#B2ADA3,1,low,#e5f5e0,0.0,2230.0
-1626,110312,Barren,,110,31,Barren Land (Rock/Sand/Clay),#B2ADA3,2,medium,#a1d99b,0.0,2230.0
-1627,110313,Barren,,110,31,Barren Land (Rock/Sand/Clay),#B2ADA3,3,high,#31a354,1.0,2230.0
-1628,110410,Barren,,110,41,Deciduous Forest,#68AA63,0,none,#ffffff,1.0,2230.0
-1629,110411,Barren,,110,41,Deciduous Forest,#68AA63,1,low,#e5f5e0,1.0,2230.0
-1630,110412,Barren,,110,41,Deciduous Forest,#68AA63,2,medium,#a1d99b,1.0,2230.0
-1631,110413,Barren,,110,41,Deciduous Forest,#68AA63,3,high,#31a354,1.0,2230.0
-1632,110420,Barren,,110,42,Evergreen Forest,#1C6330,0,none,#ffffff,1.0,2230.0
-1633,110421,Barren,,110,42,Evergreen Forest,#1C6330,1,low,#e5f5e0,1.0,2230.0
-1634,110422,Barren,,110,42,Evergreen Forest,#1C6330,2,medium,#a1d99b,1.0,2230.0
-1635,110423,Barren,,110,42,Evergreen Forest,#1C6330,3,high,#31a354,1.0,2230.0
-1636,110430,Barren,,110,43,Mixed Forest,#B5C98E,0,none,#ffffff,1.0,2230.0
-1637,110431,Barren,,110,43,Mixed Forest,#B5C98E,1,low,#e5f5e0,1.0,2230.0
-1638,110432,Barren,,110,43,Mixed Forest,#B5C98E,2,medium,#a1d99b,1.0,2230.0
-1639,110433,Barren,,110,43,Mixed Forest,#B5C98E,3,high,#31a354,1.0,2230.0
-1640,110510,Barren,,110,51,Dwarf Scrub,#A58C30,0,none,#ffffff,0.0,
-1641,110511,Barren,,110,51,Dwarf Scrub,#A58C30,1,low,#e5f5e0,0.0,
-1642,110512,Barren,,110,51,Dwarf Scrub,#A58C30,2,medium,#a1d99b,0.0,
-1643,110513,Barren,,110,51,Dwarf Scrub,#A58C30,3,high,#31a354,1.0,
-1644,110520,Barren,,110,52,Scrub/Shrub,#CCBA7C,0,none,#ffffff,1.0,2230.0
-1645,110521,Barren,,110,52,Scrub/Shrub,#CCBA7C,1,low,#e5f5e0,1.0,2230.0
-1646,110522,Barren,,110,52,Scrub/Shrub,#CCBA7C,2,medium,#a1d99b,1.0,2230.0
-1647,110523,Barren,,110,52,Scrub/Shrub,#CCBA7C,3,high,#31a354,1.0,2230.0
-1648,110710,Barren,,110,71,Grassland/Herbaceous,#E2E2C1,0,none,#ffffff,1.0,2230.0
-1649,110711,Barren,,110,71,Grassland/Herbaceous,#E2E2C1,1,low,#e5f5e0,1.0,2230.0
-1650,110712,Barren,,110,71,Grassland/Herbaceous,#E2E2C1,2,medium,#a1d99b,1.0,2230.0
-1651,110713,Barren,,110,71,Grassland/Herbaceous,#E2E2C1,3,high,#31a354,1.0,2230.0
-1652,110720,Barren,,110,72,Sedge/Herbaceuous,#C9C977,0,none,#ffffff,0.0,
-1653,110721,Barren,,110,72,Sedge/Herbaceuous,#C9C977,1,low,#e5f5e0,0.0,
-1654,110722,Barren,,110,72,Sedge/Herbaceuous,#C9C977,2,medium,#a1d99b,0.0,
-1655,110723,Barren,,110,72,Sedge/Herbaceuous,#C9C977,3,high,#31a354,1.0,
-1656,110730,Barren,,110,73,Lichens,#99C147,0,none,#ffffff,0.0,
-1657,110731,Barren,,110,73,Lichens,#99C147,1,low,#e5f5e0,0.0,
-1658,110732,Barren,,110,73,Lichens,#99C147,2,medium,#a1d99b,0.0,
-1659,110733,Barren,,110,73,Lichens,#99C147,3,high,#31a354,1.0,
-1660,110740,Barren,,110,74,Moss,#77AD93,0,none,#ffffff,0.0,
-1661,110741,Barren,,110,74,Moss,#77AD93,1,low,#e5f5e0,0.0,
-1662,110742,Barren,,110,74,Moss,#77AD93,2,medium,#a1d99b,0.0,
-1663,110743,Barren,,110,74,Moss,#77AD93,3,high,#31a354,1.0,
-1664,110810,Barren,,110,81,Pasture/Hay,#DBD83D,0,none,#ffffff,0.0,2230.0
-1665,110811,Barren,,110,81,Pasture/Hay,#DBD83D,1,low,#e5f5e0,0.0,2230.0
-1666,110812,Barren,,110,81,Pasture/Hay,#DBD83D,2,medium,#a1d99b,0.0,2230.0
-1667,110813,Barren,,110,81,Pasture/Hay,#DBD83D,3,high,#31a354,1.0,2230.0
-1668,110820,Barren,,110,82,Cultivated Crops,#AA7028,0,none,#ffffff,0.0,2230.0
-1669,110821,Barren,,110,82,Cultivated Crops,#AA7028,1,low,#e5f5e0,0.0,2230.0
-1670,110822,Barren,,110,82,Cultivated Crops,#AA7028,2,medium,#a1d99b,0.0,2230.0
-1671,110823,Barren,,110,82,Cultivated Crops,#AA7028,3,high,#31a354,1.0,2230.0
-1672,110900,Barren,,110,90,Woody Wetlands,#BAD8EA,0,none,#ffffff,1.0,2230.0
-1673,110901,Barren,,110,90,Woody Wetlands,#BAD8EA,1,low,#e5f5e0,1.0,2230.0
-1674,110902,Barren,,110,90,Woody Wetlands,#BAD8EA,2,medium,#a1d99b,1.0,2230.0
-1675,110903,Barren,,110,90,Woody Wetlands,#BAD8EA,3,high,#31a354,1.0,2230.0
-1676,110950,Barren,,110,95,Emergent Herbaceous Wetlands,#70A3BA,0,none,#ffffff,1.0,2230.0
-1677,110951,Barren,,110,95,Emergent Herbaceous Wetlands,#70A3BA,1,low,#e5f5e0,1.0,2230.0
-1678,110952,Barren,,110,95,Emergent Herbaceous Wetlands,#70A3BA,2,medium,#a1d99b,1.0,2230.0
-1679,110953,Barren,,110,95,Emergent Herbaceous Wetlands,#70A3BA,3,high,#31a354,1.0,2230.0
-1680,120110,Undifferentiated park,,120,11,Open Water,#476BA0,0,none,#ffffff,0.0,2230.0
-1681,120111,Undifferentiated park,,120,11,Open Water,#476BA0,1,low,#e5f5e0,0.0,2230.0
-1682,120112,Undifferentiated park,,120,11,Open Water,#476BA0,2,medium,#a1d99b,0.0,2230.0
-1683,120113,Undifferentiated park,,120,11,Open Water,#476BA0,3,high,#31a354,1.0,2230.0
-1684,120120,Undifferentiated park,,120,12,Perennial Ice/Snow,#D1DDF9,0,none,#ffffff,0.0,2230.0
-1685,120121,Undifferentiated park,,120,12,Perennial Ice/Snow,#D1DDF9,1,low,#e5f5e0,0.0,2230.0
-1686,120122,Undifferentiated park,,120,12,Perennial Ice/Snow,#D1DDF9,2,medium,#a1d99b,0.0,2230.0
-1687,120123,Undifferentiated park,,120,12,Perennial Ice/Snow,#D1DDF9,3,high,#31a354,1.0,2230.0
-1688,120210,Undifferentiated park,,120,21,"Developed, Open Space",#DDC9C9,0,none,#ffffff,0.0,2230.0
-1689,120211,Undifferentiated park,,120,21,"Developed, Open Space",#DDC9C9,1,low,#e5f5e0,0.0,2230.0
-1690,120212,Undifferentiated park,,120,21,"Developed, Open Space",#DDC9C9,2,medium,#a1d99b,0.0,2230.0
-1691,120213,Undifferentiated park,,120,21,"Developed, Open Space",#DDC9C9,3,high,#31a354,1.0,2230.0
-1692,120220,Undifferentiated park,,120,22,"Developed, Low Intensity",#D89382,0,none,#ffffff,0.0,2230.0
-1693,120221,Undifferentiated park,,120,22,"Developed, Low Intensity",#D89382,1,low,#e5f5e0,0.0,2230.0
-1694,120222,Undifferentiated park,,120,22,"Developed, Low Intensity",#D89382,2,medium,#a1d99b,0.0,2230.0
-1695,120223,Undifferentiated park,,120,22,"Developed, Low Intensity",#D89382,3,high,#31a354,1.0,2230.0
-1696,120230,Undifferentiated park,,120,23,"Developed, Medium Intensity",#ED0000,0,none,#ffffff,0.0,2230.0
-1697,120231,Undifferentiated park,,120,23,"Developed, Medium Intensity",#ED0000,1,low,#e5f5e0,0.0,2230.0
-1698,120232,Undifferentiated park,,120,23,"Developed, Medium Intensity",#ED0000,2,medium,#a1d99b,0.0,2230.0
-1699,120233,Undifferentiated park,,120,23,"Developed, Medium Intensity",#ED0000,3,high,#31a354,1.0,2230.0
-1700,120240,Undifferentiated park,,120,24,"Developed, High Intensity",#AA0000,0,none,#ffffff,0.0,2230.0
-1701,120241,Undifferentiated park,,120,24,"Developed, High Intensity",#AA0000,1,low,#e5f5e0,0.0,2230.0
-1702,120242,Undifferentiated park,,120,24,"Developed, High Intensity",#AA0000,2,medium,#a1d99b,0.0,2230.0
-1703,120243,Undifferentiated park,,120,24,"Developed, High Intensity",#AA0000,3,high,#31a354,1.0,2230.0
-1704,120310,Undifferentiated park,,120,31,Barren Land (Rock/Sand/Clay),#B2ADA3,0,none,#ffffff,0.0,2230.0
-1705,120311,Undifferentiated park,,120,31,Barren Land (Rock/Sand/Clay),#B2ADA3,1,low,#e5f5e0,0.0,2230.0
-1706,120312,Undifferentiated park,,120,31,Barren Land (Rock/Sand/Clay),#B2ADA3,2,medium,#a1d99b,0.0,2230.0
-1707,120313,Undifferentiated park,,120,31,Barren Land (Rock/Sand/Clay),#B2ADA3,3,high,#31a354,1.0,2230.0
-1708,120410,Undifferentiated park,,120,41,Deciduous Forest,#68AA63,0,none,#ffffff,1.0,2230.0
-1709,120411,Undifferentiated park,,120,41,Deciduous Forest,#68AA63,1,low,#e5f5e0,1.0,2230.0
-1710,120412,Undifferentiated park,,120,41,Deciduous Forest,#68AA63,2,medium,#a1d99b,1.0,2230.0
-1711,120413,Undifferentiated park,,120,41,Deciduous Forest,#68AA63,3,high,#31a354,1.0,2230.0
-1712,120420,Undifferentiated park,,120,42,Evergreen Forest,#1C6330,0,none,#ffffff,1.0,2230.0
-1713,120421,Undifferentiated park,,120,42,Evergreen Forest,#1C6330,1,low,#e5f5e0,1.0,2230.0
-1714,120422,Undifferentiated park,,120,42,Evergreen Forest,#1C6330,2,medium,#a1d99b,1.0,2230.0
-1715,120423,Undifferentiated park,,120,42,Evergreen Forest,#1C6330,3,high,#31a354,1.0,2230.0
-1716,120430,Undifferentiated park,,120,43,Mixed Forest,#B5C98E,0,none,#ffffff,1.0,2230.0
-1717,120431,Undifferentiated park,,120,43,Mixed Forest,#B5C98E,1,low,#e5f5e0,1.0,2230.0
-1718,120432,Undifferentiated park,,120,43,Mixed Forest,#B5C98E,2,medium,#a1d99b,1.0,2230.0
-1719,120433,Undifferentiated park,,120,43,Mixed Forest,#B5C98E,3,high,#31a354,1.0,2230.0
-1720,120510,Undifferentiated park,,120,51,Dwarf Scrub,#A58C30,0,none,#ffffff,0.0,
-1721,120511,Undifferentiated park,,120,51,Dwarf Scrub,#A58C30,1,low,#e5f5e0,0.0,
-1722,120512,Undifferentiated park,,120,51,Dwarf Scrub,#A58C30,2,medium,#a1d99b,0.0,
-1723,120513,Undifferentiated park,,120,51,Dwarf Scrub,#A58C30,3,high,#31a354,1.0,
-1724,120520,Undifferentiated park,,120,52,Scrub/Shrub,#CCBA7C,0,none,#ffffff,1.0,2230.0
-1725,120521,Undifferentiated park,,120,52,Scrub/Shrub,#CCBA7C,1,low,#e5f5e0,1.0,2230.0
-1726,120522,Undifferentiated park,,120,52,Scrub/Shrub,#CCBA7C,2,medium,#a1d99b,1.0,2230.0
-1727,120523,Undifferentiated park,,120,52,Scrub/Shrub,#CCBA7C,3,high,#31a354,1.0,2230.0
-1728,120710,Undifferentiated park,,120,71,Grassland/Herbaceous,#E2E2C1,0,none,#ffffff,1.0,2230.0
-1729,120711,Undifferentiated park,,120,71,Grassland/Herbaceous,#E2E2C1,1,low,#e5f5e0,1.0,2230.0
-1730,120712,Undifferentiated park,,120,71,Grassland/Herbaceous,#E2E2C1,2,medium,#a1d99b,1.0,2230.0
-1731,120713,Undifferentiated park,,120,71,Grassland/Herbaceous,#E2E2C1,3,high,#31a354,1.0,2230.0
-1732,120720,Undifferentiated park,,120,72,Sedge/Herbaceuous,#C9C977,0,none,#ffffff,0.0,
-1733,120721,Undifferentiated park,,120,72,Sedge/Herbaceuous,#C9C977,1,low,#e5f5e0,0.0,
-1734,120722,Undifferentiated park,,120,72,Sedge/Herbaceuous,#C9C977,2,medium,#a1d99b,0.0,
-1735,120723,Undifferentiated park,,120,72,Sedge/Herbaceuous,#C9C977,3,high,#31a354,1.0,
-1736,120730,Undifferentiated park,,120,73,Lichens,#99C147,0,none,#ffffff,0.0,
-1737,120731,Undifferentiated park,,120,73,Lichens,#99C147,1,low,#e5f5e0,0.0,
-1738,120732,Undifferentiated park,,120,73,Lichens,#99C147,2,medium,#a1d99b,0.0,
-1739,120733,Undifferentiated park,,120,73,Lichens,#99C147,3,high,#31a354,1.0,
-1740,120740,Undifferentiated park,,120,74,Moss,#77AD93,0,none,#ffffff,0.0,
-1741,120741,Undifferentiated park,,120,74,Moss,#77AD93,1,low,#e5f5e0,0.0,
-1742,120742,Undifferentiated park,,120,74,Moss,#77AD93,2,medium,#a1d99b,0.0,
-1743,120743,Undifferentiated park,,120,74,Moss,#77AD93,3,high,#31a354,1.0,
-1744,120810,Undifferentiated park,,120,81,Pasture/Hay,#DBD83D,0,none,#ffffff,0.0,2230.0
-1745,120811,Undifferentiated park,,120,81,Pasture/Hay,#DBD83D,1,low,#e5f5e0,0.0,2230.0
-1746,120812,Undifferentiated park,,120,81,Pasture/Hay,#DBD83D,2,medium,#a1d99b,0.0,2230.0
-1747,120813,Undifferentiated park,,120,81,Pasture/Hay,#DBD83D,3,high,#31a354,1.0,2230.0
-1748,120820,Undifferentiated park,,120,82,Cultivated Crops,#AA7028,0,none,#ffffff,0.0,2230.0
-1749,120821,Undifferentiated park,,120,82,Cultivated Crops,#AA7028,1,low,#e5f5e0,0.0,2230.0
-1750,120822,Undifferentiated park,,120,82,Cultivated Crops,#AA7028,2,medium,#a1d99b,0.0,2230.0
-1751,120823,Undifferentiated park,,120,82,Cultivated Crops,#AA7028,3,high,#31a354,1.0,2230.0
-1752,120900,Undifferentiated park,,120,90,Woody Wetlands,#BAD8EA,0,none,#ffffff,1.0,2230.0
-1753,120901,Undifferentiated park,,120,90,Woody Wetlands,#BAD8EA,1,low,#e5f5e0,1.0,2230.0
-1754,120902,Undifferentiated park,,120,90,Woody Wetlands,#BAD8EA,2,medium,#a1d99b,1.0,2230.0
-1755,120903,Undifferentiated park,,120,90,Woody Wetlands,#BAD8EA,3,high,#31a354,1.0,2230.0
-1756,120950,Undifferentiated park,,120,95,Emergent Herbaceous Wetlands,#70A3BA,0,none,#ffffff,1.0,2230.0
-1757,120951,Undifferentiated park,,120,95,Emergent Herbaceous Wetlands,#70A3BA,1,low,#e5f5e0,1.0,2230.0
-1758,120952,Undifferentiated park,,120,95,Emergent Herbaceous Wetlands,#70A3BA,2,medium,#a1d99b,1.0,2230.0
-1759,120953,Undifferentiated park,,120,95,Emergent Herbaceous Wetlands,#70A3BA,3,high,#31a354,1.0,2230.0
-1760,131110,Developed park,Urban park,131,11,Open Water,#476BA0,0,none,#ffffff,0.0,2230.0
-1761,131111,Developed park,Urban park,131,11,Open Water,#476BA0,1,low,#e5f5e0,0.0,2230.0
-1762,131112,Developed park,Urban park,131,11,Open Water,#476BA0,2,medium,#a1d99b,0.0,2230.0
-1763,131113,Developed park,Urban park,131,11,Open Water,#476BA0,3,high,#31a354,1.0,2230.0
-1764,131120,Developed park,Urban park,131,12,Perennial Ice/Snow,#D1DDF9,0,none,#ffffff,0.0,2230.0
-1765,131121,Developed park,Urban park,131,12,Perennial Ice/Snow,#D1DDF9,1,low,#e5f5e0,0.0,2230.0
-1766,131122,Developed park,Urban park,131,12,Perennial Ice/Snow,#D1DDF9,2,medium,#a1d99b,0.0,2230.0
-1767,131123,Developed park,Urban park,131,12,Perennial Ice/Snow,#D1DDF9,3,high,#31a354,1.0,2230.0
-1768,131210,Developed park,Urban park,131,21,"Developed, Open Space",#DDC9C9,0,none,#ffffff,0.0,2230.0
-1769,131211,Developed park,Urban park,131,21,"Developed, Open Space",#DDC9C9,1,low,#e5f5e0,0.0,2230.0
-1770,131212,Developed park,Urban park,131,21,"Developed, Open Space",#DDC9C9,2,medium,#a1d99b,0.0,2230.0
-1771,131213,Developed park,Urban park,131,21,"Developed, Open Space",#DDC9C9,3,high,#31a354,1.0,2230.0
-1772,131220,Developed park,Urban park,131,22,"Developed, Low Intensity",#D89382,0,none,#ffffff,0.0,2230.0
-1773,131221,Developed park,Urban park,131,22,"Developed, Low Intensity",#D89382,1,low,#e5f5e0,0.0,2230.0
-1774,131222,Developed park,Urban park,131,22,"Developed, Low Intensity",#D89382,2,medium,#a1d99b,0.0,2230.0
-1775,131223,Developed park,Urban park,131,22,"Developed, Low Intensity",#D89382,3,high,#31a354,1.0,2230.0
-1776,131230,Developed park,Urban park,131,23,"Developed, Medium Intensity",#ED0000,0,none,#ffffff,0.0,2230.0
-1777,131231,Developed park,Urban park,131,23,"Developed, Medium Intensity",#ED0000,1,low,#e5f5e0,0.0,2230.0
-1778,131232,Developed park,Urban park,131,23,"Developed, Medium Intensity",#ED0000,2,medium,#a1d99b,0.0,2230.0
-1779,131233,Developed park,Urban park,131,23,"Developed, Medium Intensity",#ED0000,3,high,#31a354,1.0,2230.0
-1780,131240,Developed park,Urban park,131,24,"Developed, High Intensity",#AA0000,0,none,#ffffff,0.0,2230.0
-1781,131241,Developed park,Urban park,131,24,"Developed, High Intensity",#AA0000,1,low,#e5f5e0,0.0,2230.0
-1782,131242,Developed park,Urban park,131,24,"Developed, High Intensity",#AA0000,2,medium,#a1d99b,0.0,2230.0
-1783,131243,Developed park,Urban park,131,24,"Developed, High Intensity",#AA0000,3,high,#31a354,1.0,2230.0
-1784,131310,Developed park,Urban park,131,31,Barren Land (Rock/Sand/Clay),#B2ADA3,0,none,#ffffff,0.0,2230.0
-1785,131311,Developed park,Urban park,131,31,Barren Land (Rock/Sand/Clay),#B2ADA3,1,low,#e5f5e0,0.0,2230.0
-1786,131312,Developed park,Urban park,131,31,Barren Land (Rock/Sand/Clay),#B2ADA3,2,medium,#a1d99b,0.0,2230.0
-1787,131313,Developed park,Urban park,131,31,Barren Land (Rock/Sand/Clay),#B2ADA3,3,high,#31a354,1.0,2230.0
-1788,131410,Developed park,Urban park,131,41,Deciduous Forest,#68AA63,0,none,#ffffff,1.0,2230.0
-1789,131411,Developed park,Urban park,131,41,Deciduous Forest,#68AA63,1,low,#e5f5e0,1.0,2230.0
-1790,131412,Developed park,Urban park,131,41,Deciduous Forest,#68AA63,2,medium,#a1d99b,1.0,2230.0
-1791,131413,Developed park,Urban park,131,41,Deciduous Forest,#68AA63,3,high,#31a354,1.0,2230.0
-1792,131420,Developed park,Urban park,131,42,Evergreen Forest,#1C6330,0,none,#ffffff,1.0,2230.0
-1793,131421,Developed park,Urban park,131,42,Evergreen Forest,#1C6330,1,low,#e5f5e0,1.0,2230.0
-1794,131422,Developed park,Urban park,131,42,Evergreen Forest,#1C6330,2,medium,#a1d99b,1.0,2230.0
-1795,131423,Developed park,Urban park,131,42,Evergreen Forest,#1C6330,3,high,#31a354,1.0,2230.0
-1796,131430,Developed park,Urban park,131,43,Mixed Forest,#B5C98E,0,none,#ffffff,1.0,2230.0
-1797,131431,Developed park,Urban park,131,43,Mixed Forest,#B5C98E,1,low,#e5f5e0,1.0,2230.0
-1798,131432,Developed park,Urban park,131,43,Mixed Forest,#B5C98E,2,medium,#a1d99b,1.0,2230.0
-1799,131433,Developed park,Urban park,131,43,Mixed Forest,#B5C98E,3,high,#31a354,1.0,2230.0
-1800,131510,Developed park,Urban park,131,51,Dwarf Scrub,#A58C30,0,none,#ffffff,0.0,
-1801,131511,Developed park,Urban park,131,51,Dwarf Scrub,#A58C30,1,low,#e5f5e0,0.0,
-1802,131512,Developed park,Urban park,131,51,Dwarf Scrub,#A58C30,2,medium,#a1d99b,0.0,
-1803,131513,Developed park,Urban park,131,51,Dwarf Scrub,#A58C30,3,high,#31a354,1.0,
-1804,131520,Developed park,Urban park,131,52,Scrub/Shrub,#CCBA7C,0,none,#ffffff,1.0,2230.0
-1805,131521,Developed park,Urban park,131,52,Scrub/Shrub,#CCBA7C,1,low,#e5f5e0,1.0,2230.0
-1806,131522,Developed park,Urban park,131,52,Scrub/Shrub,#CCBA7C,2,medium,#a1d99b,1.0,2230.0
-1807,131523,Developed park,Urban park,131,52,Scrub/Shrub,#CCBA7C,3,high,#31a354,1.0,2230.0
-1808,131710,Developed park,Urban park,131,71,Grassland/Herbaceous,#E2E2C1,0,none,#ffffff,1.0,2230.0
-1809,131711,Developed park,Urban park,131,71,Grassland/Herbaceous,#E2E2C1,1,low,#e5f5e0,1.0,2230.0
-1810,131712,Developed park,Urban park,131,71,Grassland/Herbaceous,#E2E2C1,2,medium,#a1d99b,1.0,2230.0
-1811,131713,Developed park,Urban park,131,71,Grassland/Herbaceous,#E2E2C1,3,high,#31a354,1.0,2230.0
-1812,131720,Developed park,Urban park,131,72,Sedge/Herbaceuous,#C9C977,0,none,#ffffff,0.0,
-1813,131721,Developed park,Urban park,131,72,Sedge/Herbaceuous,#C9C977,1,low,#e5f5e0,0.0,
-1814,131722,Developed park,Urban park,131,72,Sedge/Herbaceuous,#C9C977,2,medium,#a1d99b,0.0,
-1815,131723,Developed park,Urban park,131,72,Sedge/Herbaceuous,#C9C977,3,high,#31a354,1.0,
-1816,131730,Developed park,Urban park,131,73,Lichens,#99C147,0,none,#ffffff,0.0,
-1817,131731,Developed park,Urban park,131,73,Lichens,#99C147,1,low,#e5f5e0,0.0,
-1818,131732,Developed park,Urban park,131,73,Lichens,#99C147,2,medium,#a1d99b,0.0,
-1819,131733,Developed park,Urban park,131,73,Lichens,#99C147,3,high,#31a354,1.0,
-1820,131740,Developed park,Urban park,131,74,Moss,#77AD93,0,none,#ffffff,0.0,
-1821,131741,Developed park,Urban park,131,74,Moss,#77AD93,1,low,#e5f5e0,0.0,
-1822,131742,Developed park,Urban park,131,74,Moss,#77AD93,2,medium,#a1d99b,0.0,
-1823,131743,Developed park,Urban park,131,74,Moss,#77AD93,3,high,#31a354,1.0,
-1824,131810,Developed park,Urban park,131,81,Pasture/Hay,#DBD83D,0,none,#ffffff,0.0,2230.0
-1825,131811,Developed park,Urban park,131,81,Pasture/Hay,#DBD83D,1,low,#e5f5e0,0.0,2230.0
-1826,131812,Developed park,Urban park,131,81,Pasture/Hay,#DBD83D,2,medium,#a1d99b,0.0,2230.0
-1827,131813,Developed park,Urban park,131,81,Pasture/Hay,#DBD83D,3,high,#31a354,1.0,2230.0
-1828,131820,Developed park,Urban park,131,82,Cultivated Crops,#AA7028,0,none,#ffffff,0.0,2230.0
-1829,131821,Developed park,Urban park,131,82,Cultivated Crops,#AA7028,1,low,#e5f5e0,0.0,2230.0
-1830,131822,Developed park,Urban park,131,82,Cultivated Crops,#AA7028,2,medium,#a1d99b,0.0,2230.0
-1831,131823,Developed park,Urban park,131,82,Cultivated Crops,#AA7028,3,high,#31a354,1.0,2230.0
-1832,131900,Developed park,Urban park,131,90,Woody Wetlands,#BAD8EA,0,none,#ffffff,1.0,2230.0
-1833,131901,Developed park,Urban park,131,90,Woody Wetlands,#BAD8EA,1,low,#e5f5e0,1.0,2230.0
-1834,131902,Developed park,Urban park,131,90,Woody Wetlands,#BAD8EA,2,medium,#a1d99b,1.0,2230.0
-1835,131903,Developed park,Urban park,131,90,Woody Wetlands,#BAD8EA,3,high,#31a354,1.0,2230.0
-1836,131950,Developed park,Urban park,131,95,Emergent Herbaceous Wetlands,#70A3BA,0,none,#ffffff,1.0,2230.0
-1837,131951,Developed park,Urban park,131,95,Emergent Herbaceous Wetlands,#70A3BA,1,low,#e5f5e0,1.0,2230.0
-1838,131952,Developed park,Urban park,131,95,Emergent Herbaceous Wetlands,#70A3BA,2,medium,#a1d99b,1.0,2230.0
-1839,131953,Developed park,Urban park,131,95,Emergent Herbaceous Wetlands,#70A3BA,3,high,#31a354,1.0,2230.0
-1840,132110,Developed park,Golf course,132,11,Open Water,#476BA0,0,none,#ffffff,0.0,2230.0
-1841,132111,Developed park,Golf course,132,11,Open Water,#476BA0,1,low,#e5f5e0,0.0,2230.0
-1842,132112,Developed park,Golf course,132,11,Open Water,#476BA0,2,medium,#a1d99b,0.0,2230.0
-1843,132113,Developed park,Golf course,132,11,Open Water,#476BA0,3,high,#31a354,1.0,2230.0
-1844,132120,Developed park,Golf course,132,12,Perennial Ice/Snow,#D1DDF9,0,none,#ffffff,0.0,2230.0
-1845,132121,Developed park,Golf course,132,12,Perennial Ice/Snow,#D1DDF9,1,low,#e5f5e0,0.0,2230.0
-1846,132122,Developed park,Golf course,132,12,Perennial Ice/Snow,#D1DDF9,2,medium,#a1d99b,0.0,2230.0
-1847,132123,Developed park,Golf course,132,12,Perennial Ice/Snow,#D1DDF9,3,high,#31a354,1.0,2230.0
-1848,132210,Developed park,Golf course,132,21,"Developed, Open Space",#DDC9C9,0,none,#ffffff,0.0,2230.0
-1849,132211,Developed park,Golf course,132,21,"Developed, Open Space",#DDC9C9,1,low,#e5f5e0,0.0,2230.0
-1850,132212,Developed park,Golf course,132,21,"Developed, Open Space",#DDC9C9,2,medium,#a1d99b,0.0,2230.0
-1851,132213,Developed park,Golf course,132,21,"Developed, Open Space",#DDC9C9,3,high,#31a354,1.0,2230.0
-1852,132220,Developed park,Golf course,132,22,"Developed, Low Intensity",#D89382,0,none,#ffffff,0.0,2230.0
-1853,132221,Developed park,Golf course,132,22,"Developed, Low Intensity",#D89382,1,low,#e5f5e0,0.0,2230.0
-1854,132222,Developed park,Golf course,132,22,"Developed, Low Intensity",#D89382,2,medium,#a1d99b,0.0,2230.0
-1855,132223,Developed park,Golf course,132,22,"Developed, Low Intensity",#D89382,3,high,#31a354,1.0,2230.0
-1856,132230,Developed park,Golf course,132,23,"Developed, Medium Intensity",#ED0000,0,none,#ffffff,0.0,2230.0
-1857,132231,Developed park,Golf course,132,23,"Developed, Medium Intensity",#ED0000,1,low,#e5f5e0,0.0,2230.0
-1858,132232,Developed park,Golf course,132,23,"Developed, Medium Intensity",#ED0000,2,medium,#a1d99b,0.0,2230.0
-1859,132233,Developed park,Golf course,132,23,"Developed, Medium Intensity",#ED0000,3,high,#31a354,1.0,2230.0
-1860,132240,Developed park,Golf course,132,24,"Developed, High Intensity",#AA0000,0,none,#ffffff,0.0,2230.0
-1861,132241,Developed park,Golf course,132,24,"Developed, High Intensity",#AA0000,1,low,#e5f5e0,0.0,2230.0
-1862,132242,Developed park,Golf course,132,24,"Developed, High Intensity",#AA0000,2,medium,#a1d99b,0.0,2230.0
-1863,132243,Developed park,Golf course,132,24,"Developed, High Intensity",#AA0000,3,high,#31a354,1.0,2230.0
-1864,132310,Developed park,Golf course,132,31,Barren Land (Rock/Sand/Clay),#B2ADA3,0,none,#ffffff,0.0,2230.0
-1865,132311,Developed park,Golf course,132,31,Barren Land (Rock/Sand/Clay),#B2ADA3,1,low,#e5f5e0,0.0,2230.0
-1866,132312,Developed park,Golf course,132,31,Barren Land (Rock/Sand/Clay),#B2ADA3,2,medium,#a1d99b,0.0,2230.0
-1867,132313,Developed park,Golf course,132,31,Barren Land (Rock/Sand/Clay),#B2ADA3,3,high,#31a354,1.0,2230.0
-1868,132410,Developed park,Golf course,132,41,Deciduous Forest,#68AA63,0,none,#ffffff,1.0,2230.0
-1869,132411,Developed park,Golf course,132,41,Deciduous Forest,#68AA63,1,low,#e5f5e0,1.0,2230.0
-1870,132412,Developed park,Golf course,132,41,Deciduous Forest,#68AA63,2,medium,#a1d99b,1.0,2230.0
-1871,132413,Developed park,Golf course,132,41,Deciduous Forest,#68AA63,3,high,#31a354,1.0,2230.0
-1872,132420,Developed park,Golf course,132,42,Evergreen Forest,#1C6330,0,none,#ffffff,1.0,2230.0
-1873,132421,Developed park,Golf course,132,42,Evergreen Forest,#1C6330,1,low,#e5f5e0,1.0,2230.0
-1874,132422,Developed park,Golf course,132,42,Evergreen Forest,#1C6330,2,medium,#a1d99b,1.0,2230.0
-1875,132423,Developed park,Golf course,132,42,Evergreen Forest,#1C6330,3,high,#31a354,1.0,2230.0
-1876,132430,Developed park,Golf course,132,43,Mixed Forest,#B5C98E,0,none,#ffffff,1.0,2230.0
-1877,132431,Developed park,Golf course,132,43,Mixed Forest,#B5C98E,1,low,#e5f5e0,1.0,2230.0
-1878,132432,Developed park,Golf course,132,43,Mixed Forest,#B5C98E,2,medium,#a1d99b,1.0,2230.0
-1879,132433,Developed park,Golf course,132,43,Mixed Forest,#B5C98E,3,high,#31a354,1.0,2230.0
-1880,132510,Developed park,Golf course,132,51,Dwarf Scrub,#A58C30,0,none,#ffffff,0.0,
-1881,132511,Developed park,Golf course,132,51,Dwarf Scrub,#A58C30,1,low,#e5f5e0,0.0,
-1882,132512,Developed park,Golf course,132,51,Dwarf Scrub,#A58C30,2,medium,#a1d99b,0.0,
-1883,132513,Developed park,Golf course,132,51,Dwarf Scrub,#A58C30,3,high,#31a354,1.0,
-1884,132520,Developed park,Golf course,132,52,Scrub/Shrub,#CCBA7C,0,none,#ffffff,1.0,2230.0
-1885,132521,Developed park,Golf course,132,52,Scrub/Shrub,#CCBA7C,1,low,#e5f5e0,1.0,2230.0
-1886,132522,Developed park,Golf course,132,52,Scrub/Shrub,#CCBA7C,2,medium,#a1d99b,1.0,2230.0
-1887,132523,Developed park,Golf course,132,52,Scrub/Shrub,#CCBA7C,3,high,#31a354,1.0,2230.0
-1888,132710,Developed park,Golf course,132,71,Grassland/Herbaceous,#E2E2C1,0,none,#ffffff,1.0,2230.0
-1889,132711,Developed park,Golf course,132,71,Grassland/Herbaceous,#E2E2C1,1,low,#e5f5e0,1.0,2230.0
-1890,132712,Developed park,Golf course,132,71,Grassland/Herbaceous,#E2E2C1,2,medium,#a1d99b,1.0,2230.0
-1891,132713,Developed park,Golf course,132,71,Grassland/Herbaceous,#E2E2C1,3,high,#31a354,1.0,2230.0
-1892,132720,Developed park,Golf course,132,72,Sedge/Herbaceuous,#C9C977,0,none,#ffffff,0.0,
-1893,132721,Developed park,Golf course,132,72,Sedge/Herbaceuous,#C9C977,1,low,#e5f5e0,0.0,
-1894,132722,Developed park,Golf course,132,72,Sedge/Herbaceuous,#C9C977,2,medium,#a1d99b,0.0,
-1895,132723,Developed park,Golf course,132,72,Sedge/Herbaceuous,#C9C977,3,high,#31a354,1.0,
-1896,132730,Developed park,Golf course,132,73,Lichens,#99C147,0,none,#ffffff,0.0,
-1897,132731,Developed park,Golf course,132,73,Lichens,#99C147,1,low,#e5f5e0,0.0,
-1898,132732,Developed park,Golf course,132,73,Lichens,#99C147,2,medium,#a1d99b,0.0,
-1899,132733,Developed park,Golf course,132,73,Lichens,#99C147,3,high,#31a354,1.0,
-1900,132740,Developed park,Golf course,132,74,Moss,#77AD93,0,none,#ffffff,0.0,
-1901,132741,Developed park,Golf course,132,74,Moss,#77AD93,1,low,#e5f5e0,0.0,
-1902,132742,Developed park,Golf course,132,74,Moss,#77AD93,2,medium,#a1d99b,0.0,
-1903,132743,Developed park,Golf course,132,74,Moss,#77AD93,3,high,#31a354,1.0,
-1904,132810,Developed park,Golf course,132,81,Pasture/Hay,#DBD83D,0,none,#ffffff,0.0,2230.0
-1905,132811,Developed park,Golf course,132,81,Pasture/Hay,#DBD83D,1,low,#e5f5e0,0.0,2230.0
-1906,132812,Developed park,Golf course,132,81,Pasture/Hay,#DBD83D,2,medium,#a1d99b,0.0,2230.0
-1907,132813,Developed park,Golf course,132,81,Pasture/Hay,#DBD83D,3,high,#31a354,1.0,2230.0
-1908,132820,Developed park,Golf course,132,82,Cultivated Crops,#AA7028,0,none,#ffffff,0.0,2230.0
-1909,132821,Developed park,Golf course,132,82,Cultivated Crops,#AA7028,1,low,#e5f5e0,0.0,2230.0
-1910,132822,Developed park,Golf course,132,82,Cultivated Crops,#AA7028,2,medium,#a1d99b,0.0,2230.0
-1911,132823,Developed park,Golf course,132,82,Cultivated Crops,#AA7028,3,high,#31a354,1.0,2230.0
-1912,132900,Developed park,Golf course,132,90,Woody Wetlands,#BAD8EA,0,none,#ffffff,1.0,2230.0
-1913,132901,Developed park,Golf course,132,90,Woody Wetlands,#BAD8EA,1,low,#e5f5e0,1.0,2230.0
-1914,132902,Developed park,Golf course,132,90,Woody Wetlands,#BAD8EA,2,medium,#a1d99b,1.0,2230.0
-1915,132903,Developed park,Golf course,132,90,Woody Wetlands,#BAD8EA,3,high,#31a354,1.0,2230.0
-1916,132950,Developed park,Golf course,132,95,Emergent Herbaceous Wetlands,#70A3BA,0,none,#ffffff,1.0,2230.0
-1917,132951,Developed park,Golf course,132,95,Emergent Herbaceous Wetlands,#70A3BA,1,low,#e5f5e0,1.0,2230.0
-1918,132952,Developed park,Golf course,132,95,Emergent Herbaceous Wetlands,#70A3BA,2,medium,#a1d99b,1.0,2230.0
-1919,132953,Developed park,Golf course,132,95,Emergent Herbaceous Wetlands,#70A3BA,3,high,#31a354,1.0,2230.0
-1920,133110,Developed park,Resort/ski area,133,11,Open Water,#476BA0,0,none,#ffffff,0.0,2230.0
-1921,133111,Developed park,Resort/ski area,133,11,Open Water,#476BA0,1,low,#e5f5e0,0.0,2230.0
-1922,133112,Developed park,Resort/ski area,133,11,Open Water,#476BA0,2,medium,#a1d99b,0.0,2230.0
-1923,133113,Developed park,Resort/ski area,133,11,Open Water,#476BA0,3,high,#31a354,1.0,2230.0
-1924,133120,Developed park,Resort/ski area,133,12,Perennial Ice/Snow,#D1DDF9,0,none,#ffffff,0.0,2230.0
-1925,133121,Developed park,Resort/ski area,133,12,Perennial Ice/Snow,#D1DDF9,1,low,#e5f5e0,0.0,2230.0
-1926,133122,Developed park,Resort/ski area,133,12,Perennial Ice/Snow,#D1DDF9,2,medium,#a1d99b,0.0,2230.0
-1927,133123,Developed park,Resort/ski area,133,12,Perennial Ice/Snow,#D1DDF9,3,high,#31a354,1.0,2230.0
-1928,133210,Developed park,Resort/ski area,133,21,"Developed, Open Space",#DDC9C9,0,none,#ffffff,0.0,2230.0
-1929,133211,Developed park,Resort/ski area,133,21,"Developed, Open Space",#DDC9C9,1,low,#e5f5e0,0.0,2230.0
-1930,133212,Developed park,Resort/ski area,133,21,"Developed, Open Space",#DDC9C9,2,medium,#a1d99b,0.0,2230.0
-1931,133213,Developed park,Resort/ski area,133,21,"Developed, Open Space",#DDC9C9,3,high,#31a354,1.0,2230.0
-1932,133220,Developed park,Resort/ski area,133,22,"Developed, Low Intensity",#D89382,0,none,#ffffff,0.0,2230.0
-1933,133221,Developed park,Resort/ski area,133,22,"Developed, Low Intensity",#D89382,1,low,#e5f5e0,0.0,2230.0
-1934,133222,Developed park,Resort/ski area,133,22,"Developed, Low Intensity",#D89382,2,medium,#a1d99b,0.0,2230.0
-1935,133223,Developed park,Resort/ski area,133,22,"Developed, Low Intensity",#D89382,3,high,#31a354,1.0,2230.0
-1936,133230,Developed park,Resort/ski area,133,23,"Developed, Medium Intensity",#ED0000,0,none,#ffffff,0.0,2230.0
-1937,133231,Developed park,Resort/ski area,133,23,"Developed, Medium Intensity",#ED0000,1,low,#e5f5e0,0.0,2230.0
-1938,133232,Developed park,Resort/ski area,133,23,"Developed, Medium Intensity",#ED0000,2,medium,#a1d99b,0.0,2230.0
-1939,133233,Developed park,Resort/ski area,133,23,"Developed, Medium Intensity",#ED0000,3,high,#31a354,1.0,2230.0
-1940,133240,Developed park,Resort/ski area,133,24,"Developed, High Intensity",#AA0000,0,none,#ffffff,0.0,2230.0
-1941,133241,Developed park,Resort/ski area,133,24,"Developed, High Intensity",#AA0000,1,low,#e5f5e0,0.0,2230.0
-1942,133242,Developed park,Resort/ski area,133,24,"Developed, High Intensity",#AA0000,2,medium,#a1d99b,0.0,2230.0
-1943,133243,Developed park,Resort/ski area,133,24,"Developed, High Intensity",#AA0000,3,high,#31a354,1.0,2230.0
-1944,133310,Developed park,Resort/ski area,133,31,Barren Land (Rock/Sand/Clay),#B2ADA3,0,none,#ffffff,0.0,2230.0
-1945,133311,Developed park,Resort/ski area,133,31,Barren Land (Rock/Sand/Clay),#B2ADA3,1,low,#e5f5e0,0.0,2230.0
-1946,133312,Developed park,Resort/ski area,133,31,Barren Land (Rock/Sand/Clay),#B2ADA3,2,medium,#a1d99b,0.0,2230.0
-1947,133313,Developed park,Resort/ski area,133,31,Barren Land (Rock/Sand/Clay),#B2ADA3,3,high,#31a354,1.0,2230.0
-1948,133410,Developed park,Resort/ski area,133,41,Deciduous Forest,#68AA63,0,none,#ffffff,1.0,2230.0
-1949,133411,Developed park,Resort/ski area,133,41,Deciduous Forest,#68AA63,1,low,#e5f5e0,1.0,2230.0
-1950,133412,Developed park,Resort/ski area,133,41,Deciduous Forest,#68AA63,2,medium,#a1d99b,1.0,2230.0
-1951,133413,Developed park,Resort/ski area,133,41,Deciduous Forest,#68AA63,3,high,#31a354,1.0,2230.0
-1952,133420,Developed park,Resort/ski area,133,42,Evergreen Forest,#1C6330,0,none,#ffffff,1.0,2230.0
-1953,133421,Developed park,Resort/ski area,133,42,Evergreen Forest,#1C6330,1,low,#e5f5e0,1.0,2230.0
-1954,133422,Developed park,Resort/ski area,133,42,Evergreen Forest,#1C6330,2,medium,#a1d99b,1.0,2230.0
-1955,133423,Developed park,Resort/ski area,133,42,Evergreen Forest,#1C6330,3,high,#31a354,1.0,2230.0
-1956,133430,Developed park,Resort/ski area,133,43,Mixed Forest,#B5C98E,0,none,#ffffff,1.0,2230.0
-1957,133431,Developed park,Resort/ski area,133,43,Mixed Forest,#B5C98E,1,low,#e5f5e0,1.0,2230.0
-1958,133432,Developed park,Resort/ski area,133,43,Mixed Forest,#B5C98E,2,medium,#a1d99b,1.0,2230.0
-1959,133433,Developed park,Resort/ski area,133,43,Mixed Forest,#B5C98E,3,high,#31a354,1.0,2230.0
-1960,133510,Developed park,Resort/ski area,133,51,Dwarf Scrub,#A58C30,0,none,#ffffff,0.0,
-1961,133511,Developed park,Resort/ski area,133,51,Dwarf Scrub,#A58C30,1,low,#e5f5e0,0.0,
-1962,133512,Developed park,Resort/ski area,133,51,Dwarf Scrub,#A58C30,2,medium,#a1d99b,0.0,
-1963,133513,Developed park,Resort/ski area,133,51,Dwarf Scrub,#A58C30,3,high,#31a354,1.0,
-1964,133520,Developed park,Resort/ski area,133,52,Scrub/Shrub,#CCBA7C,0,none,#ffffff,1.0,2230.0
-1965,133521,Developed park,Resort/ski area,133,52,Scrub/Shrub,#CCBA7C,1,low,#e5f5e0,1.0,2230.0
-1966,133522,Developed park,Resort/ski area,133,52,Scrub/Shrub,#CCBA7C,2,medium,#a1d99b,1.0,2230.0
-1967,133523,Developed park,Resort/ski area,133,52,Scrub/Shrub,#CCBA7C,3,high,#31a354,1.0,2230.0
-1968,133710,Developed park,Resort/ski area,133,71,Grassland/Herbaceous,#E2E2C1,0,none,#ffffff,1.0,2230.0
-1969,133711,Developed park,Resort/ski area,133,71,Grassland/Herbaceous,#E2E2C1,1,low,#e5f5e0,1.0,2230.0
-1970,133712,Developed park,Resort/ski area,133,71,Grassland/Herbaceous,#E2E2C1,2,medium,#a1d99b,1.0,2230.0
-1971,133713,Developed park,Resort/ski area,133,71,Grassland/Herbaceous,#E2E2C1,3,high,#31a354,1.0,2230.0
-1972,133720,Developed park,Resort/ski area,133,72,Sedge/Herbaceuous,#C9C977,0,none,#ffffff,0.0,
-1973,133721,Developed park,Resort/ski area,133,72,Sedge/Herbaceuous,#C9C977,1,low,#e5f5e0,0.0,
-1974,133722,Developed park,Resort/ski area,133,72,Sedge/Herbaceuous,#C9C977,2,medium,#a1d99b,0.0,
-1975,133723,Developed park,Resort/ski area,133,72,Sedge/Herbaceuous,#C9C977,3,high,#31a354,1.0,
-1976,133730,Developed park,Resort/ski area,133,73,Lichens,#99C147,0,none,#ffffff,0.0,
-1977,133731,Developed park,Resort/ski area,133,73,Lichens,#99C147,1,low,#e5f5e0,0.0,
-1978,133732,Developed park,Resort/ski area,133,73,Lichens,#99C147,2,medium,#a1d99b,0.0,
-1979,133733,Developed park,Resort/ski area,133,73,Lichens,#99C147,3,high,#31a354,1.0,
-1980,133740,Developed park,Resort/ski area,133,74,Moss,#77AD93,0,none,#ffffff,0.0,
-1981,133741,Developed park,Resort/ski area,133,74,Moss,#77AD93,1,low,#e5f5e0,0.0,
-1982,133742,Developed park,Resort/ski area,133,74,Moss,#77AD93,2,medium,#a1d99b,0.0,
-1983,133743,Developed park,Resort/ski area,133,74,Moss,#77AD93,3,high,#31a354,1.0,
-1984,133810,Developed park,Resort/ski area,133,81,Pasture/Hay,#DBD83D,0,none,#ffffff,0.0,2230.0
-1985,133811,Developed park,Resort/ski area,133,81,Pasture/Hay,#DBD83D,1,low,#e5f5e0,0.0,2230.0
-1986,133812,Developed park,Resort/ski area,133,81,Pasture/Hay,#DBD83D,2,medium,#a1d99b,0.0,2230.0
-1987,133813,Developed park,Resort/ski area,133,81,Pasture/Hay,#DBD83D,3,high,#31a354,1.0,2230.0
-1988,133820,Developed park,Resort/ski area,133,82,Cultivated Crops,#AA7028,0,none,#ffffff,0.0,2230.0
-1989,133821,Developed park,Resort/ski area,133,82,Cultivated Crops,#AA7028,1,low,#e5f5e0,0.0,2230.0
-1990,133822,Developed park,Resort/ski area,133,82,Cultivated Crops,#AA7028,2,medium,#a1d99b,0.0,2230.0
-1991,133823,Developed park,Resort/ski area,133,82,Cultivated Crops,#AA7028,3,high,#31a354,1.0,2230.0
-1992,133900,Developed park,Resort/ski area,133,90,Woody Wetlands,#BAD8EA,0,none,#ffffff,1.0,2230.0
-1993,133901,Developed park,Resort/ski area,133,90,Woody Wetlands,#BAD8EA,1,low,#e5f5e0,1.0,2230.0
-1994,133902,Developed park,Resort/ski area,133,90,Woody Wetlands,#BAD8EA,2,medium,#a1d99b,1.0,2230.0
-1995,133903,Developed park,Resort/ski area,133,90,Woody Wetlands,#BAD8EA,3,high,#31a354,1.0,2230.0
-1996,133950,Developed park,Resort/ski area,133,95,Emergent Herbaceous Wetlands,#70A3BA,0,none,#ffffff,1.0,2230.0
-1997,133951,Developed park,Resort/ski area,133,95,Emergent Herbaceous Wetlands,#70A3BA,1,low,#e5f5e0,1.0,2230.0
-1998,133952,Developed park,Resort/ski area,133,95,Emergent Herbaceous Wetlands,#70A3BA,2,medium,#a1d99b,1.0,2230.0
-1999,133953,Developed park,Resort/ski area,133,95,Emergent Herbaceous Wetlands,#70A3BA,3,high,#31a354,1.0,2230.0
-2000,134110,Developed park,Other,134,11,Open Water,#476BA0,0,none,#ffffff,0.0,2230.0
-2001,134111,Developed park,Other,134,11,Open Water,#476BA0,1,low,#e5f5e0,0.0,2230.0
-2002,134112,Developed park,Other,134,11,Open Water,#476BA0,2,medium,#a1d99b,0.0,2230.0
-2003,134113,Developed park,Other,134,11,Open Water,#476BA0,3,high,#31a354,1.0,2230.0
-2004,134120,Developed park,Other,134,12,Perennial Ice/Snow,#D1DDF9,0,none,#ffffff,0.0,2230.0
-2005,134121,Developed park,Other,134,12,Perennial Ice/Snow,#D1DDF9,1,low,#e5f5e0,0.0,2230.0
-2006,134122,Developed park,Other,134,12,Perennial Ice/Snow,#D1DDF9,2,medium,#a1d99b,0.0,2230.0
-2007,134123,Developed park,Other,134,12,Perennial Ice/Snow,#D1DDF9,3,high,#31a354,1.0,2230.0
-2008,134210,Developed park,Other,134,21,"Developed, Open Space",#DDC9C9,0,none,#ffffff,0.0,2230.0
-2009,134211,Developed park,Other,134,21,"Developed, Open Space",#DDC9C9,1,low,#e5f5e0,0.0,2230.0
-2010,134212,Developed park,Other,134,21,"Developed, Open Space",#DDC9C9,2,medium,#a1d99b,0.0,2230.0
-2011,134213,Developed park,Other,134,21,"Developed, Open Space",#DDC9C9,3,high,#31a354,1.0,2230.0
-2012,134220,Developed park,Other,134,22,"Developed, Low Intensity",#D89382,0,none,#ffffff,0.0,2230.0
-2013,134221,Developed park,Other,134,22,"Developed, Low Intensity",#D89382,1,low,#e5f5e0,0.0,2230.0
-2014,134222,Developed park,Other,134,22,"Developed, Low Intensity",#D89382,2,medium,#a1d99b,0.0,2230.0
-2015,134223,Developed park,Other,134,22,"Developed, Low Intensity",#D89382,3,high,#31a354,1.0,2230.0
-2016,134230,Developed park,Other,134,23,"Developed, Medium Intensity",#ED0000,0,none,#ffffff,0.0,2230.0
-2017,134231,Developed park,Other,134,23,"Developed, Medium Intensity",#ED0000,1,low,#e5f5e0,0.0,2230.0
-2018,134232,Developed park,Other,134,23,"Developed, Medium Intensity",#ED0000,2,medium,#a1d99b,0.0,2230.0
-2019,134233,Developed park,Other,134,23,"Developed, Medium Intensity",#ED0000,3,high,#31a354,1.0,2230.0
-2020,134240,Developed park,Other,134,24,"Developed, High Intensity",#AA0000,0,none,#ffffff,0.0,2230.0
-2021,134241,Developed park,Other,134,24,"Developed, High Intensity",#AA0000,1,low,#e5f5e0,0.0,2230.0
-2022,134242,Developed park,Other,134,24,"Developed, High Intensity",#AA0000,2,medium,#a1d99b,0.0,2230.0
-2023,134243,Developed park,Other,134,24,"Developed, High Intensity",#AA0000,3,high,#31a354,1.0,2230.0
-2024,134310,Developed park,Other,134,31,Barren Land (Rock/Sand/Clay),#B2ADA3,0,none,#ffffff,0.0,2230.0
-2025,134311,Developed park,Other,134,31,Barren Land (Rock/Sand/Clay),#B2ADA3,1,low,#e5f5e0,0.0,2230.0
-2026,134312,Developed park,Other,134,31,Barren Land (Rock/Sand/Clay),#B2ADA3,2,medium,#a1d99b,0.0,2230.0
-2027,134313,Developed park,Other,134,31,Barren Land (Rock/Sand/Clay),#B2ADA3,3,high,#31a354,1.0,2230.0
-2028,134410,Developed park,Other,134,41,Deciduous Forest,#68AA63,0,none,#ffffff,1.0,2230.0
-2029,134411,Developed park,Other,134,41,Deciduous Forest,#68AA63,1,low,#e5f5e0,1.0,2230.0
-2030,134412,Developed park,Other,134,41,Deciduous Forest,#68AA63,2,medium,#a1d99b,1.0,2230.0
-2031,134413,Developed park,Other,134,41,Deciduous Forest,#68AA63,3,high,#31a354,1.0,2230.0
-2032,134420,Developed park,Other,134,42,Evergreen Forest,#1C6330,0,none,#ffffff,1.0,2230.0
-2033,134421,Developed park,Other,134,42,Evergreen Forest,#1C6330,1,low,#e5f5e0,1.0,2230.0
-2034,134422,Developed park,Other,134,42,Evergreen Forest,#1C6330,2,medium,#a1d99b,1.0,2230.0
-2035,134423,Developed park,Other,134,42,Evergreen Forest,#1C6330,3,high,#31a354,1.0,2230.0
-2036,134430,Developed park,Other,134,43,Mixed Forest,#B5C98E,0,none,#ffffff,1.0,2230.0
-2037,134431,Developed park,Other,134,43,Mixed Forest,#B5C98E,1,low,#e5f5e0,1.0,2230.0
-2038,134432,Developed park,Other,134,43,Mixed Forest,#B5C98E,2,medium,#a1d99b,1.0,2230.0
-2039,134433,Developed park,Other,134,43,Mixed Forest,#B5C98E,3,high,#31a354,1.0,2230.0
-2040,134510,Developed park,Other,134,51,Dwarf Scrub,#A58C30,0,none,#ffffff,0.0,
-2041,134511,Developed park,Other,134,51,Dwarf Scrub,#A58C30,1,low,#e5f5e0,0.0,
-2042,134512,Developed park,Other,134,51,Dwarf Scrub,#A58C30,2,medium,#a1d99b,0.0,
-2043,134513,Developed park,Other,134,51,Dwarf Scrub,#A58C30,3,high,#31a354,1.0,
-2044,134520,Developed park,Other,134,52,Scrub/Shrub,#CCBA7C,0,none,#ffffff,1.0,2230.0
-2045,134521,Developed park,Other,134,52,Scrub/Shrub,#CCBA7C,1,low,#e5f5e0,1.0,2230.0
-2046,134522,Developed park,Other,134,52,Scrub/Shrub,#CCBA7C,2,medium,#a1d99b,1.0,2230.0
-2047,134523,Developed park,Other,134,52,Scrub/Shrub,#CCBA7C,3,high,#31a354,1.0,2230.0
-2048,134710,Developed park,Other,134,71,Grassland/Herbaceous,#E2E2C1,0,none,#ffffff,1.0,2230.0
-2049,134711,Developed park,Other,134,71,Grassland/Herbaceous,#E2E2C1,1,low,#e5f5e0,1.0,2230.0
-2050,134712,Developed park,Other,134,71,Grassland/Herbaceous,#E2E2C1,2,medium,#a1d99b,1.0,2230.0
-2051,134713,Developed park,Other,134,71,Grassland/Herbaceous,#E2E2C1,3,high,#31a354,1.0,2230.0
-2052,134720,Developed park,Other,134,72,Sedge/Herbaceuous,#C9C977,0,none,#ffffff,0.0,
-2053,134721,Developed park,Other,134,72,Sedge/Herbaceuous,#C9C977,1,low,#e5f5e0,0.0,
-2054,134722,Developed park,Other,134,72,Sedge/Herbaceuous,#C9C977,2,medium,#a1d99b,0.0,
-2055,134723,Developed park,Other,134,72,Sedge/Herbaceuous,#C9C977,3,high,#31a354,1.0,
-2056,134730,Developed park,Other,134,73,Lichens,#99C147,0,none,#ffffff,0.0,
-2057,134731,Developed park,Other,134,73,Lichens,#99C147,1,low,#e5f5e0,0.0,
-2058,134732,Developed park,Other,134,73,Lichens,#99C147,2,medium,#a1d99b,0.0,
-2059,134733,Developed park,Other,134,73,Lichens,#99C147,3,high,#31a354,1.0,
-2060,134740,Developed park,Other,134,74,Moss,#77AD93,0,none,#ffffff,0.0,
-2061,134741,Developed park,Other,134,74,Moss,#77AD93,1,low,#e5f5e0,0.0,
-2062,134742,Developed park,Other,134,74,Moss,#77AD93,2,medium,#a1d99b,0.0,
-2063,134743,Developed park,Other,134,74,Moss,#77AD93,3,high,#31a354,1.0,
-2064,134810,Developed park,Other,134,81,Pasture/Hay,#DBD83D,0,none,#ffffff,0.0,2230.0
-2065,134811,Developed park,Other,134,81,Pasture/Hay,#DBD83D,1,low,#e5f5e0,0.0,2230.0
-2066,134812,Developed park,Other,134,81,Pasture/Hay,#DBD83D,2,medium,#a1d99b,0.0,2230.0
-2067,134813,Developed park,Other,134,81,Pasture/Hay,#DBD83D,3,high,#31a354,1.0,2230.0
-2068,134820,Developed park,Other,134,82,Cultivated Crops,#AA7028,0,none,#ffffff,0.0,2230.0
-2069,134821,Developed park,Other,134,82,Cultivated Crops,#AA7028,1,low,#e5f5e0,0.0,2230.0
-2070,134822,Developed park,Other,134,82,Cultivated Crops,#AA7028,2,medium,#a1d99b,0.0,2230.0
-2071,134823,Developed park,Other,134,82,Cultivated Crops,#AA7028,3,high,#31a354,1.0,2230.0
-2072,134900,Developed park,Other,134,90,Woody Wetlands,#BAD8EA,0,none,#ffffff,1.0,2230.0
-2073,134901,Developed park,Other,134,90,Woody Wetlands,#BAD8EA,1,low,#e5f5e0,1.0,2230.0
-2074,134902,Developed park,Other,134,90,Woody Wetlands,#BAD8EA,2,medium,#a1d99b,1.0,2230.0
-2075,134903,Developed park,Other,134,90,Woody Wetlands,#BAD8EA,3,high,#31a354,1.0,2230.0
-2076,134950,Developed park,Other,134,95,Emergent Herbaceous Wetlands,#70A3BA,0,none,#ffffff,1.0,2230.0
-2077,134951,Developed park,Other,134,95,Emergent Herbaceous Wetlands,#70A3BA,1,low,#e5f5e0,1.0,2230.0
-2078,134952,Developed park,Other,134,95,Emergent Herbaceous Wetlands,#70A3BA,2,medium,#a1d99b,1.0,2230.0
-2079,134953,Developed park,Other,134,95,Emergent Herbaceous Wetlands,#70A3BA,3,high,#31a354,1.0,2230.0
-2080,140110,Natural park,,140,11,Open Water,#476BA0,0,none,#ffffff,0.0,2230.0
-2081,140111,Natural park,,140,11,Open Water,#476BA0,1,low,#e5f5e0,0.0,2230.0
-2082,140112,Natural park,,140,11,Open Water,#476BA0,2,medium,#a1d99b,0.0,2230.0
-2083,140113,Natural park,,140,11,Open Water,#476BA0,3,high,#31a354,1.0,2230.0
-2084,140120,Natural park,,140,12,Perennial Ice/Snow,#D1DDF9,0,none,#ffffff,0.0,2230.0
-2085,140121,Natural park,,140,12,Perennial Ice/Snow,#D1DDF9,1,low,#e5f5e0,0.0,2230.0
-2086,140122,Natural park,,140,12,Perennial Ice/Snow,#D1DDF9,2,medium,#a1d99b,0.0,2230.0
-2087,140123,Natural park,,140,12,Perennial Ice/Snow,#D1DDF9,3,high,#31a354,1.0,2230.0
-2088,140210,Natural park,,140,21,"Developed, Open Space",#DDC9C9,0,none,#ffffff,0.0,2230.0
-2089,140211,Natural park,,140,21,"Developed, Open Space",#DDC9C9,1,low,#e5f5e0,0.0,2230.0
-2090,140212,Natural park,,140,21,"Developed, Open Space",#DDC9C9,2,medium,#a1d99b,0.0,2230.0
-2091,140213,Natural park,,140,21,"Developed, Open Space",#DDC9C9,3,high,#31a354,1.0,2230.0
-2092,140220,Natural park,,140,22,"Developed, Low Intensity",#D89382,0,none,#ffffff,0.0,2230.0
-2093,140221,Natural park,,140,22,"Developed, Low Intensity",#D89382,1,low,#e5f5e0,0.0,2230.0
-2094,140222,Natural park,,140,22,"Developed, Low Intensity",#D89382,2,medium,#a1d99b,0.0,2230.0
-2095,140223,Natural park,,140,22,"Developed, Low Intensity",#D89382,3,high,#31a354,1.0,2230.0
-2096,140230,Natural park,,140,23,"Developed, Medium Intensity",#ED0000,0,none,#ffffff,0.0,2230.0
-2097,140231,Natural park,,140,23,"Developed, Medium Intensity",#ED0000,1,low,#e5f5e0,0.0,2230.0
-2098,140232,Natural park,,140,23,"Developed, Medium Intensity",#ED0000,2,medium,#a1d99b,0.0,2230.0
-2099,140233,Natural park,,140,23,"Developed, Medium Intensity",#ED0000,3,high,#31a354,1.0,2230.0
-2100,140240,Natural park,,140,24,"Developed, High Intensity",#AA0000,0,none,#ffffff,0.0,2230.0
-2101,140241,Natural park,,140,24,"Developed, High Intensity",#AA0000,1,low,#e5f5e0,0.0,2230.0
-2102,140242,Natural park,,140,24,"Developed, High Intensity",#AA0000,2,medium,#a1d99b,0.0,2230.0
-2103,140243,Natural park,,140,24,"Developed, High Intensity",#AA0000,3,high,#31a354,1.0,2230.0
-2104,140310,Natural park,,140,31,Barren Land (Rock/Sand/Clay),#B2ADA3,0,none,#ffffff,0.0,2230.0
-2105,140311,Natural park,,140,31,Barren Land (Rock/Sand/Clay),#B2ADA3,1,low,#e5f5e0,0.0,2230.0
-2106,140312,Natural park,,140,31,Barren Land (Rock/Sand/Clay),#B2ADA3,2,medium,#a1d99b,0.0,2230.0
-2107,140313,Natural park,,140,31,Barren Land (Rock/Sand/Clay),#B2ADA3,3,high,#31a354,1.0,2230.0
-2108,140410,Natural park,,140,41,Deciduous Forest,#68AA63,0,none,#ffffff,1.0,2230.0
-2109,140411,Natural park,,140,41,Deciduous Forest,#68AA63,1,low,#e5f5e0,1.0,2230.0
-2110,140412,Natural park,,140,41,Deciduous Forest,#68AA63,2,medium,#a1d99b,1.0,2230.0
-2111,140413,Natural park,,140,41,Deciduous Forest,#68AA63,3,high,#31a354,1.0,2230.0
-2112,140420,Natural park,,140,42,Evergreen Forest,#1C6330,0,none,#ffffff,1.0,2230.0
-2113,140421,Natural park,,140,42,Evergreen Forest,#1C6330,1,low,#e5f5e0,1.0,2230.0
-2114,140422,Natural park,,140,42,Evergreen Forest,#1C6330,2,medium,#a1d99b,1.0,2230.0
-2115,140423,Natural park,,140,42,Evergreen Forest,#1C6330,3,high,#31a354,1.0,2230.0
-2116,140430,Natural park,,140,43,Mixed Forest,#B5C98E,0,none,#ffffff,1.0,2230.0
-2117,140431,Natural park,,140,43,Mixed Forest,#B5C98E,1,low,#e5f5e0,1.0,2230.0
-2118,140432,Natural park,,140,43,Mixed Forest,#B5C98E,2,medium,#a1d99b,1.0,2230.0
-2119,140433,Natural park,,140,43,Mixed Forest,#B5C98E,3,high,#31a354,1.0,2230.0
-2120,140510,Natural park,,140,51,Dwarf Scrub,#A58C30,0,none,#ffffff,0.0,
-2121,140511,Natural park,,140,51,Dwarf Scrub,#A58C30,1,low,#e5f5e0,0.0,
-2122,140512,Natural park,,140,51,Dwarf Scrub,#A58C30,2,medium,#a1d99b,0.0,
-2123,140513,Natural park,,140,51,Dwarf Scrub,#A58C30,3,high,#31a354,1.0,
-2124,140520,Natural park,,140,52,Scrub/Shrub,#CCBA7C,0,none,#ffffff,1.0,2230.0
-2125,140521,Natural park,,140,52,Scrub/Shrub,#CCBA7C,1,low,#e5f5e0,1.0,2230.0
-2126,140522,Natural park,,140,52,Scrub/Shrub,#CCBA7C,2,medium,#a1d99b,1.0,2230.0
-2127,140523,Natural park,,140,52,Scrub/Shrub,#CCBA7C,3,high,#31a354,1.0,2230.0
-2128,140710,Natural park,,140,71,Grassland/Herbaceous,#E2E2C1,0,none,#ffffff,1.0,2230.0
-2129,140711,Natural park,,140,71,Grassland/Herbaceous,#E2E2C1,1,low,#e5f5e0,1.0,2230.0
-2130,140712,Natural park,,140,71,Grassland/Herbaceous,#E2E2C1,2,medium,#a1d99b,1.0,2230.0
-2131,140713,Natural park,,140,71,Grassland/Herbaceous,#E2E2C1,3,high,#31a354,1.0,2230.0
-2132,140720,Natural park,,140,72,Sedge/Herbaceuous,#C9C977,0,none,#ffffff,0.0,
-2133,140721,Natural park,,140,72,Sedge/Herbaceuous,#C9C977,1,low,#e5f5e0,0.0,
-2134,140722,Natural park,,140,72,Sedge/Herbaceuous,#C9C977,2,medium,#a1d99b,0.0,
-2135,140723,Natural park,,140,72,Sedge/Herbaceuous,#C9C977,3,high,#31a354,1.0,
-2136,140730,Natural park,,140,73,Lichens,#99C147,0,none,#ffffff,0.0,
-2137,140731,Natural park,,140,73,Lichens,#99C147,1,low,#e5f5e0,0.0,
-2138,140732,Natural park,,140,73,Lichens,#99C147,2,medium,#a1d99b,0.0,
-2139,140733,Natural park,,140,73,Lichens,#99C147,3,high,#31a354,1.0,
-2140,140740,Natural park,,140,74,Moss,#77AD93,0,none,#ffffff,0.0,
-2141,140741,Natural park,,140,74,Moss,#77AD93,1,low,#e5f5e0,0.0,
-2142,140742,Natural park,,140,74,Moss,#77AD93,2,medium,#a1d99b,0.0,
-2143,140743,Natural park,,140,74,Moss,#77AD93,3,high,#31a354,1.0,
-2144,140810,Natural park,,140,81,Pasture/Hay,#DBD83D,0,none,#ffffff,0.0,2230.0
-2145,140811,Natural park,,140,81,Pasture/Hay,#DBD83D,1,low,#e5f5e0,0.0,2230.0
-2146,140812,Natural park,,140,81,Pasture/Hay,#DBD83D,2,medium,#a1d99b,0.0,2230.0
-2147,140813,Natural park,,140,81,Pasture/Hay,#DBD83D,3,high,#31a354,1.0,2230.0
-2148,140820,Natural park,,140,82,Cultivated Crops,#AA7028,0,none,#ffffff,0.0,2230.0
-2149,140821,Natural park,,140,82,Cultivated Crops,#AA7028,1,low,#e5f5e0,0.0,2230.0
-2150,140822,Natural park,,140,82,Cultivated Crops,#AA7028,2,medium,#a1d99b,0.0,2230.0
-2151,140823,Natural park,,140,82,Cultivated Crops,#AA7028,3,high,#31a354,1.0,2230.0
-2152,140900,Natural park,,140,90,Woody Wetlands,#BAD8EA,0,none,#ffffff,1.0,2230.0
-2153,140901,Natural park,,140,90,Woody Wetlands,#BAD8EA,1,low,#e5f5e0,1.0,2230.0
-2154,140902,Natural park,,140,90,Woody Wetlands,#BAD8EA,2,medium,#a1d99b,1.0,2230.0
-2155,140903,Natural park,,140,90,Woody Wetlands,#BAD8EA,3,high,#31a354,1.0,2230.0
-2156,140950,Natural park,,140,95,Emergent Herbaceous Wetlands,#70A3BA,0,none,#ffffff,1.0,2230.0
-2157,140951,Natural park,,140,95,Emergent Herbaceous Wetlands,#70A3BA,1,low,#e5f5e0,1.0,2230.0
-2158,140952,Natural park,,140,95,Emergent Herbaceous Wetlands,#70A3BA,2,medium,#a1d99b,1.0,2230.0
-2159,140953,Natural park,,140,95,Emergent Herbaceous Wetlands,#70A3BA,3,high,#31a354,1.0,2230.0
-2160,151110,Conservation,Public,151,11,Open Water,#476BA0,0,none,#ffffff,0.0,2230.0
-2161,151111,Conservation,Public,151,11,Open Water,#476BA0,1,low,#e5f5e0,0.0,2230.0
-2162,151112,Conservation,Public,151,11,Open Water,#476BA0,2,medium,#a1d99b,0.0,2230.0
-2163,151113,Conservation,Public,151,11,Open Water,#476BA0,3,high,#31a354,1.0,2230.0
-2164,151120,Conservation,Public,151,12,Perennial Ice/Snow,#D1DDF9,0,none,#ffffff,0.0,2230.0
-2165,151121,Conservation,Public,151,12,Perennial Ice/Snow,#D1DDF9,1,low,#e5f5e0,0.0,2230.0
-2166,151122,Conservation,Public,151,12,Perennial Ice/Snow,#D1DDF9,2,medium,#a1d99b,0.0,2230.0
-2167,151123,Conservation,Public,151,12,Perennial Ice/Snow,#D1DDF9,3,high,#31a354,1.0,2230.0
-2168,151210,Conservation,Public,151,21,"Developed, Open Space",#DDC9C9,0,none,#ffffff,0.0,2230.0
-2169,151211,Conservation,Public,151,21,"Developed, Open Space",#DDC9C9,1,low,#e5f5e0,0.0,2230.0
-2170,151212,Conservation,Public,151,21,"Developed, Open Space",#DDC9C9,2,medium,#a1d99b,0.0,2230.0
-2171,151213,Conservation,Public,151,21,"Developed, Open Space",#DDC9C9,3,high,#31a354,1.0,2230.0
-2172,151220,Conservation,Public,151,22,"Developed, Low Intensity",#D89382,0,none,#ffffff,0.0,2230.0
-2173,151221,Conservation,Public,151,22,"Developed, Low Intensity",#D89382,1,low,#e5f5e0,0.0,2230.0
-2174,151222,Conservation,Public,151,22,"Developed, Low Intensity",#D89382,2,medium,#a1d99b,0.0,2230.0
-2175,151223,Conservation,Public,151,22,"Developed, Low Intensity",#D89382,3,high,#31a354,1.0,2230.0
-2176,151230,Conservation,Public,151,23,"Developed, Medium Intensity",#ED0000,0,none,#ffffff,0.0,2230.0
-2177,151231,Conservation,Public,151,23,"Developed, Medium Intensity",#ED0000,1,low,#e5f5e0,0.0,2230.0
-2178,151232,Conservation,Public,151,23,"Developed, Medium Intensity",#ED0000,2,medium,#a1d99b,0.0,2230.0
-2179,151233,Conservation,Public,151,23,"Developed, Medium Intensity",#ED0000,3,high,#31a354,1.0,2230.0
-2180,151240,Conservation,Public,151,24,"Developed, High Intensity",#AA0000,0,none,#ffffff,0.0,2230.0
-2181,151241,Conservation,Public,151,24,"Developed, High Intensity",#AA0000,1,low,#e5f5e0,0.0,2230.0
-2182,151242,Conservation,Public,151,24,"Developed, High Intensity",#AA0000,2,medium,#a1d99b,0.0,2230.0
-2183,151243,Conservation,Public,151,24,"Developed, High Intensity",#AA0000,3,high,#31a354,1.0,2230.0
-2184,151310,Conservation,Public,151,31,Barren Land (Rock/Sand/Clay),#B2ADA3,0,none,#ffffff,0.0,2230.0
-2185,151311,Conservation,Public,151,31,Barren Land (Rock/Sand/Clay),#B2ADA3,1,low,#e5f5e0,0.0,2230.0
-2186,151312,Conservation,Public,151,31,Barren Land (Rock/Sand/Clay),#B2ADA3,2,medium,#a1d99b,0.0,2230.0
-2187,151313,Conservation,Public,151,31,Barren Land (Rock/Sand/Clay),#B2ADA3,3,high,#31a354,1.0,2230.0
-2188,151410,Conservation,Public,151,41,Deciduous Forest,#68AA63,0,none,#ffffff,1.0,2230.0
-2189,151411,Conservation,Public,151,41,Deciduous Forest,#68AA63,1,low,#e5f5e0,1.0,2230.0
-2190,151412,Conservation,Public,151,41,Deciduous Forest,#68AA63,2,medium,#a1d99b,1.0,2230.0
-2191,151413,Conservation,Public,151,41,Deciduous Forest,#68AA63,3,high,#31a354,1.0,2230.0
-2192,151420,Conservation,Public,151,42,Evergreen Forest,#1C6330,0,none,#ffffff,1.0,2230.0
-2193,151421,Conservation,Public,151,42,Evergreen Forest,#1C6330,1,low,#e5f5e0,1.0,2230.0
-2194,151422,Conservation,Public,151,42,Evergreen Forest,#1C6330,2,medium,#a1d99b,1.0,2230.0
-2195,151423,Conservation,Public,151,42,Evergreen Forest,#1C6330,3,high,#31a354,1.0,2230.0
-2196,151430,Conservation,Public,151,43,Mixed Forest,#B5C98E,0,none,#ffffff,1.0,2230.0
-2197,151431,Conservation,Public,151,43,Mixed Forest,#B5C98E,1,low,#e5f5e0,1.0,2230.0
-2198,151432,Conservation,Public,151,43,Mixed Forest,#B5C98E,2,medium,#a1d99b,1.0,2230.0
-2199,151433,Conservation,Public,151,43,Mixed Forest,#B5C98E,3,high,#31a354,1.0,2230.0
-2200,151510,Conservation,Public,151,51,Dwarf Scrub,#A58C30,0,none,#ffffff,0.0,
-2201,151511,Conservation,Public,151,51,Dwarf Scrub,#A58C30,1,low,#e5f5e0,0.0,
-2202,151512,Conservation,Public,151,51,Dwarf Scrub,#A58C30,2,medium,#a1d99b,0.0,
-2203,151513,Conservation,Public,151,51,Dwarf Scrub,#A58C30,3,high,#31a354,1.0,
-2204,151520,Conservation,Public,151,52,Scrub/Shrub,#CCBA7C,0,none,#ffffff,1.0,2230.0
-2205,151521,Conservation,Public,151,52,Scrub/Shrub,#CCBA7C,1,low,#e5f5e0,1.0,2230.0
-2206,151522,Conservation,Public,151,52,Scrub/Shrub,#CCBA7C,2,medium,#a1d99b,1.0,2230.0
-2207,151523,Conservation,Public,151,52,Scrub/Shrub,#CCBA7C,3,high,#31a354,1.0,2230.0
-2208,151710,Conservation,Public,151,71,Grassland/Herbaceous,#E2E2C1,0,none,#ffffff,1.0,2230.0
-2209,151711,Conservation,Public,151,71,Grassland/Herbaceous,#E2E2C1,1,low,#e5f5e0,1.0,2230.0
-2210,151712,Conservation,Public,151,71,Grassland/Herbaceous,#E2E2C1,2,medium,#a1d99b,1.0,2230.0
-2211,151713,Conservation,Public,151,71,Grassland/Herbaceous,#E2E2C1,3,high,#31a354,1.0,2230.0
-2212,151720,Conservation,Public,151,72,Sedge/Herbaceuous,#C9C977,0,none,#ffffff,0.0,
-2213,151721,Conservation,Public,151,72,Sedge/Herbaceuous,#C9C977,1,low,#e5f5e0,0.0,
-2214,151722,Conservation,Public,151,72,Sedge/Herbaceuous,#C9C977,2,medium,#a1d99b,0.0,
-2215,151723,Conservation,Public,151,72,Sedge/Herbaceuous,#C9C977,3,high,#31a354,1.0,
-2216,151730,Conservation,Public,151,73,Lichens,#99C147,0,none,#ffffff,0.0,
-2217,151731,Conservation,Public,151,73,Lichens,#99C147,1,low,#e5f5e0,0.0,
-2218,151732,Conservation,Public,151,73,Lichens,#99C147,2,medium,#a1d99b,0.0,
-2219,151733,Conservation,Public,151,73,Lichens,#99C147,3,high,#31a354,1.0,
-2220,151740,Conservation,Public,151,74,Moss,#77AD93,0,none,#ffffff,0.0,
-2221,151741,Conservation,Public,151,74,Moss,#77AD93,1,low,#e5f5e0,0.0,
-2222,151742,Conservation,Public,151,74,Moss,#77AD93,2,medium,#a1d99b,0.0,
-2223,151743,Conservation,Public,151,74,Moss,#77AD93,3,high,#31a354,1.0,
-2224,151810,Conservation,Public,151,81,Pasture/Hay,#DBD83D,0,none,#ffffff,0.0,2230.0
-2225,151811,Conservation,Public,151,81,Pasture/Hay,#DBD83D,1,low,#e5f5e0,0.0,2230.0
-2226,151812,Conservation,Public,151,81,Pasture/Hay,#DBD83D,2,medium,#a1d99b,0.0,2230.0
-2227,151813,Conservation,Public,151,81,Pasture/Hay,#DBD83D,3,high,#31a354,1.0,2230.0
-2228,151820,Conservation,Public,151,82,Cultivated Crops,#AA7028,0,none,#ffffff,0.0,2230.0
-2229,151821,Conservation,Public,151,82,Cultivated Crops,#AA7028,1,low,#e5f5e0,0.0,2230.0
-2230,151822,Conservation,Public,151,82,Cultivated Crops,#AA7028,2,medium,#a1d99b,0.0,2230.0
-2231,151823,Conservation,Public,151,82,Cultivated Crops,#AA7028,3,high,#31a354,1.0,2230.0
-2232,151900,Conservation,Public,151,90,Woody Wetlands,#BAD8EA,0,none,#ffffff,1.0,2230.0
-2233,151901,Conservation,Public,151,90,Woody Wetlands,#BAD8EA,1,low,#e5f5e0,1.0,2230.0
-2234,151902,Conservation,Public,151,90,Woody Wetlands,#BAD8EA,2,medium,#a1d99b,1.0,2230.0
-2235,151903,Conservation,Public,151,90,Woody Wetlands,#BAD8EA,3,high,#31a354,1.0,2230.0
-2236,151950,Conservation,Public,151,95,Emergent Herbaceous Wetlands,#70A3BA,0,none,#ffffff,1.0,2230.0
-2237,151951,Conservation,Public,151,95,Emergent Herbaceous Wetlands,#70A3BA,1,low,#e5f5e0,1.0,2230.0
-2238,151952,Conservation,Public,151,95,Emergent Herbaceous Wetlands,#70A3BA,2,medium,#a1d99b,1.0,2230.0
-2239,151953,Conservation,Public,151,95,Emergent Herbaceous Wetlands,#70A3BA,3,high,#31a354,1.0,2230.0
-2240,152110,Conservation,Public-limited access,152,11,Open Water,#476BA0,0,none,#ffffff,0.0,2230.0
-2241,152111,Conservation,Public-limited access,152,11,Open Water,#476BA0,1,low,#e5f5e0,0.0,2230.0
-2242,152112,Conservation,Public-limited access,152,11,Open Water,#476BA0,2,medium,#a1d99b,0.0,2230.0
-2243,152113,Conservation,Public-limited access,152,11,Open Water,#476BA0,3,high,#31a354,1.0,2230.0
-2244,152120,Conservation,Public-limited access,152,12,Perennial Ice/Snow,#D1DDF9,0,none,#ffffff,0.0,2230.0
-2245,152121,Conservation,Public-limited access,152,12,Perennial Ice/Snow,#D1DDF9,1,low,#e5f5e0,0.0,2230.0
-2246,152122,Conservation,Public-limited access,152,12,Perennial Ice/Snow,#D1DDF9,2,medium,#a1d99b,0.0,2230.0
-2247,152123,Conservation,Public-limited access,152,12,Perennial Ice/Snow,#D1DDF9,3,high,#31a354,1.0,2230.0
-2248,152210,Conservation,Public-limited access,152,21,"Developed, Open Space",#DDC9C9,0,none,#ffffff,0.0,2230.0
-2249,152211,Conservation,Public-limited access,152,21,"Developed, Open Space",#DDC9C9,1,low,#e5f5e0,0.0,2230.0
-2250,152212,Conservation,Public-limited access,152,21,"Developed, Open Space",#DDC9C9,2,medium,#a1d99b,0.0,2230.0
-2251,152213,Conservation,Public-limited access,152,21,"Developed, Open Space",#DDC9C9,3,high,#31a354,1.0,2230.0
-2252,152220,Conservation,Public-limited access,152,22,"Developed, Low Intensity",#D89382,0,none,#ffffff,0.0,2230.0
-2253,152221,Conservation,Public-limited access,152,22,"Developed, Low Intensity",#D89382,1,low,#e5f5e0,0.0,2230.0
-2254,152222,Conservation,Public-limited access,152,22,"Developed, Low Intensity",#D89382,2,medium,#a1d99b,0.0,2230.0
-2255,152223,Conservation,Public-limited access,152,22,"Developed, Low Intensity",#D89382,3,high,#31a354,1.0,2230.0
-2256,152230,Conservation,Public-limited access,152,23,"Developed, Medium Intensity",#ED0000,0,none,#ffffff,0.0,2230.0
-2257,152231,Conservation,Public-limited access,152,23,"Developed, Medium Intensity",#ED0000,1,low,#e5f5e0,0.0,2230.0
-2258,152232,Conservation,Public-limited access,152,23,"Developed, Medium Intensity",#ED0000,2,medium,#a1d99b,0.0,2230.0
-2259,152233,Conservation,Public-limited access,152,23,"Developed, Medium Intensity",#ED0000,3,high,#31a354,1.0,2230.0
-2260,152240,Conservation,Public-limited access,152,24,"Developed, High Intensity",#AA0000,0,none,#ffffff,0.0,2230.0
-2261,152241,Conservation,Public-limited access,152,24,"Developed, High Intensity",#AA0000,1,low,#e5f5e0,0.0,2230.0
-2262,152242,Conservation,Public-limited access,152,24,"Developed, High Intensity",#AA0000,2,medium,#a1d99b,0.0,2230.0
-2263,152243,Conservation,Public-limited access,152,24,"Developed, High Intensity",#AA0000,3,high,#31a354,1.0,2230.0
-2264,152310,Conservation,Public-limited access,152,31,Barren Land (Rock/Sand/Clay),#B2ADA3,0,none,#ffffff,0.0,2230.0
-2265,152311,Conservation,Public-limited access,152,31,Barren Land (Rock/Sand/Clay),#B2ADA3,1,low,#e5f5e0,0.0,2230.0
-2266,152312,Conservation,Public-limited access,152,31,Barren Land (Rock/Sand/Clay),#B2ADA3,2,medium,#a1d99b,0.0,2230.0
-2267,152313,Conservation,Public-limited access,152,31,Barren Land (Rock/Sand/Clay),#B2ADA3,3,high,#31a354,1.0,2230.0
-2268,152410,Conservation,Public-limited access,152,41,Deciduous Forest,#68AA63,0,none,#ffffff,1.0,2230.0
-2269,152411,Conservation,Public-limited access,152,41,Deciduous Forest,#68AA63,1,low,#e5f5e0,1.0,2230.0
-2270,152412,Conservation,Public-limited access,152,41,Deciduous Forest,#68AA63,2,medium,#a1d99b,1.0,2230.0
-2271,152413,Conservation,Public-limited access,152,41,Deciduous Forest,#68AA63,3,high,#31a354,1.0,2230.0
-2272,152420,Conservation,Public-limited access,152,42,Evergreen Forest,#1C6330,0,none,#ffffff,1.0,2230.0
-2273,152421,Conservation,Public-limited access,152,42,Evergreen Forest,#1C6330,1,low,#e5f5e0,1.0,2230.0
-2274,152422,Conservation,Public-limited access,152,42,Evergreen Forest,#1C6330,2,medium,#a1d99b,1.0,2230.0
-2275,152423,Conservation,Public-limited access,152,42,Evergreen Forest,#1C6330,3,high,#31a354,1.0,2230.0
-2276,152430,Conservation,Public-limited access,152,43,Mixed Forest,#B5C98E,0,none,#ffffff,1.0,2230.0
-2277,152431,Conservation,Public-limited access,152,43,Mixed Forest,#B5C98E,1,low,#e5f5e0,1.0,2230.0
-2278,152432,Conservation,Public-limited access,152,43,Mixed Forest,#B5C98E,2,medium,#a1d99b,1.0,2230.0
-2279,152433,Conservation,Public-limited access,152,43,Mixed Forest,#B5C98E,3,high,#31a354,1.0,2230.0
-2280,152510,Conservation,Public-limited access,152,51,Dwarf Scrub,#A58C30,0,none,#ffffff,0.0,
-2281,152511,Conservation,Public-limited access,152,51,Dwarf Scrub,#A58C30,1,low,#e5f5e0,0.0,
-2282,152512,Conservation,Public-limited access,152,51,Dwarf Scrub,#A58C30,2,medium,#a1d99b,0.0,
-2283,152513,Conservation,Public-limited access,152,51,Dwarf Scrub,#A58C30,3,high,#31a354,1.0,
-2284,152520,Conservation,Public-limited access,152,52,Scrub/Shrub,#CCBA7C,0,none,#ffffff,1.0,2230.0
-2285,152521,Conservation,Public-limited access,152,52,Scrub/Shrub,#CCBA7C,1,low,#e5f5e0,1.0,2230.0
-2286,152522,Conservation,Public-limited access,152,52,Scrub/Shrub,#CCBA7C,2,medium,#a1d99b,1.0,2230.0
-2287,152523,Conservation,Public-limited access,152,52,Scrub/Shrub,#CCBA7C,3,high,#31a354,1.0,2230.0
-2288,152710,Conservation,Public-limited access,152,71,Grassland/Herbaceous,#E2E2C1,0,none,#ffffff,1.0,2230.0
-2289,152711,Conservation,Public-limited access,152,71,Grassland/Herbaceous,#E2E2C1,1,low,#e5f5e0,1.0,2230.0
-2290,152712,Conservation,Public-limited access,152,71,Grassland/Herbaceous,#E2E2C1,2,medium,#a1d99b,1.0,2230.0
-2291,152713,Conservation,Public-limited access,152,71,Grassland/Herbaceous,#E2E2C1,3,high,#31a354,1.0,2230.0
-2292,152720,Conservation,Public-limited access,152,72,Sedge/Herbaceuous,#C9C977,0,none,#ffffff,0.0,
-2293,152721,Conservation,Public-limited access,152,72,Sedge/Herbaceuous,#C9C977,1,low,#e5f5e0,0.0,
-2294,152722,Conservation,Public-limited access,152,72,Sedge/Herbaceuous,#C9C977,2,medium,#a1d99b,0.0,
-2295,152723,Conservation,Public-limited access,152,72,Sedge/Herbaceuous,#C9C977,3,high,#31a354,1.0,
-2296,152730,Conservation,Public-limited access,152,73,Lichens,#99C147,0,none,#ffffff,0.0,
-2297,152731,Conservation,Public-limited access,152,73,Lichens,#99C147,1,low,#e5f5e0,0.0,
-2298,152732,Conservation,Public-limited access,152,73,Lichens,#99C147,2,medium,#a1d99b,0.0,
-2299,152733,Conservation,Public-limited access,152,73,Lichens,#99C147,3,high,#31a354,1.0,
-2300,152740,Conservation,Public-limited access,152,74,Moss,#77AD93,0,none,#ffffff,0.0,
-2301,152741,Conservation,Public-limited access,152,74,Moss,#77AD93,1,low,#e5f5e0,0.0,
-2302,152742,Conservation,Public-limited access,152,74,Moss,#77AD93,2,medium,#a1d99b,0.0,
-2303,152743,Conservation,Public-limited access,152,74,Moss,#77AD93,3,high,#31a354,1.0,
-2304,152810,Conservation,Public-limited access,152,81,Pasture/Hay,#DBD83D,0,none,#ffffff,0.0,2230.0
-2305,152811,Conservation,Public-limited access,152,81,Pasture/Hay,#DBD83D,1,low,#e5f5e0,0.0,2230.0
-2306,152812,Conservation,Public-limited access,152,81,Pasture/Hay,#DBD83D,2,medium,#a1d99b,0.0,2230.0
-2307,152813,Conservation,Public-limited access,152,81,Pasture/Hay,#DBD83D,3,high,#31a354,1.0,2230.0
-2308,152820,Conservation,Public-limited access,152,82,Cultivated Crops,#AA7028,0,none,#ffffff,0.0,2230.0
-2309,152821,Conservation,Public-limited access,152,82,Cultivated Crops,#AA7028,1,low,#e5f5e0,0.0,2230.0
-2310,152822,Conservation,Public-limited access,152,82,Cultivated Crops,#AA7028,2,medium,#a1d99b,0.0,2230.0
-2311,152823,Conservation,Public-limited access,152,82,Cultivated Crops,#AA7028,3,high,#31a354,1.0,2230.0
-2312,152900,Conservation,Public-limited access,152,90,Woody Wetlands,#BAD8EA,0,none,#ffffff,1.0,2230.0
-2313,152901,Conservation,Public-limited access,152,90,Woody Wetlands,#BAD8EA,1,low,#e5f5e0,1.0,2230.0
-2314,152902,Conservation,Public-limited access,152,90,Woody Wetlands,#BAD8EA,2,medium,#a1d99b,1.0,2230.0
-2315,152903,Conservation,Public-limited access,152,90,Woody Wetlands,#BAD8EA,3,high,#31a354,1.0,2230.0
-2316,152950,Conservation,Public-limited access,152,95,Emergent Herbaceous Wetlands,#70A3BA,0,none,#ffffff,1.0,2230.0
-2317,152951,Conservation,Public-limited access,152,95,Emergent Herbaceous Wetlands,#70A3BA,1,low,#e5f5e0,1.0,2230.0
-2318,152952,Conservation,Public-limited access,152,95,Emergent Herbaceous Wetlands,#70A3BA,2,medium,#a1d99b,1.0,2230.0
-2319,152953,Conservation,Public-limited access,152,95,Emergent Herbaceous Wetlands,#70A3BA,3,high,#31a354,1.0,2230.0
-2320,153110,Conservation,Private easement,153,11,Open Water,#476BA0,0,none,#ffffff,0.0,2230.0
-2321,153111,Conservation,Private easement,153,11,Open Water,#476BA0,1,low,#e5f5e0,0.0,2230.0
-2322,153112,Conservation,Private easement,153,11,Open Water,#476BA0,2,medium,#a1d99b,0.0,2230.0
-2323,153113,Conservation,Private easement,153,11,Open Water,#476BA0,3,high,#31a354,1.0,2230.0
-2324,153120,Conservation,Private easement,153,12,Perennial Ice/Snow,#D1DDF9,0,none,#ffffff,0.0,2230.0
-2325,153121,Conservation,Private easement,153,12,Perennial Ice/Snow,#D1DDF9,1,low,#e5f5e0,0.0,2230.0
-2326,153122,Conservation,Private easement,153,12,Perennial Ice/Snow,#D1DDF9,2,medium,#a1d99b,0.0,2230.0
-2327,153123,Conservation,Private easement,153,12,Perennial Ice/Snow,#D1DDF9,3,high,#31a354,1.0,2230.0
-2328,153210,Conservation,Private easement,153,21,"Developed, Open Space",#DDC9C9,0,none,#ffffff,0.0,2230.0
-2329,153211,Conservation,Private easement,153,21,"Developed, Open Space",#DDC9C9,1,low,#e5f5e0,0.0,2230.0
-2330,153212,Conservation,Private easement,153,21,"Developed, Open Space",#DDC9C9,2,medium,#a1d99b,0.0,2230.0
-2331,153213,Conservation,Private easement,153,21,"Developed, Open Space",#DDC9C9,3,high,#31a354,1.0,2230.0
-2332,153220,Conservation,Private easement,153,22,"Developed, Low Intensity",#D89382,0,none,#ffffff,0.0,2230.0
-2333,153221,Conservation,Private easement,153,22,"Developed, Low Intensity",#D89382,1,low,#e5f5e0,0.0,2230.0
-2334,153222,Conservation,Private easement,153,22,"Developed, Low Intensity",#D89382,2,medium,#a1d99b,0.0,2230.0
-2335,153223,Conservation,Private easement,153,22,"Developed, Low Intensity",#D89382,3,high,#31a354,1.0,2230.0
-2336,153230,Conservation,Private easement,153,23,"Developed, Medium Intensity",#ED0000,0,none,#ffffff,0.0,2230.0
-2337,153231,Conservation,Private easement,153,23,"Developed, Medium Intensity",#ED0000,1,low,#e5f5e0,0.0,2230.0
-2338,153232,Conservation,Private easement,153,23,"Developed, Medium Intensity",#ED0000,2,medium,#a1d99b,0.0,2230.0
-2339,153233,Conservation,Private easement,153,23,"Developed, Medium Intensity",#ED0000,3,high,#31a354,1.0,2230.0
-2340,153240,Conservation,Private easement,153,24,"Developed, High Intensity",#AA0000,0,none,#ffffff,0.0,2230.0
-2341,153241,Conservation,Private easement,153,24,"Developed, High Intensity",#AA0000,1,low,#e5f5e0,0.0,2230.0
-2342,153242,Conservation,Private easement,153,24,"Developed, High Intensity",#AA0000,2,medium,#a1d99b,0.0,2230.0
-2343,153243,Conservation,Private easement,153,24,"Developed, High Intensity",#AA0000,3,high,#31a354,1.0,2230.0
-2344,153310,Conservation,Private easement,153,31,Barren Land (Rock/Sand/Clay),#B2ADA3,0,none,#ffffff,0.0,2230.0
-2345,153311,Conservation,Private easement,153,31,Barren Land (Rock/Sand/Clay),#B2ADA3,1,low,#e5f5e0,0.0,2230.0
-2346,153312,Conservation,Private easement,153,31,Barren Land (Rock/Sand/Clay),#B2ADA3,2,medium,#a1d99b,0.0,2230.0
-2347,153313,Conservation,Private easement,153,31,Barren Land (Rock/Sand/Clay),#B2ADA3,3,high,#31a354,1.0,2230.0
-2348,153410,Conservation,Private easement,153,41,Deciduous Forest,#68AA63,0,none,#ffffff,1.0,2230.0
-2349,153411,Conservation,Private easement,153,41,Deciduous Forest,#68AA63,1,low,#e5f5e0,1.0,2230.0
-2350,153412,Conservation,Private easement,153,41,Deciduous Forest,#68AA63,2,medium,#a1d99b,1.0,2230.0
-2351,153413,Conservation,Private easement,153,41,Deciduous Forest,#68AA63,3,high,#31a354,1.0,2230.0
-2352,153420,Conservation,Private easement,153,42,Evergreen Forest,#1C6330,0,none,#ffffff,1.0,2230.0
-2353,153421,Conservation,Private easement,153,42,Evergreen Forest,#1C6330,1,low,#e5f5e0,1.0,2230.0
-2354,153422,Conservation,Private easement,153,42,Evergreen Forest,#1C6330,2,medium,#a1d99b,1.0,2230.0
-2355,153423,Conservation,Private easement,153,42,Evergreen Forest,#1C6330,3,high,#31a354,1.0,2230.0
-2356,153430,Conservation,Private easement,153,43,Mixed Forest,#B5C98E,0,none,#ffffff,1.0,2230.0
-2357,153431,Conservation,Private easement,153,43,Mixed Forest,#B5C98E,1,low,#e5f5e0,1.0,2230.0
-2358,153432,Conservation,Private easement,153,43,Mixed Forest,#B5C98E,2,medium,#a1d99b,1.0,2230.0
-2359,153433,Conservation,Private easement,153,43,Mixed Forest,#B5C98E,3,high,#31a354,1.0,2230.0
-2360,153510,Conservation,Private easement,153,51,Dwarf Scrub,#A58C30,0,none,#ffffff,0.0,
-2361,153511,Conservation,Private easement,153,51,Dwarf Scrub,#A58C30,1,low,#e5f5e0,0.0,
-2362,153512,Conservation,Private easement,153,51,Dwarf Scrub,#A58C30,2,medium,#a1d99b,0.0,
-2363,153513,Conservation,Private easement,153,51,Dwarf Scrub,#A58C30,3,high,#31a354,1.0,
-2364,153520,Conservation,Private easement,153,52,Scrub/Shrub,#CCBA7C,0,none,#ffffff,1.0,2230.0
-2365,153521,Conservation,Private easement,153,52,Scrub/Shrub,#CCBA7C,1,low,#e5f5e0,1.0,2230.0
-2366,153522,Conservation,Private easement,153,52,Scrub/Shrub,#CCBA7C,2,medium,#a1d99b,1.0,2230.0
-2367,153523,Conservation,Private easement,153,52,Scrub/Shrub,#CCBA7C,3,high,#31a354,1.0,2230.0
-2368,153710,Conservation,Private easement,153,71,Grassland/Herbaceous,#E2E2C1,0,none,#ffffff,1.0,2230.0
-2369,153711,Conservation,Private easement,153,71,Grassland/Herbaceous,#E2E2C1,1,low,#e5f5e0,1.0,2230.0
-2370,153712,Conservation,Private easement,153,71,Grassland/Herbaceous,#E2E2C1,2,medium,#a1d99b,1.0,2230.0
-2371,153713,Conservation,Private easement,153,71,Grassland/Herbaceous,#E2E2C1,3,high,#31a354,1.0,2230.0
-2372,153720,Conservation,Private easement,153,72,Sedge/Herbaceuous,#C9C977,0,none,#ffffff,0.0,
-2373,153721,Conservation,Private easement,153,72,Sedge/Herbaceuous,#C9C977,1,low,#e5f5e0,0.0,
-2374,153722,Conservation,Private easement,153,72,Sedge/Herbaceuous,#C9C977,2,medium,#a1d99b,0.0,
-2375,153723,Conservation,Private easement,153,72,Sedge/Herbaceuous,#C9C977,3,high,#31a354,1.0,
-2376,153730,Conservation,Private easement,153,73,Lichens,#99C147,0,none,#ffffff,0.0,
-2377,153731,Conservation,Private easement,153,73,Lichens,#99C147,1,low,#e5f5e0,0.0,
-2378,153732,Conservation,Private easement,153,73,Lichens,#99C147,2,medium,#a1d99b,0.0,
-2379,153733,Conservation,Private easement,153,73,Lichens,#99C147,3,high,#31a354,1.0,
-2380,153740,Conservation,Private easement,153,74,Moss,#77AD93,0,none,#ffffff,0.0,
-2381,153741,Conservation,Private easement,153,74,Moss,#77AD93,1,low,#e5f5e0,0.0,
-2382,153742,Conservation,Private easement,153,74,Moss,#77AD93,2,medium,#a1d99b,0.0,
-2383,153743,Conservation,Private easement,153,74,Moss,#77AD93,3,high,#31a354,1.0,
-2384,153810,Conservation,Private easement,153,81,Pasture/Hay,#DBD83D,0,none,#ffffff,0.0,2230.0
-2385,153811,Conservation,Private easement,153,81,Pasture/Hay,#DBD83D,1,low,#e5f5e0,0.0,2230.0
-2386,153812,Conservation,Private easement,153,81,Pasture/Hay,#DBD83D,2,medium,#a1d99b,0.0,2230.0
-2387,153813,Conservation,Private easement,153,81,Pasture/Hay,#DBD83D,3,high,#31a354,1.0,2230.0
-2388,153820,Conservation,Private easement,153,82,Cultivated Crops,#AA7028,0,none,#ffffff,0.0,2230.0
-2389,153821,Conservation,Private easement,153,82,Cultivated Crops,#AA7028,1,low,#e5f5e0,0.0,2230.0
-2390,153822,Conservation,Private easement,153,82,Cultivated Crops,#AA7028,2,medium,#a1d99b,0.0,2230.0
-2391,153823,Conservation,Private easement,153,82,Cultivated Crops,#AA7028,3,high,#31a354,1.0,2230.0
-2392,153900,Conservation,Private easement,153,90,Woody Wetlands,#BAD8EA,0,none,#ffffff,1.0,2230.0
-2393,153901,Conservation,Private easement,153,90,Woody Wetlands,#BAD8EA,1,low,#e5f5e0,1.0,2230.0
-2394,153902,Conservation,Private easement,153,90,Woody Wetlands,#BAD8EA,2,medium,#a1d99b,1.0,2230.0
-2395,153903,Conservation,Private easement,153,90,Woody Wetlands,#BAD8EA,3,high,#31a354,1.0,2230.0
-2396,153950,Conservation,Private easement,153,95,Emergent Herbaceous Wetlands,#70A3BA,0,none,#ffffff,1.0,2230.0
-2397,153951,Conservation,Private easement,153,95,Emergent Herbaceous Wetlands,#70A3BA,1,low,#e5f5e0,1.0,2230.0
-2398,153952,Conservation,Private easement,153,95,Emergent Herbaceous Wetlands,#70A3BA,2,medium,#a1d99b,1.0,2230.0
-2399,153953,Conservation,Private easement,153,95,Emergent Herbaceous Wetlands,#70A3BA,3,high,#31a354,1.0,2230.0
+lucode,code,nlud_simple_class,nlud_simple_subclass,simple_nlud,nlcd,nlcd_lulc,nlcd_colors,tree,tree_canopy_cover,tree_colors,urban_nature,search_radius_m
+0,001110,Waterbody,Natural,1,11,Open Water,#476BA0,0,none,#ffffff,0,2230
+1,001111,Waterbody,Natural,1,11,Open Water,#476BA0,1,low,#e5f5e0,0,2230
+2,001112,Waterbody,Natural,1,11,Open Water,#476BA0,2,medium,#a1d99b,0,2230
+3,001113,Waterbody,Natural,1,11,Open Water,#476BA0,3,high,#31a354,1,2230
+4,001120,Waterbody,Natural,1,12,Perennial Ice/Snow,#D1DDF9,0,none,#ffffff,0,2230
+5,001121,Waterbody,Natural,1,12,Perennial Ice/Snow,#D1DDF9,1,low,#e5f5e0,0,2230
+6,001122,Waterbody,Natural,1,12,Perennial Ice/Snow,#D1DDF9,2,medium,#a1d99b,0,2230
+7,001123,Waterbody,Natural,1,12,Perennial Ice/Snow,#D1DDF9,3,high,#31a354,1,2230
+8,001210,Waterbody,Natural,1,21,"Developed, Open Space",#DDC9C9,0,none,#ffffff,0,2230
+9,001211,Waterbody,Natural,1,21,"Developed, Open Space",#DDC9C9,1,low,#e5f5e0,0,2230
+10,001212,Waterbody,Natural,1,21,"Developed, Open Space",#DDC9C9,2,medium,#a1d99b,0,2230
+11,001213,Waterbody,Natural,1,21,"Developed, Open Space",#DDC9C9,3,high,#31a354,1,2230
+12,001220,Waterbody,Natural,1,22,"Developed, Low Intensity",#D89382,0,none,#ffffff,0,2230
+13,001221,Waterbody,Natural,1,22,"Developed, Low Intensity",#D89382,1,low,#e5f5e0,0,2230
+14,001222,Waterbody,Natural,1,22,"Developed, Low Intensity",#D89382,2,medium,#a1d99b,0,2230
+15,001223,Waterbody,Natural,1,22,"Developed, Low Intensity",#D89382,3,high,#31a354,1,2230
+16,001230,Waterbody,Natural,1,23,"Developed, Medium Intensity",#ED0000,0,none,#ffffff,0,2230
+17,001231,Waterbody,Natural,1,23,"Developed, Medium Intensity",#ED0000,1,low,#e5f5e0,0,2230
+18,001232,Waterbody,Natural,1,23,"Developed, Medium Intensity",#ED0000,2,medium,#a1d99b,0,2230
+19,001233,Waterbody,Natural,1,23,"Developed, Medium Intensity",#ED0000,3,high,#31a354,1,2230
+20,001240,Waterbody,Natural,1,24,"Developed, High Intensity",#AA0000,0,none,#ffffff,0,2230
+21,001241,Waterbody,Natural,1,24,"Developed, High Intensity",#AA0000,1,low,#e5f5e0,0,2230
+22,001242,Waterbody,Natural,1,24,"Developed, High Intensity",#AA0000,2,medium,#a1d99b,0,2230
+23,001243,Waterbody,Natural,1,24,"Developed, High Intensity",#AA0000,3,high,#31a354,1,2230
+24,001310,Waterbody,Natural,1,31,Barren Land (Rock/Sand/Clay),#B2ADA3,0,none,#ffffff,0,2230
+25,001311,Waterbody,Natural,1,31,Barren Land (Rock/Sand/Clay),#B2ADA3,1,low,#e5f5e0,0,2230
+26,001312,Waterbody,Natural,1,31,Barren Land (Rock/Sand/Clay),#B2ADA3,2,medium,#a1d99b,0,2230
+27,001313,Waterbody,Natural,1,31,Barren Land (Rock/Sand/Clay),#B2ADA3,3,high,#31a354,1,2230
+28,001410,Waterbody,Natural,1,41,Deciduous Forest,#68AA63,0,none,#ffffff,1,2230
+29,001411,Waterbody,Natural,1,41,Deciduous Forest,#68AA63,1,low,#e5f5e0,1,2230
+30,001412,Waterbody,Natural,1,41,Deciduous Forest,#68AA63,2,medium,#a1d99b,1,2230
+31,001413,Waterbody,Natural,1,41,Deciduous Forest,#68AA63,3,high,#31a354,1,2230
+32,001420,Waterbody,Natural,1,42,Evergreen Forest,#1C6330,0,none,#ffffff,1,2230
+33,001421,Waterbody,Natural,1,42,Evergreen Forest,#1C6330,1,low,#e5f5e0,1,2230
+34,001422,Waterbody,Natural,1,42,Evergreen Forest,#1C6330,2,medium,#a1d99b,1,2230
+35,001423,Waterbody,Natural,1,42,Evergreen Forest,#1C6330,3,high,#31a354,1,2230
+36,001430,Waterbody,Natural,1,43,Mixed Forest,#B5C98E,0,none,#ffffff,1,2230
+37,001431,Waterbody,Natural,1,43,Mixed Forest,#B5C98E,1,low,#e5f5e0,1,2230
+38,001432,Waterbody,Natural,1,43,Mixed Forest,#B5C98E,2,medium,#a1d99b,1,2230
+39,001433,Waterbody,Natural,1,43,Mixed Forest,#B5C98E,3,high,#31a354,1,2230
+40,001510,Waterbody,Natural,1,51,Dwarf Scrub,#A58C30,0,none,#ffffff,0,
+41,001511,Waterbody,Natural,1,51,Dwarf Scrub,#A58C30,1,low,#e5f5e0,0,
+42,001512,Waterbody,Natural,1,51,Dwarf Scrub,#A58C30,2,medium,#a1d99b,0,
+43,001513,Waterbody,Natural,1,51,Dwarf Scrub,#A58C30,3,high,#31a354,1,
+44,001520,Waterbody,Natural,1,52,Scrub/Shrub,#CCBA7C,0,none,#ffffff,1,2230
+45,001521,Waterbody,Natural,1,52,Scrub/Shrub,#CCBA7C,1,low,#e5f5e0,1,2230
+46,001522,Waterbody,Natural,1,52,Scrub/Shrub,#CCBA7C,2,medium,#a1d99b,1,2230
+47,001523,Waterbody,Natural,1,52,Scrub/Shrub,#CCBA7C,3,high,#31a354,1,2230
+48,001710,Waterbody,Natural,1,71,Grassland/Herbaceous,#E2E2C1,0,none,#ffffff,1,2230
+49,001711,Waterbody,Natural,1,71,Grassland/Herbaceous,#E2E2C1,1,low,#e5f5e0,1,2230
+50,001712,Waterbody,Natural,1,71,Grassland/Herbaceous,#E2E2C1,2,medium,#a1d99b,1,2230
+51,001713,Waterbody,Natural,1,71,Grassland/Herbaceous,#E2E2C1,3,high,#31a354,1,2230
+52,001720,Waterbody,Natural,1,72,Sedge/Herbaceuous,#C9C977,0,none,#ffffff,0,
+53,001721,Waterbody,Natural,1,72,Sedge/Herbaceuous,#C9C977,1,low,#e5f5e0,0,
+54,001722,Waterbody,Natural,1,72,Sedge/Herbaceuous,#C9C977,2,medium,#a1d99b,0,
+55,001723,Waterbody,Natural,1,72,Sedge/Herbaceuous,#C9C977,3,high,#31a354,1,
+56,001730,Waterbody,Natural,1,73,Lichens,#99C147,0,none,#ffffff,0,
+57,001731,Waterbody,Natural,1,73,Lichens,#99C147,1,low,#e5f5e0,0,
+58,001732,Waterbody,Natural,1,73,Lichens,#99C147,2,medium,#a1d99b,0,
+59,001733,Waterbody,Natural,1,73,Lichens,#99C147,3,high,#31a354,1,
+60,001740,Waterbody,Natural,1,74,Moss,#77AD93,0,none,#ffffff,0,
+61,001741,Waterbody,Natural,1,74,Moss,#77AD93,1,low,#e5f5e0,0,
+62,001742,Waterbody,Natural,1,74,Moss,#77AD93,2,medium,#a1d99b,0,
+63,001743,Waterbody,Natural,1,74,Moss,#77AD93,3,high,#31a354,1,
+64,001810,Waterbody,Natural,1,81,Pasture/Hay,#DBD83D,0,none,#ffffff,0,2230
+65,001811,Waterbody,Natural,1,81,Pasture/Hay,#DBD83D,1,low,#e5f5e0,0,2230
+66,001812,Waterbody,Natural,1,81,Pasture/Hay,#DBD83D,2,medium,#a1d99b,0,2230
+67,001813,Waterbody,Natural,1,81,Pasture/Hay,#DBD83D,3,high,#31a354,1,2230
+68,001820,Waterbody,Natural,1,82,Cultivated Crops,#AA7028,0,none,#ffffff,0,2230
+69,001821,Waterbody,Natural,1,82,Cultivated Crops,#AA7028,1,low,#e5f5e0,0,2230
+70,001822,Waterbody,Natural,1,82,Cultivated Crops,#AA7028,2,medium,#a1d99b,0,2230
+71,001823,Waterbody,Natural,1,82,Cultivated Crops,#AA7028,3,high,#31a354,1,2230
+72,001900,Waterbody,Natural,1,90,Woody Wetlands,#BAD8EA,0,none,#ffffff,1,2230
+73,001901,Waterbody,Natural,1,90,Woody Wetlands,#BAD8EA,1,low,#e5f5e0,1,2230
+74,001902,Waterbody,Natural,1,90,Woody Wetlands,#BAD8EA,2,medium,#a1d99b,1,2230
+75,001903,Waterbody,Natural,1,90,Woody Wetlands,#BAD8EA,3,high,#31a354,1,2230
+76,001950,Waterbody,Natural,1,95,Emergent Herbaceous Wetlands,#70A3BA,0,none,#ffffff,1,2230
+77,001951,Waterbody,Natural,1,95,Emergent Herbaceous Wetlands,#70A3BA,1,low,#e5f5e0,1,2230
+78,001952,Waterbody,Natural,1,95,Emergent Herbaceous Wetlands,#70A3BA,2,medium,#a1d99b,1,2230
+79,001953,Waterbody,Natural,1,95,Emergent Herbaceous Wetlands,#70A3BA,3,high,#31a354,1,2230
+80,002110,Waterbody,Wetland,2,11,Open Water,#476BA0,0,none,#ffffff,0,2230
+81,002111,Waterbody,Wetland,2,11,Open Water,#476BA0,1,low,#e5f5e0,0,2230
+82,002112,Waterbody,Wetland,2,11,Open Water,#476BA0,2,medium,#a1d99b,0,2230
+83,002113,Waterbody,Wetland,2,11,Open Water,#476BA0,3,high,#31a354,1,2230
+84,002120,Waterbody,Wetland,2,12,Perennial Ice/Snow,#D1DDF9,0,none,#ffffff,0,2230
+85,002121,Waterbody,Wetland,2,12,Perennial Ice/Snow,#D1DDF9,1,low,#e5f5e0,0,2230
+86,002122,Waterbody,Wetland,2,12,Perennial Ice/Snow,#D1DDF9,2,medium,#a1d99b,0,2230
+87,002123,Waterbody,Wetland,2,12,Perennial Ice/Snow,#D1DDF9,3,high,#31a354,1,2230
+88,002210,Waterbody,Wetland,2,21,"Developed, Open Space",#DDC9C9,0,none,#ffffff,0,2230
+89,002211,Waterbody,Wetland,2,21,"Developed, Open Space",#DDC9C9,1,low,#e5f5e0,0,2230
+90,002212,Waterbody,Wetland,2,21,"Developed, Open Space",#DDC9C9,2,medium,#a1d99b,0,2230
+91,002213,Waterbody,Wetland,2,21,"Developed, Open Space",#DDC9C9,3,high,#31a354,1,2230
+92,002220,Waterbody,Wetland,2,22,"Developed, Low Intensity",#D89382,0,none,#ffffff,0,2230
+93,002221,Waterbody,Wetland,2,22,"Developed, Low Intensity",#D89382,1,low,#e5f5e0,0,2230
+94,002222,Waterbody,Wetland,2,22,"Developed, Low Intensity",#D89382,2,medium,#a1d99b,0,2230
+95,002223,Waterbody,Wetland,2,22,"Developed, Low Intensity",#D89382,3,high,#31a354,1,2230
+96,002230,Waterbody,Wetland,2,23,"Developed, Medium Intensity",#ED0000,0,none,#ffffff,0,2230
+97,002231,Waterbody,Wetland,2,23,"Developed, Medium Intensity",#ED0000,1,low,#e5f5e0,0,2230
+98,002232,Waterbody,Wetland,2,23,"Developed, Medium Intensity",#ED0000,2,medium,#a1d99b,0,2230
+99,002233,Waterbody,Wetland,2,23,"Developed, Medium Intensity",#ED0000,3,high,#31a354,1,2230
+100,002240,Waterbody,Wetland,2,24,"Developed, High Intensity",#AA0000,0,none,#ffffff,0,2230
+101,002241,Waterbody,Wetland,2,24,"Developed, High Intensity",#AA0000,1,low,#e5f5e0,0,2230
+102,002242,Waterbody,Wetland,2,24,"Developed, High Intensity",#AA0000,2,medium,#a1d99b,0,2230
+103,002243,Waterbody,Wetland,2,24,"Developed, High Intensity",#AA0000,3,high,#31a354,1,2230
+104,002310,Waterbody,Wetland,2,31,Barren Land (Rock/Sand/Clay),#B2ADA3,0,none,#ffffff,0,2230
+105,002311,Waterbody,Wetland,2,31,Barren Land (Rock/Sand/Clay),#B2ADA3,1,low,#e5f5e0,0,2230
+106,002312,Waterbody,Wetland,2,31,Barren Land (Rock/Sand/Clay),#B2ADA3,2,medium,#a1d99b,0,2230
+107,002313,Waterbody,Wetland,2,31,Barren Land (Rock/Sand/Clay),#B2ADA3,3,high,#31a354,1,2230
+108,002410,Waterbody,Wetland,2,41,Deciduous Forest,#68AA63,0,none,#ffffff,1,2230
+109,002411,Waterbody,Wetland,2,41,Deciduous Forest,#68AA63,1,low,#e5f5e0,1,2230
+110,002412,Waterbody,Wetland,2,41,Deciduous Forest,#68AA63,2,medium,#a1d99b,1,2230
+111,002413,Waterbody,Wetland,2,41,Deciduous Forest,#68AA63,3,high,#31a354,1,2230
+112,002420,Waterbody,Wetland,2,42,Evergreen Forest,#1C6330,0,none,#ffffff,1,2230
+113,002421,Waterbody,Wetland,2,42,Evergreen Forest,#1C6330,1,low,#e5f5e0,1,2230
+114,002422,Waterbody,Wetland,2,42,Evergreen Forest,#1C6330,2,medium,#a1d99b,1,2230
+115,002423,Waterbody,Wetland,2,42,Evergreen Forest,#1C6330,3,high,#31a354,1,2230
+116,002430,Waterbody,Wetland,2,43,Mixed Forest,#B5C98E,0,none,#ffffff,1,2230
+117,002431,Waterbody,Wetland,2,43,Mixed Forest,#B5C98E,1,low,#e5f5e0,1,2230
+118,002432,Waterbody,Wetland,2,43,Mixed Forest,#B5C98E,2,medium,#a1d99b,1,2230
+119,002433,Waterbody,Wetland,2,43,Mixed Forest,#B5C98E,3,high,#31a354,1,2230
+120,002510,Waterbody,Wetland,2,51,Dwarf Scrub,#A58C30,0,none,#ffffff,0,
+121,002511,Waterbody,Wetland,2,51,Dwarf Scrub,#A58C30,1,low,#e5f5e0,0,
+122,002512,Waterbody,Wetland,2,51,Dwarf Scrub,#A58C30,2,medium,#a1d99b,0,
+123,002513,Waterbody,Wetland,2,51,Dwarf Scrub,#A58C30,3,high,#31a354,1,
+124,002520,Waterbody,Wetland,2,52,Scrub/Shrub,#CCBA7C,0,none,#ffffff,1,2230
+125,002521,Waterbody,Wetland,2,52,Scrub/Shrub,#CCBA7C,1,low,#e5f5e0,1,2230
+126,002522,Waterbody,Wetland,2,52,Scrub/Shrub,#CCBA7C,2,medium,#a1d99b,1,2230
+127,002523,Waterbody,Wetland,2,52,Scrub/Shrub,#CCBA7C,3,high,#31a354,1,2230
+128,002710,Waterbody,Wetland,2,71,Grassland/Herbaceous,#E2E2C1,0,none,#ffffff,1,2230
+129,002711,Waterbody,Wetland,2,71,Grassland/Herbaceous,#E2E2C1,1,low,#e5f5e0,1,2230
+130,002712,Waterbody,Wetland,2,71,Grassland/Herbaceous,#E2E2C1,2,medium,#a1d99b,1,2230
+131,002713,Waterbody,Wetland,2,71,Grassland/Herbaceous,#E2E2C1,3,high,#31a354,1,2230
+132,002720,Waterbody,Wetland,2,72,Sedge/Herbaceuous,#C9C977,0,none,#ffffff,0,
+133,002721,Waterbody,Wetland,2,72,Sedge/Herbaceuous,#C9C977,1,low,#e5f5e0,0,
+134,002722,Waterbody,Wetland,2,72,Sedge/Herbaceuous,#C9C977,2,medium,#a1d99b,0,
+135,002723,Waterbody,Wetland,2,72,Sedge/Herbaceuous,#C9C977,3,high,#31a354,1,
+136,002730,Waterbody,Wetland,2,73,Lichens,#99C147,0,none,#ffffff,0,
+137,002731,Waterbody,Wetland,2,73,Lichens,#99C147,1,low,#e5f5e0,0,
+138,002732,Waterbody,Wetland,2,73,Lichens,#99C147,2,medium,#a1d99b,0,
+139,002733,Waterbody,Wetland,2,73,Lichens,#99C147,3,high,#31a354,1,
+140,002740,Waterbody,Wetland,2,74,Moss,#77AD93,0,none,#ffffff,0,
+141,002741,Waterbody,Wetland,2,74,Moss,#77AD93,1,low,#e5f5e0,0,
+142,002742,Waterbody,Wetland,2,74,Moss,#77AD93,2,medium,#a1d99b,0,
+143,002743,Waterbody,Wetland,2,74,Moss,#77AD93,3,high,#31a354,1,
+144,002810,Waterbody,Wetland,2,81,Pasture/Hay,#DBD83D,0,none,#ffffff,0,2230
+145,002811,Waterbody,Wetland,2,81,Pasture/Hay,#DBD83D,1,low,#e5f5e0,0,2230
+146,002812,Waterbody,Wetland,2,81,Pasture/Hay,#DBD83D,2,medium,#a1d99b,0,2230
+147,002813,Waterbody,Wetland,2,81,Pasture/Hay,#DBD83D,3,high,#31a354,1,2230
+148,002820,Waterbody,Wetland,2,82,Cultivated Crops,#AA7028,0,none,#ffffff,0,2230
+149,002821,Waterbody,Wetland,2,82,Cultivated Crops,#AA7028,1,low,#e5f5e0,0,2230
+150,002822,Waterbody,Wetland,2,82,Cultivated Crops,#AA7028,2,medium,#a1d99b,0,2230
+151,002823,Waterbody,Wetland,2,82,Cultivated Crops,#AA7028,3,high,#31a354,1,2230
+152,002900,Waterbody,Wetland,2,90,Woody Wetlands,#BAD8EA,0,none,#ffffff,1,2230
+153,002901,Waterbody,Wetland,2,90,Woody Wetlands,#BAD8EA,1,low,#e5f5e0,1,2230
+154,002902,Waterbody,Wetland,2,90,Woody Wetlands,#BAD8EA,2,medium,#a1d99b,1,2230
+155,002903,Waterbody,Wetland,2,90,Woody Wetlands,#BAD8EA,3,high,#31a354,1,2230
+156,002950,Waterbody,Wetland,2,95,Emergent Herbaceous Wetlands,#70A3BA,0,none,#ffffff,1,2230
+157,002951,Waterbody,Wetland,2,95,Emergent Herbaceous Wetlands,#70A3BA,1,low,#e5f5e0,1,2230
+158,002952,Waterbody,Wetland,2,95,Emergent Herbaceous Wetlands,#70A3BA,2,medium,#a1d99b,1,2230
+159,002953,Waterbody,Wetland,2,95,Emergent Herbaceous Wetlands,#70A3BA,3,high,#31a354,1,2230
+160,003110,Waterbody,Artificial,3,11,Open Water,#476BA0,0,none,#ffffff,0,2230
+161,003111,Waterbody,Artificial,3,11,Open Water,#476BA0,1,low,#e5f5e0,0,2230
+162,003112,Waterbody,Artificial,3,11,Open Water,#476BA0,2,medium,#a1d99b,0,2230
+163,003113,Waterbody,Artificial,3,11,Open Water,#476BA0,3,high,#31a354,1,2230
+164,003120,Waterbody,Artificial,3,12,Perennial Ice/Snow,#D1DDF9,0,none,#ffffff,0,2230
+165,003121,Waterbody,Artificial,3,12,Perennial Ice/Snow,#D1DDF9,1,low,#e5f5e0,0,2230
+166,003122,Waterbody,Artificial,3,12,Perennial Ice/Snow,#D1DDF9,2,medium,#a1d99b,0,2230
+167,003123,Waterbody,Artificial,3,12,Perennial Ice/Snow,#D1DDF9,3,high,#31a354,1,2230
+168,003210,Waterbody,Artificial,3,21,"Developed, Open Space",#DDC9C9,0,none,#ffffff,0,2230
+169,003211,Waterbody,Artificial,3,21,"Developed, Open Space",#DDC9C9,1,low,#e5f5e0,0,2230
+170,003212,Waterbody,Artificial,3,21,"Developed, Open Space",#DDC9C9,2,medium,#a1d99b,0,2230
+171,003213,Waterbody,Artificial,3,21,"Developed, Open Space",#DDC9C9,3,high,#31a354,1,2230
+172,003220,Waterbody,Artificial,3,22,"Developed, Low Intensity",#D89382,0,none,#ffffff,0,2230
+173,003221,Waterbody,Artificial,3,22,"Developed, Low Intensity",#D89382,1,low,#e5f5e0,0,2230
+174,003222,Waterbody,Artificial,3,22,"Developed, Low Intensity",#D89382,2,medium,#a1d99b,0,2230
+175,003223,Waterbody,Artificial,3,22,"Developed, Low Intensity",#D89382,3,high,#31a354,1,2230
+176,003230,Waterbody,Artificial,3,23,"Developed, Medium Intensity",#ED0000,0,none,#ffffff,0,2230
+177,003231,Waterbody,Artificial,3,23,"Developed, Medium Intensity",#ED0000,1,low,#e5f5e0,0,2230
+178,003232,Waterbody,Artificial,3,23,"Developed, Medium Intensity",#ED0000,2,medium,#a1d99b,0,2230
+179,003233,Waterbody,Artificial,3,23,"Developed, Medium Intensity",#ED0000,3,high,#31a354,1,2230
+180,003240,Waterbody,Artificial,3,24,"Developed, High Intensity",#AA0000,0,none,#ffffff,0,2230
+181,003241,Waterbody,Artificial,3,24,"Developed, High Intensity",#AA0000,1,low,#e5f5e0,0,2230
+182,003242,Waterbody,Artificial,3,24,"Developed, High Intensity",#AA0000,2,medium,#a1d99b,0,2230
+183,003243,Waterbody,Artificial,3,24,"Developed, High Intensity",#AA0000,3,high,#31a354,1,2230
+184,003310,Waterbody,Artificial,3,31,Barren Land (Rock/Sand/Clay),#B2ADA3,0,none,#ffffff,0,2230
+185,003311,Waterbody,Artificial,3,31,Barren Land (Rock/Sand/Clay),#B2ADA3,1,low,#e5f5e0,0,2230
+186,003312,Waterbody,Artificial,3,31,Barren Land (Rock/Sand/Clay),#B2ADA3,2,medium,#a1d99b,0,2230
+187,003313,Waterbody,Artificial,3,31,Barren Land (Rock/Sand/Clay),#B2ADA3,3,high,#31a354,1,2230
+188,003410,Waterbody,Artificial,3,41,Deciduous Forest,#68AA63,0,none,#ffffff,1,2230
+189,003411,Waterbody,Artificial,3,41,Deciduous Forest,#68AA63,1,low,#e5f5e0,1,2230
+190,003412,Waterbody,Artificial,3,41,Deciduous Forest,#68AA63,2,medium,#a1d99b,1,2230
+191,003413,Waterbody,Artificial,3,41,Deciduous Forest,#68AA63,3,high,#31a354,1,2230
+192,003420,Waterbody,Artificial,3,42,Evergreen Forest,#1C6330,0,none,#ffffff,1,2230
+193,003421,Waterbody,Artificial,3,42,Evergreen Forest,#1C6330,1,low,#e5f5e0,1,2230
+194,003422,Waterbody,Artificial,3,42,Evergreen Forest,#1C6330,2,medium,#a1d99b,1,2230
+195,003423,Waterbody,Artificial,3,42,Evergreen Forest,#1C6330,3,high,#31a354,1,2230
+196,003430,Waterbody,Artificial,3,43,Mixed Forest,#B5C98E,0,none,#ffffff,1,2230
+197,003431,Waterbody,Artificial,3,43,Mixed Forest,#B5C98E,1,low,#e5f5e0,1,2230
+198,003432,Waterbody,Artificial,3,43,Mixed Forest,#B5C98E,2,medium,#a1d99b,1,2230
+199,003433,Waterbody,Artificial,3,43,Mixed Forest,#B5C98E,3,high,#31a354,1,2230
+200,003510,Waterbody,Artificial,3,51,Dwarf Scrub,#A58C30,0,none,#ffffff,0,
+201,003511,Waterbody,Artificial,3,51,Dwarf Scrub,#A58C30,1,low,#e5f5e0,0,
+202,003512,Waterbody,Artificial,3,51,Dwarf Scrub,#A58C30,2,medium,#a1d99b,0,
+203,003513,Waterbody,Artificial,3,51,Dwarf Scrub,#A58C30,3,high,#31a354,1,
+204,003520,Waterbody,Artificial,3,52,Scrub/Shrub,#CCBA7C,0,none,#ffffff,1,2230
+205,003521,Waterbody,Artificial,3,52,Scrub/Shrub,#CCBA7C,1,low,#e5f5e0,1,2230
+206,003522,Waterbody,Artificial,3,52,Scrub/Shrub,#CCBA7C,2,medium,#a1d99b,1,2230
+207,003523,Waterbody,Artificial,3,52,Scrub/Shrub,#CCBA7C,3,high,#31a354,1,2230
+208,003710,Waterbody,Artificial,3,71,Grassland/Herbaceous,#E2E2C1,0,none,#ffffff,1,2230
+209,003711,Waterbody,Artificial,3,71,Grassland/Herbaceous,#E2E2C1,1,low,#e5f5e0,1,2230
+210,003712,Waterbody,Artificial,3,71,Grassland/Herbaceous,#E2E2C1,2,medium,#a1d99b,1,2230
+211,003713,Waterbody,Artificial,3,71,Grassland/Herbaceous,#E2E2C1,3,high,#31a354,1,2230
+212,003720,Waterbody,Artificial,3,72,Sedge/Herbaceuous,#C9C977,0,none,#ffffff,0,
+213,003721,Waterbody,Artificial,3,72,Sedge/Herbaceuous,#C9C977,1,low,#e5f5e0,0,
+214,003722,Waterbody,Artificial,3,72,Sedge/Herbaceuous,#C9C977,2,medium,#a1d99b,0,
+215,003723,Waterbody,Artificial,3,72,Sedge/Herbaceuous,#C9C977,3,high,#31a354,1,
+216,003730,Waterbody,Artificial,3,73,Lichens,#99C147,0,none,#ffffff,0,
+217,003731,Waterbody,Artificial,3,73,Lichens,#99C147,1,low,#e5f5e0,0,
+218,003732,Waterbody,Artificial,3,73,Lichens,#99C147,2,medium,#a1d99b,0,
+219,003733,Waterbody,Artificial,3,73,Lichens,#99C147,3,high,#31a354,1,
+220,003740,Waterbody,Artificial,3,74,Moss,#77AD93,0,none,#ffffff,0,
+221,003741,Waterbody,Artificial,3,74,Moss,#77AD93,1,low,#e5f5e0,0,
+222,003742,Waterbody,Artificial,3,74,Moss,#77AD93,2,medium,#a1d99b,0,
+223,003743,Waterbody,Artificial,3,74,Moss,#77AD93,3,high,#31a354,1,
+224,003810,Waterbody,Artificial,3,81,Pasture/Hay,#DBD83D,0,none,#ffffff,0,2230
+225,003811,Waterbody,Artificial,3,81,Pasture/Hay,#DBD83D,1,low,#e5f5e0,0,2230
+226,003812,Waterbody,Artificial,3,81,Pasture/Hay,#DBD83D,2,medium,#a1d99b,0,2230
+227,003813,Waterbody,Artificial,3,81,Pasture/Hay,#DBD83D,3,high,#31a354,1,2230
+228,003820,Waterbody,Artificial,3,82,Cultivated Crops,#AA7028,0,none,#ffffff,0,2230
+229,003821,Waterbody,Artificial,3,82,Cultivated Crops,#AA7028,1,low,#e5f5e0,0,2230
+230,003822,Waterbody,Artificial,3,82,Cultivated Crops,#AA7028,2,medium,#a1d99b,0,2230
+231,003823,Waterbody,Artificial,3,82,Cultivated Crops,#AA7028,3,high,#31a354,1,2230
+232,003900,Waterbody,Artificial,3,90,Woody Wetlands,#BAD8EA,0,none,#ffffff,1,2230
+233,003901,Waterbody,Artificial,3,90,Woody Wetlands,#BAD8EA,1,low,#e5f5e0,1,2230
+234,003902,Waterbody,Artificial,3,90,Woody Wetlands,#BAD8EA,2,medium,#a1d99b,1,2230
+235,003903,Waterbody,Artificial,3,90,Woody Wetlands,#BAD8EA,3,high,#31a354,1,2230
+236,003950,Waterbody,Artificial,3,95,Emergent Herbaceous Wetlands,#70A3BA,0,none,#ffffff,1,2230
+237,003951,Waterbody,Artificial,3,95,Emergent Herbaceous Wetlands,#70A3BA,1,low,#e5f5e0,1,2230
+238,003952,Waterbody,Artificial,3,95,Emergent Herbaceous Wetlands,#70A3BA,2,medium,#a1d99b,1,2230
+239,003953,Waterbody,Artificial,3,95,Emergent Herbaceous Wetlands,#70A3BA,3,high,#31a354,1,2230
+240,004110,Waterbody,Perennial Ice/Snow,4,11,Open Water,#476BA0,0,none,#ffffff,0,2230
+241,004111,Waterbody,Perennial Ice/Snow,4,11,Open Water,#476BA0,1,low,#e5f5e0,0,2230
+242,004112,Waterbody,Perennial Ice/Snow,4,11,Open Water,#476BA0,2,medium,#a1d99b,0,2230
+243,004113,Waterbody,Perennial Ice/Snow,4,11,Open Water,#476BA0,3,high,#31a354,1,2230
+244,004120,Waterbody,Perennial Ice/Snow,4,12,Perennial Ice/Snow,#D1DDF9,0,none,#ffffff,0,2230
+245,004121,Waterbody,Perennial Ice/Snow,4,12,Perennial Ice/Snow,#D1DDF9,1,low,#e5f5e0,0,2230
+246,004122,Waterbody,Perennial Ice/Snow,4,12,Perennial Ice/Snow,#D1DDF9,2,medium,#a1d99b,0,2230
+247,004123,Waterbody,Perennial Ice/Snow,4,12,Perennial Ice/Snow,#D1DDF9,3,high,#31a354,1,2230
+248,004210,Waterbody,Perennial Ice/Snow,4,21,"Developed, Open Space",#DDC9C9,0,none,#ffffff,0,2230
+249,004211,Waterbody,Perennial Ice/Snow,4,21,"Developed, Open Space",#DDC9C9,1,low,#e5f5e0,0,2230
+250,004212,Waterbody,Perennial Ice/Snow,4,21,"Developed, Open Space",#DDC9C9,2,medium,#a1d99b,0,2230
+251,004213,Waterbody,Perennial Ice/Snow,4,21,"Developed, Open Space",#DDC9C9,3,high,#31a354,1,2230
+252,004220,Waterbody,Perennial Ice/Snow,4,22,"Developed, Low Intensity",#D89382,0,none,#ffffff,0,2230
+253,004221,Waterbody,Perennial Ice/Snow,4,22,"Developed, Low Intensity",#D89382,1,low,#e5f5e0,0,2230
+254,004222,Waterbody,Perennial Ice/Snow,4,22,"Developed, Low Intensity",#D89382,2,medium,#a1d99b,0,2230
+255,004223,Waterbody,Perennial Ice/Snow,4,22,"Developed, Low Intensity",#D89382,3,high,#31a354,1,2230
+256,004230,Waterbody,Perennial Ice/Snow,4,23,"Developed, Medium Intensity",#ED0000,0,none,#ffffff,0,2230
+257,004231,Waterbody,Perennial Ice/Snow,4,23,"Developed, Medium Intensity",#ED0000,1,low,#e5f5e0,0,2230
+258,004232,Waterbody,Perennial Ice/Snow,4,23,"Developed, Medium Intensity",#ED0000,2,medium,#a1d99b,0,2230
+259,004233,Waterbody,Perennial Ice/Snow,4,23,"Developed, Medium Intensity",#ED0000,3,high,#31a354,1,2230
+260,004240,Waterbody,Perennial Ice/Snow,4,24,"Developed, High Intensity",#AA0000,0,none,#ffffff,0,2230
+261,004241,Waterbody,Perennial Ice/Snow,4,24,"Developed, High Intensity",#AA0000,1,low,#e5f5e0,0,2230
+262,004242,Waterbody,Perennial Ice/Snow,4,24,"Developed, High Intensity",#AA0000,2,medium,#a1d99b,0,2230
+263,004243,Waterbody,Perennial Ice/Snow,4,24,"Developed, High Intensity",#AA0000,3,high,#31a354,1,2230
+264,004310,Waterbody,Perennial Ice/Snow,4,31,Barren Land (Rock/Sand/Clay),#B2ADA3,0,none,#ffffff,0,2230
+265,004311,Waterbody,Perennial Ice/Snow,4,31,Barren Land (Rock/Sand/Clay),#B2ADA3,1,low,#e5f5e0,0,2230
+266,004312,Waterbody,Perennial Ice/Snow,4,31,Barren Land (Rock/Sand/Clay),#B2ADA3,2,medium,#a1d99b,0,2230
+267,004313,Waterbody,Perennial Ice/Snow,4,31,Barren Land (Rock/Sand/Clay),#B2ADA3,3,high,#31a354,1,2230
+268,004410,Waterbody,Perennial Ice/Snow,4,41,Deciduous Forest,#68AA63,0,none,#ffffff,1,2230
+269,004411,Waterbody,Perennial Ice/Snow,4,41,Deciduous Forest,#68AA63,1,low,#e5f5e0,1,2230
+270,004412,Waterbody,Perennial Ice/Snow,4,41,Deciduous Forest,#68AA63,2,medium,#a1d99b,1,2230
+271,004413,Waterbody,Perennial Ice/Snow,4,41,Deciduous Forest,#68AA63,3,high,#31a354,1,2230
+272,004420,Waterbody,Perennial Ice/Snow,4,42,Evergreen Forest,#1C6330,0,none,#ffffff,1,2230
+273,004421,Waterbody,Perennial Ice/Snow,4,42,Evergreen Forest,#1C6330,1,low,#e5f5e0,1,2230
+274,004422,Waterbody,Perennial Ice/Snow,4,42,Evergreen Forest,#1C6330,2,medium,#a1d99b,1,2230
+275,004423,Waterbody,Perennial Ice/Snow,4,42,Evergreen Forest,#1C6330,3,high,#31a354,1,2230
+276,004430,Waterbody,Perennial Ice/Snow,4,43,Mixed Forest,#B5C98E,0,none,#ffffff,1,2230
+277,004431,Waterbody,Perennial Ice/Snow,4,43,Mixed Forest,#B5C98E,1,low,#e5f5e0,1,2230
+278,004432,Waterbody,Perennial Ice/Snow,4,43,Mixed Forest,#B5C98E,2,medium,#a1d99b,1,2230
+279,004433,Waterbody,Perennial Ice/Snow,4,43,Mixed Forest,#B5C98E,3,high,#31a354,1,2230
+280,004510,Waterbody,Perennial Ice/Snow,4,51,Dwarf Scrub,#A58C30,0,none,#ffffff,0,
+281,004511,Waterbody,Perennial Ice/Snow,4,51,Dwarf Scrub,#A58C30,1,low,#e5f5e0,0,
+282,004512,Waterbody,Perennial Ice/Snow,4,51,Dwarf Scrub,#A58C30,2,medium,#a1d99b,0,
+283,004513,Waterbody,Perennial Ice/Snow,4,51,Dwarf Scrub,#A58C30,3,high,#31a354,1,
+284,004520,Waterbody,Perennial Ice/Snow,4,52,Scrub/Shrub,#CCBA7C,0,none,#ffffff,1,2230
+285,004521,Waterbody,Perennial Ice/Snow,4,52,Scrub/Shrub,#CCBA7C,1,low,#e5f5e0,1,2230
+286,004522,Waterbody,Perennial Ice/Snow,4,52,Scrub/Shrub,#CCBA7C,2,medium,#a1d99b,1,2230
+287,004523,Waterbody,Perennial Ice/Snow,4,52,Scrub/Shrub,#CCBA7C,3,high,#31a354,1,2230
+288,004710,Waterbody,Perennial Ice/Snow,4,71,Grassland/Herbaceous,#E2E2C1,0,none,#ffffff,1,2230
+289,004711,Waterbody,Perennial Ice/Snow,4,71,Grassland/Herbaceous,#E2E2C1,1,low,#e5f5e0,1,2230
+290,004712,Waterbody,Perennial Ice/Snow,4,71,Grassland/Herbaceous,#E2E2C1,2,medium,#a1d99b,1,2230
+291,004713,Waterbody,Perennial Ice/Snow,4,71,Grassland/Herbaceous,#E2E2C1,3,high,#31a354,1,2230
+292,004720,Waterbody,Perennial Ice/Snow,4,72,Sedge/Herbaceuous,#C9C977,0,none,#ffffff,0,
+293,004721,Waterbody,Perennial Ice/Snow,4,72,Sedge/Herbaceuous,#C9C977,1,low,#e5f5e0,0,
+294,004722,Waterbody,Perennial Ice/Snow,4,72,Sedge/Herbaceuous,#C9C977,2,medium,#a1d99b,0,
+295,004723,Waterbody,Perennial Ice/Snow,4,72,Sedge/Herbaceuous,#C9C977,3,high,#31a354,1,
+296,004730,Waterbody,Perennial Ice/Snow,4,73,Lichens,#99C147,0,none,#ffffff,0,
+297,004731,Waterbody,Perennial Ice/Snow,4,73,Lichens,#99C147,1,low,#e5f5e0,0,
+298,004732,Waterbody,Perennial Ice/Snow,4,73,Lichens,#99C147,2,medium,#a1d99b,0,
+299,004733,Waterbody,Perennial Ice/Snow,4,73,Lichens,#99C147,3,high,#31a354,1,
+300,004740,Waterbody,Perennial Ice/Snow,4,74,Moss,#77AD93,0,none,#ffffff,0,
+301,004741,Waterbody,Perennial Ice/Snow,4,74,Moss,#77AD93,1,low,#e5f5e0,0,
+302,004742,Waterbody,Perennial Ice/Snow,4,74,Moss,#77AD93,2,medium,#a1d99b,0,
+303,004743,Waterbody,Perennial Ice/Snow,4,74,Moss,#77AD93,3,high,#31a354,1,
+304,004810,Waterbody,Perennial Ice/Snow,4,81,Pasture/Hay,#DBD83D,0,none,#ffffff,0,2230
+305,004811,Waterbody,Perennial Ice/Snow,4,81,Pasture/Hay,#DBD83D,1,low,#e5f5e0,0,2230
+306,004812,Waterbody,Perennial Ice/Snow,4,81,Pasture/Hay,#DBD83D,2,medium,#a1d99b,0,2230
+307,004813,Waterbody,Perennial Ice/Snow,4,81,Pasture/Hay,#DBD83D,3,high,#31a354,1,2230
+308,004820,Waterbody,Perennial Ice/Snow,4,82,Cultivated Crops,#AA7028,0,none,#ffffff,0,2230
+309,004821,Waterbody,Perennial Ice/Snow,4,82,Cultivated Crops,#AA7028,1,low,#e5f5e0,0,2230
+310,004822,Waterbody,Perennial Ice/Snow,4,82,Cultivated Crops,#AA7028,2,medium,#a1d99b,0,2230
+311,004823,Waterbody,Perennial Ice/Snow,4,82,Cultivated Crops,#AA7028,3,high,#31a354,1,2230
+312,004900,Waterbody,Perennial Ice/Snow,4,90,Woody Wetlands,#BAD8EA,0,none,#ffffff,1,2230
+313,004901,Waterbody,Perennial Ice/Snow,4,90,Woody Wetlands,#BAD8EA,1,low,#e5f5e0,1,2230
+314,004902,Waterbody,Perennial Ice/Snow,4,90,Woody Wetlands,#BAD8EA,2,medium,#a1d99b,1,2230
+315,004903,Waterbody,Perennial Ice/Snow,4,90,Woody Wetlands,#BAD8EA,3,high,#31a354,1,2230
+316,004950,Waterbody,Perennial Ice/Snow,4,95,Emergent Herbaceous Wetlands,#70A3BA,0,none,#ffffff,1,2230
+317,004951,Waterbody,Perennial Ice/Snow,4,95,Emergent Herbaceous Wetlands,#70A3BA,1,low,#e5f5e0,1,2230
+318,004952,Waterbody,Perennial Ice/Snow,4,95,Emergent Herbaceous Wetlands,#70A3BA,2,medium,#a1d99b,1,2230
+319,004953,Waterbody,Perennial Ice/Snow,4,95,Emergent Herbaceous Wetlands,#70A3BA,3,high,#31a354,1,2230
+320,011110,Residential,Dense urban,11,11,Open Water,#476BA0,0,none,#ffffff,0,2230
+321,011111,Residential,Dense urban,11,11,Open Water,#476BA0,1,low,#e5f5e0,0,2230
+322,011112,Residential,Dense urban,11,11,Open Water,#476BA0,2,medium,#a1d99b,0,2230
+323,011113,Residential,Dense urban,11,11,Open Water,#476BA0,3,high,#31a354,1,2230
+324,011120,Residential,Dense urban,11,12,Perennial Ice/Snow,#D1DDF9,0,none,#ffffff,0,2230
+325,011121,Residential,Dense urban,11,12,Perennial Ice/Snow,#D1DDF9,1,low,#e5f5e0,0,2230
+326,011122,Residential,Dense urban,11,12,Perennial Ice/Snow,#D1DDF9,2,medium,#a1d99b,0,2230
+327,011123,Residential,Dense urban,11,12,Perennial Ice/Snow,#D1DDF9,3,high,#31a354,1,2230
+328,011210,Residential,Dense urban,11,21,"Developed, Open Space",#DDC9C9,0,none,#ffffff,0,2230
+329,011211,Residential,Dense urban,11,21,"Developed, Open Space",#DDC9C9,1,low,#e5f5e0,0,2230
+330,011212,Residential,Dense urban,11,21,"Developed, Open Space",#DDC9C9,2,medium,#a1d99b,0,2230
+331,011213,Residential,Dense urban,11,21,"Developed, Open Space",#DDC9C9,3,high,#31a354,1,2230
+332,011220,Residential,Dense urban,11,22,"Developed, Low Intensity",#D89382,0,none,#ffffff,0,2230
+333,011221,Residential,Dense urban,11,22,"Developed, Low Intensity",#D89382,1,low,#e5f5e0,0,2230
+334,011222,Residential,Dense urban,11,22,"Developed, Low Intensity",#D89382,2,medium,#a1d99b,0,2230
+335,011223,Residential,Dense urban,11,22,"Developed, Low Intensity",#D89382,3,high,#31a354,1,2230
+336,011230,Residential,Dense urban,11,23,"Developed, Medium Intensity",#ED0000,0,none,#ffffff,0,2230
+337,011231,Residential,Dense urban,11,23,"Developed, Medium Intensity",#ED0000,1,low,#e5f5e0,0,2230
+338,011232,Residential,Dense urban,11,23,"Developed, Medium Intensity",#ED0000,2,medium,#a1d99b,0,2230
+339,011233,Residential,Dense urban,11,23,"Developed, Medium Intensity",#ED0000,3,high,#31a354,1,2230
+340,011240,Residential,Dense urban,11,24,"Developed, High Intensity",#AA0000,0,none,#ffffff,0,2230
+341,011241,Residential,Dense urban,11,24,"Developed, High Intensity",#AA0000,1,low,#e5f5e0,0,2230
+342,011242,Residential,Dense urban,11,24,"Developed, High Intensity",#AA0000,2,medium,#a1d99b,0,2230
+343,011243,Residential,Dense urban,11,24,"Developed, High Intensity",#AA0000,3,high,#31a354,1,2230
+344,011310,Residential,Dense urban,11,31,Barren Land (Rock/Sand/Clay),#B2ADA3,0,none,#ffffff,0,2230
+345,011311,Residential,Dense urban,11,31,Barren Land (Rock/Sand/Clay),#B2ADA3,1,low,#e5f5e0,0,2230
+346,011312,Residential,Dense urban,11,31,Barren Land (Rock/Sand/Clay),#B2ADA3,2,medium,#a1d99b,0,2230
+347,011313,Residential,Dense urban,11,31,Barren Land (Rock/Sand/Clay),#B2ADA3,3,high,#31a354,1,2230
+348,011410,Residential,Dense urban,11,41,Deciduous Forest,#68AA63,0,none,#ffffff,1,2230
+349,011411,Residential,Dense urban,11,41,Deciduous Forest,#68AA63,1,low,#e5f5e0,1,2230
+350,011412,Residential,Dense urban,11,41,Deciduous Forest,#68AA63,2,medium,#a1d99b,1,2230
+351,011413,Residential,Dense urban,11,41,Deciduous Forest,#68AA63,3,high,#31a354,1,2230
+352,011420,Residential,Dense urban,11,42,Evergreen Forest,#1C6330,0,none,#ffffff,1,2230
+353,011421,Residential,Dense urban,11,42,Evergreen Forest,#1C6330,1,low,#e5f5e0,1,2230
+354,011422,Residential,Dense urban,11,42,Evergreen Forest,#1C6330,2,medium,#a1d99b,1,2230
+355,011423,Residential,Dense urban,11,42,Evergreen Forest,#1C6330,3,high,#31a354,1,2230
+356,011430,Residential,Dense urban,11,43,Mixed Forest,#B5C98E,0,none,#ffffff,1,2230
+357,011431,Residential,Dense urban,11,43,Mixed Forest,#B5C98E,1,low,#e5f5e0,1,2230
+358,011432,Residential,Dense urban,11,43,Mixed Forest,#B5C98E,2,medium,#a1d99b,1,2230
+359,011433,Residential,Dense urban,11,43,Mixed Forest,#B5C98E,3,high,#31a354,1,2230
+360,011510,Residential,Dense urban,11,51,Dwarf Scrub,#A58C30,0,none,#ffffff,0,
+361,011511,Residential,Dense urban,11,51,Dwarf Scrub,#A58C30,1,low,#e5f5e0,0,
+362,011512,Residential,Dense urban,11,51,Dwarf Scrub,#A58C30,2,medium,#a1d99b,0,
+363,011513,Residential,Dense urban,11,51,Dwarf Scrub,#A58C30,3,high,#31a354,1,
+364,011520,Residential,Dense urban,11,52,Scrub/Shrub,#CCBA7C,0,none,#ffffff,1,2230
+365,011521,Residential,Dense urban,11,52,Scrub/Shrub,#CCBA7C,1,low,#e5f5e0,1,2230
+366,011522,Residential,Dense urban,11,52,Scrub/Shrub,#CCBA7C,2,medium,#a1d99b,1,2230
+367,011523,Residential,Dense urban,11,52,Scrub/Shrub,#CCBA7C,3,high,#31a354,1,2230
+368,011710,Residential,Dense urban,11,71,Grassland/Herbaceous,#E2E2C1,0,none,#ffffff,1,2230
+369,011711,Residential,Dense urban,11,71,Grassland/Herbaceous,#E2E2C1,1,low,#e5f5e0,1,2230
+370,011712,Residential,Dense urban,11,71,Grassland/Herbaceous,#E2E2C1,2,medium,#a1d99b,1,2230
+371,011713,Residential,Dense urban,11,71,Grassland/Herbaceous,#E2E2C1,3,high,#31a354,1,2230
+372,011720,Residential,Dense urban,11,72,Sedge/Herbaceuous,#C9C977,0,none,#ffffff,0,
+373,011721,Residential,Dense urban,11,72,Sedge/Herbaceuous,#C9C977,1,low,#e5f5e0,0,
+374,011722,Residential,Dense urban,11,72,Sedge/Herbaceuous,#C9C977,2,medium,#a1d99b,0,
+375,011723,Residential,Dense urban,11,72,Sedge/Herbaceuous,#C9C977,3,high,#31a354,1,
+376,011730,Residential,Dense urban,11,73,Lichens,#99C147,0,none,#ffffff,0,
+377,011731,Residential,Dense urban,11,73,Lichens,#99C147,1,low,#e5f5e0,0,
+378,011732,Residential,Dense urban,11,73,Lichens,#99C147,2,medium,#a1d99b,0,
+379,011733,Residential,Dense urban,11,73,Lichens,#99C147,3,high,#31a354,1,
+380,011740,Residential,Dense urban,11,74,Moss,#77AD93,0,none,#ffffff,0,
+381,011741,Residential,Dense urban,11,74,Moss,#77AD93,1,low,#e5f5e0,0,
+382,011742,Residential,Dense urban,11,74,Moss,#77AD93,2,medium,#a1d99b,0,
+383,011743,Residential,Dense urban,11,74,Moss,#77AD93,3,high,#31a354,1,
+384,011810,Residential,Dense urban,11,81,Pasture/Hay,#DBD83D,0,none,#ffffff,0,2230
+385,011811,Residential,Dense urban,11,81,Pasture/Hay,#DBD83D,1,low,#e5f5e0,0,2230
+386,011812,Residential,Dense urban,11,81,Pasture/Hay,#DBD83D,2,medium,#a1d99b,0,2230
+387,011813,Residential,Dense urban,11,81,Pasture/Hay,#DBD83D,3,high,#31a354,1,2230
+388,011820,Residential,Dense urban,11,82,Cultivated Crops,#AA7028,0,none,#ffffff,0,2230
+389,011821,Residential,Dense urban,11,82,Cultivated Crops,#AA7028,1,low,#e5f5e0,0,2230
+390,011822,Residential,Dense urban,11,82,Cultivated Crops,#AA7028,2,medium,#a1d99b,0,2230
+391,011823,Residential,Dense urban,11,82,Cultivated Crops,#AA7028,3,high,#31a354,1,2230
+392,011900,Residential,Dense urban,11,90,Woody Wetlands,#BAD8EA,0,none,#ffffff,1,2230
+393,011901,Residential,Dense urban,11,90,Woody Wetlands,#BAD8EA,1,low,#e5f5e0,1,2230
+394,011902,Residential,Dense urban,11,90,Woody Wetlands,#BAD8EA,2,medium,#a1d99b,1,2230
+395,011903,Residential,Dense urban,11,90,Woody Wetlands,#BAD8EA,3,high,#31a354,1,2230
+396,011950,Residential,Dense urban,11,95,Emergent Herbaceous Wetlands,#70A3BA,0,none,#ffffff,1,2230
+397,011951,Residential,Dense urban,11,95,Emergent Herbaceous Wetlands,#70A3BA,1,low,#e5f5e0,1,2230
+398,011952,Residential,Dense urban,11,95,Emergent Herbaceous Wetlands,#70A3BA,2,medium,#a1d99b,1,2230
+399,011953,Residential,Dense urban,11,95,Emergent Herbaceous Wetlands,#70A3BA,3,high,#31a354,1,2230
+400,012110,Residential,Urban,12,11,Open Water,#476BA0,0,none,#ffffff,0,2230
+401,012111,Residential,Urban,12,11,Open Water,#476BA0,1,low,#e5f5e0,0,2230
+402,012112,Residential,Urban,12,11,Open Water,#476BA0,2,medium,#a1d99b,0,2230
+403,012113,Residential,Urban,12,11,Open Water,#476BA0,3,high,#31a354,1,2230
+404,012120,Residential,Urban,12,12,Perennial Ice/Snow,#D1DDF9,0,none,#ffffff,0,2230
+405,012121,Residential,Urban,12,12,Perennial Ice/Snow,#D1DDF9,1,low,#e5f5e0,0,2230
+406,012122,Residential,Urban,12,12,Perennial Ice/Snow,#D1DDF9,2,medium,#a1d99b,0,2230
+407,012123,Residential,Urban,12,12,Perennial Ice/Snow,#D1DDF9,3,high,#31a354,1,2230
+408,012210,Residential,Urban,12,21,"Developed, Open Space",#DDC9C9,0,none,#ffffff,0,2230
+409,012211,Residential,Urban,12,21,"Developed, Open Space",#DDC9C9,1,low,#e5f5e0,0,2230
+410,012212,Residential,Urban,12,21,"Developed, Open Space",#DDC9C9,2,medium,#a1d99b,0,2230
+411,012213,Residential,Urban,12,21,"Developed, Open Space",#DDC9C9,3,high,#31a354,1,2230
+412,012220,Residential,Urban,12,22,"Developed, Low Intensity",#D89382,0,none,#ffffff,0,2230
+413,012221,Residential,Urban,12,22,"Developed, Low Intensity",#D89382,1,low,#e5f5e0,0,2230
+414,012222,Residential,Urban,12,22,"Developed, Low Intensity",#D89382,2,medium,#a1d99b,0,2230
+415,012223,Residential,Urban,12,22,"Developed, Low Intensity",#D89382,3,high,#31a354,1,2230
+416,012230,Residential,Urban,12,23,"Developed, Medium Intensity",#ED0000,0,none,#ffffff,0,2230
+417,012231,Residential,Urban,12,23,"Developed, Medium Intensity",#ED0000,1,low,#e5f5e0,0,2230
+418,012232,Residential,Urban,12,23,"Developed, Medium Intensity",#ED0000,2,medium,#a1d99b,0,2230
+419,012233,Residential,Urban,12,23,"Developed, Medium Intensity",#ED0000,3,high,#31a354,1,2230
+420,012240,Residential,Urban,12,24,"Developed, High Intensity",#AA0000,0,none,#ffffff,0,2230
+421,012241,Residential,Urban,12,24,"Developed, High Intensity",#AA0000,1,low,#e5f5e0,0,2230
+422,012242,Residential,Urban,12,24,"Developed, High Intensity",#AA0000,2,medium,#a1d99b,0,2230
+423,012243,Residential,Urban,12,24,"Developed, High Intensity",#AA0000,3,high,#31a354,1,2230
+424,012310,Residential,Urban,12,31,Barren Land (Rock/Sand/Clay),#B2ADA3,0,none,#ffffff,0,2230
+425,012311,Residential,Urban,12,31,Barren Land (Rock/Sand/Clay),#B2ADA3,1,low,#e5f5e0,0,2230
+426,012312,Residential,Urban,12,31,Barren Land (Rock/Sand/Clay),#B2ADA3,2,medium,#a1d99b,0,2230
+427,012313,Residential,Urban,12,31,Barren Land (Rock/Sand/Clay),#B2ADA3,3,high,#31a354,1,2230
+428,012410,Residential,Urban,12,41,Deciduous Forest,#68AA63,0,none,#ffffff,1,2230
+429,012411,Residential,Urban,12,41,Deciduous Forest,#68AA63,1,low,#e5f5e0,1,2230
+430,012412,Residential,Urban,12,41,Deciduous Forest,#68AA63,2,medium,#a1d99b,1,2230
+431,012413,Residential,Urban,12,41,Deciduous Forest,#68AA63,3,high,#31a354,1,2230
+432,012420,Residential,Urban,12,42,Evergreen Forest,#1C6330,0,none,#ffffff,1,2230
+433,012421,Residential,Urban,12,42,Evergreen Forest,#1C6330,1,low,#e5f5e0,1,2230
+434,012422,Residential,Urban,12,42,Evergreen Forest,#1C6330,2,medium,#a1d99b,1,2230
+435,012423,Residential,Urban,12,42,Evergreen Forest,#1C6330,3,high,#31a354,1,2230
+436,012430,Residential,Urban,12,43,Mixed Forest,#B5C98E,0,none,#ffffff,1,2230
+437,012431,Residential,Urban,12,43,Mixed Forest,#B5C98E,1,low,#e5f5e0,1,2230
+438,012432,Residential,Urban,12,43,Mixed Forest,#B5C98E,2,medium,#a1d99b,1,2230
+439,012433,Residential,Urban,12,43,Mixed Forest,#B5C98E,3,high,#31a354,1,2230
+440,012510,Residential,Urban,12,51,Dwarf Scrub,#A58C30,0,none,#ffffff,0,
+441,012511,Residential,Urban,12,51,Dwarf Scrub,#A58C30,1,low,#e5f5e0,0,
+442,012512,Residential,Urban,12,51,Dwarf Scrub,#A58C30,2,medium,#a1d99b,0,
+443,012513,Residential,Urban,12,51,Dwarf Scrub,#A58C30,3,high,#31a354,1,
+444,012520,Residential,Urban,12,52,Scrub/Shrub,#CCBA7C,0,none,#ffffff,1,2230
+445,012521,Residential,Urban,12,52,Scrub/Shrub,#CCBA7C,1,low,#e5f5e0,1,2230
+446,012522,Residential,Urban,12,52,Scrub/Shrub,#CCBA7C,2,medium,#a1d99b,1,2230
+447,012523,Residential,Urban,12,52,Scrub/Shrub,#CCBA7C,3,high,#31a354,1,2230
+448,012710,Residential,Urban,12,71,Grassland/Herbaceous,#E2E2C1,0,none,#ffffff,1,2230
+449,012711,Residential,Urban,12,71,Grassland/Herbaceous,#E2E2C1,1,low,#e5f5e0,1,2230
+450,012712,Residential,Urban,12,71,Grassland/Herbaceous,#E2E2C1,2,medium,#a1d99b,1,2230
+451,012713,Residential,Urban,12,71,Grassland/Herbaceous,#E2E2C1,3,high,#31a354,1,2230
+452,012720,Residential,Urban,12,72,Sedge/Herbaceuous,#C9C977,0,none,#ffffff,0,
+453,012721,Residential,Urban,12,72,Sedge/Herbaceuous,#C9C977,1,low,#e5f5e0,0,
+454,012722,Residential,Urban,12,72,Sedge/Herbaceuous,#C9C977,2,medium,#a1d99b,0,
+455,012723,Residential,Urban,12,72,Sedge/Herbaceuous,#C9C977,3,high,#31a354,1,
+456,012730,Residential,Urban,12,73,Lichens,#99C147,0,none,#ffffff,0,
+457,012731,Residential,Urban,12,73,Lichens,#99C147,1,low,#e5f5e0,0,
+458,012732,Residential,Urban,12,73,Lichens,#99C147,2,medium,#a1d99b,0,
+459,012733,Residential,Urban,12,73,Lichens,#99C147,3,high,#31a354,1,
+460,012740,Residential,Urban,12,74,Moss,#77AD93,0,none,#ffffff,0,
+461,012741,Residential,Urban,12,74,Moss,#77AD93,1,low,#e5f5e0,0,
+462,012742,Residential,Urban,12,74,Moss,#77AD93,2,medium,#a1d99b,0,
+463,012743,Residential,Urban,12,74,Moss,#77AD93,3,high,#31a354,1,
+464,012810,Residential,Urban,12,81,Pasture/Hay,#DBD83D,0,none,#ffffff,0,2230
+465,012811,Residential,Urban,12,81,Pasture/Hay,#DBD83D,1,low,#e5f5e0,0,2230
+466,012812,Residential,Urban,12,81,Pasture/Hay,#DBD83D,2,medium,#a1d99b,0,2230
+467,012813,Residential,Urban,12,81,Pasture/Hay,#DBD83D,3,high,#31a354,1,2230
+468,012820,Residential,Urban,12,82,Cultivated Crops,#AA7028,0,none,#ffffff,0,2230
+469,012821,Residential,Urban,12,82,Cultivated Crops,#AA7028,1,low,#e5f5e0,0,2230
+470,012822,Residential,Urban,12,82,Cultivated Crops,#AA7028,2,medium,#a1d99b,0,2230
+471,012823,Residential,Urban,12,82,Cultivated Crops,#AA7028,3,high,#31a354,1,2230
+472,012900,Residential,Urban,12,90,Woody Wetlands,#BAD8EA,0,none,#ffffff,1,2230
+473,012901,Residential,Urban,12,90,Woody Wetlands,#BAD8EA,1,low,#e5f5e0,1,2230
+474,012902,Residential,Urban,12,90,Woody Wetlands,#BAD8EA,2,medium,#a1d99b,1,2230
+475,012903,Residential,Urban,12,90,Woody Wetlands,#BAD8EA,3,high,#31a354,1,2230
+476,012950,Residential,Urban,12,95,Emergent Herbaceous Wetlands,#70A3BA,0,none,#ffffff,1,2230
+477,012951,Residential,Urban,12,95,Emergent Herbaceous Wetlands,#70A3BA,1,low,#e5f5e0,1,2230
+478,012952,Residential,Urban,12,95,Emergent Herbaceous Wetlands,#70A3BA,2,medium,#a1d99b,1,2230
+479,012953,Residential,Urban,12,95,Emergent Herbaceous Wetlands,#70A3BA,3,high,#31a354,1,2230
+480,013110,Residential,Suburban,13,11,Open Water,#476BA0,0,none,#ffffff,0,2230
+481,013111,Residential,Suburban,13,11,Open Water,#476BA0,1,low,#e5f5e0,0,2230
+482,013112,Residential,Suburban,13,11,Open Water,#476BA0,2,medium,#a1d99b,0,2230
+483,013113,Residential,Suburban,13,11,Open Water,#476BA0,3,high,#31a354,1,2230
+484,013120,Residential,Suburban,13,12,Perennial Ice/Snow,#D1DDF9,0,none,#ffffff,0,2230
+485,013121,Residential,Suburban,13,12,Perennial Ice/Snow,#D1DDF9,1,low,#e5f5e0,0,2230
+486,013122,Residential,Suburban,13,12,Perennial Ice/Snow,#D1DDF9,2,medium,#a1d99b,0,2230
+487,013123,Residential,Suburban,13,12,Perennial Ice/Snow,#D1DDF9,3,high,#31a354,1,2230
+488,013210,Residential,Suburban,13,21,"Developed, Open Space",#DDC9C9,0,none,#ffffff,0,2230
+489,013211,Residential,Suburban,13,21,"Developed, Open Space",#DDC9C9,1,low,#e5f5e0,0,2230
+490,013212,Residential,Suburban,13,21,"Developed, Open Space",#DDC9C9,2,medium,#a1d99b,0,2230
+491,013213,Residential,Suburban,13,21,"Developed, Open Space",#DDC9C9,3,high,#31a354,1,2230
+492,013220,Residential,Suburban,13,22,"Developed, Low Intensity",#D89382,0,none,#ffffff,0,2230
+493,013221,Residential,Suburban,13,22,"Developed, Low Intensity",#D89382,1,low,#e5f5e0,0,2230
+494,013222,Residential,Suburban,13,22,"Developed, Low Intensity",#D89382,2,medium,#a1d99b,0,2230
+495,013223,Residential,Suburban,13,22,"Developed, Low Intensity",#D89382,3,high,#31a354,1,2230
+496,013230,Residential,Suburban,13,23,"Developed, Medium Intensity",#ED0000,0,none,#ffffff,0,2230
+497,013231,Residential,Suburban,13,23,"Developed, Medium Intensity",#ED0000,1,low,#e5f5e0,0,2230
+498,013232,Residential,Suburban,13,23,"Developed, Medium Intensity",#ED0000,2,medium,#a1d99b,0,2230
+499,013233,Residential,Suburban,13,23,"Developed, Medium Intensity",#ED0000,3,high,#31a354,1,2230
+500,013240,Residential,Suburban,13,24,"Developed, High Intensity",#AA0000,0,none,#ffffff,0,2230
+501,013241,Residential,Suburban,13,24,"Developed, High Intensity",#AA0000,1,low,#e5f5e0,0,2230
+502,013242,Residential,Suburban,13,24,"Developed, High Intensity",#AA0000,2,medium,#a1d99b,0,2230
+503,013243,Residential,Suburban,13,24,"Developed, High Intensity",#AA0000,3,high,#31a354,1,2230
+504,013310,Residential,Suburban,13,31,Barren Land (Rock/Sand/Clay),#B2ADA3,0,none,#ffffff,0,2230
+505,013311,Residential,Suburban,13,31,Barren Land (Rock/Sand/Clay),#B2ADA3,1,low,#e5f5e0,0,2230
+506,013312,Residential,Suburban,13,31,Barren Land (Rock/Sand/Clay),#B2ADA3,2,medium,#a1d99b,0,2230
+507,013313,Residential,Suburban,13,31,Barren Land (Rock/Sand/Clay),#B2ADA3,3,high,#31a354,1,2230
+508,013410,Residential,Suburban,13,41,Deciduous Forest,#68AA63,0,none,#ffffff,1,2230
+509,013411,Residential,Suburban,13,41,Deciduous Forest,#68AA63,1,low,#e5f5e0,1,2230
+510,013412,Residential,Suburban,13,41,Deciduous Forest,#68AA63,2,medium,#a1d99b,1,2230
+511,013413,Residential,Suburban,13,41,Deciduous Forest,#68AA63,3,high,#31a354,1,2230
+512,013420,Residential,Suburban,13,42,Evergreen Forest,#1C6330,0,none,#ffffff,1,2230
+513,013421,Residential,Suburban,13,42,Evergreen Forest,#1C6330,1,low,#e5f5e0,1,2230
+514,013422,Residential,Suburban,13,42,Evergreen Forest,#1C6330,2,medium,#a1d99b,1,2230
+515,013423,Residential,Suburban,13,42,Evergreen Forest,#1C6330,3,high,#31a354,1,2230
+516,013430,Residential,Suburban,13,43,Mixed Forest,#B5C98E,0,none,#ffffff,1,2230
+517,013431,Residential,Suburban,13,43,Mixed Forest,#B5C98E,1,low,#e5f5e0,1,2230
+518,013432,Residential,Suburban,13,43,Mixed Forest,#B5C98E,2,medium,#a1d99b,1,2230
+519,013433,Residential,Suburban,13,43,Mixed Forest,#B5C98E,3,high,#31a354,1,2230
+520,013510,Residential,Suburban,13,51,Dwarf Scrub,#A58C30,0,none,#ffffff,0,
+521,013511,Residential,Suburban,13,51,Dwarf Scrub,#A58C30,1,low,#e5f5e0,0,
+522,013512,Residential,Suburban,13,51,Dwarf Scrub,#A58C30,2,medium,#a1d99b,0,
+523,013513,Residential,Suburban,13,51,Dwarf Scrub,#A58C30,3,high,#31a354,1,
+524,013520,Residential,Suburban,13,52,Scrub/Shrub,#CCBA7C,0,none,#ffffff,1,2230
+525,013521,Residential,Suburban,13,52,Scrub/Shrub,#CCBA7C,1,low,#e5f5e0,1,2230
+526,013522,Residential,Suburban,13,52,Scrub/Shrub,#CCBA7C,2,medium,#a1d99b,1,2230
+527,013523,Residential,Suburban,13,52,Scrub/Shrub,#CCBA7C,3,high,#31a354,1,2230
+528,013710,Residential,Suburban,13,71,Grassland/Herbaceous,#E2E2C1,0,none,#ffffff,1,2230
+529,013711,Residential,Suburban,13,71,Grassland/Herbaceous,#E2E2C1,1,low,#e5f5e0,1,2230
+530,013712,Residential,Suburban,13,71,Grassland/Herbaceous,#E2E2C1,2,medium,#a1d99b,1,2230
+531,013713,Residential,Suburban,13,71,Grassland/Herbaceous,#E2E2C1,3,high,#31a354,1,2230
+532,013720,Residential,Suburban,13,72,Sedge/Herbaceuous,#C9C977,0,none,#ffffff,0,
+533,013721,Residential,Suburban,13,72,Sedge/Herbaceuous,#C9C977,1,low,#e5f5e0,0,
+534,013722,Residential,Suburban,13,72,Sedge/Herbaceuous,#C9C977,2,medium,#a1d99b,0,
+535,013723,Residential,Suburban,13,72,Sedge/Herbaceuous,#C9C977,3,high,#31a354,1,
+536,013730,Residential,Suburban,13,73,Lichens,#99C147,0,none,#ffffff,0,
+537,013731,Residential,Suburban,13,73,Lichens,#99C147,1,low,#e5f5e0,0,
+538,013732,Residential,Suburban,13,73,Lichens,#99C147,2,medium,#a1d99b,0,
+539,013733,Residential,Suburban,13,73,Lichens,#99C147,3,high,#31a354,1,
+540,013740,Residential,Suburban,13,74,Moss,#77AD93,0,none,#ffffff,0,
+541,013741,Residential,Suburban,13,74,Moss,#77AD93,1,low,#e5f5e0,0,
+542,013742,Residential,Suburban,13,74,Moss,#77AD93,2,medium,#a1d99b,0,
+543,013743,Residential,Suburban,13,74,Moss,#77AD93,3,high,#31a354,1,
+544,013810,Residential,Suburban,13,81,Pasture/Hay,#DBD83D,0,none,#ffffff,0,2230
+545,013811,Residential,Suburban,13,81,Pasture/Hay,#DBD83D,1,low,#e5f5e0,0,2230
+546,013812,Residential,Suburban,13,81,Pasture/Hay,#DBD83D,2,medium,#a1d99b,0,2230
+547,013813,Residential,Suburban,13,81,Pasture/Hay,#DBD83D,3,high,#31a354,1,2230
+548,013820,Residential,Suburban,13,82,Cultivated Crops,#AA7028,0,none,#ffffff,0,2230
+549,013821,Residential,Suburban,13,82,Cultivated Crops,#AA7028,1,low,#e5f5e0,0,2230
+550,013822,Residential,Suburban,13,82,Cultivated Crops,#AA7028,2,medium,#a1d99b,0,2230
+551,013823,Residential,Suburban,13,82,Cultivated Crops,#AA7028,3,high,#31a354,1,2230
+552,013900,Residential,Suburban,13,90,Woody Wetlands,#BAD8EA,0,none,#ffffff,1,2230
+553,013901,Residential,Suburban,13,90,Woody Wetlands,#BAD8EA,1,low,#e5f5e0,1,2230
+554,013902,Residential,Suburban,13,90,Woody Wetlands,#BAD8EA,2,medium,#a1d99b,1,2230
+555,013903,Residential,Suburban,13,90,Woody Wetlands,#BAD8EA,3,high,#31a354,1,2230
+556,013950,Residential,Suburban,13,95,Emergent Herbaceous Wetlands,#70A3BA,0,none,#ffffff,1,2230
+557,013951,Residential,Suburban,13,95,Emergent Herbaceous Wetlands,#70A3BA,1,low,#e5f5e0,1,2230
+558,013952,Residential,Suburban,13,95,Emergent Herbaceous Wetlands,#70A3BA,2,medium,#a1d99b,1,2230
+559,013953,Residential,Suburban,13,95,Emergent Herbaceous Wetlands,#70A3BA,3,high,#31a354,1,2230
+560,014110,Residential,Exurban,14,11,Open Water,#476BA0,0,none,#ffffff,0,2230
+561,014111,Residential,Exurban,14,11,Open Water,#476BA0,1,low,#e5f5e0,0,2230
+562,014112,Residential,Exurban,14,11,Open Water,#476BA0,2,medium,#a1d99b,0,2230
+563,014113,Residential,Exurban,14,11,Open Water,#476BA0,3,high,#31a354,1,2230
+564,014120,Residential,Exurban,14,12,Perennial Ice/Snow,#D1DDF9,0,none,#ffffff,0,2230
+565,014121,Residential,Exurban,14,12,Perennial Ice/Snow,#D1DDF9,1,low,#e5f5e0,0,2230
+566,014122,Residential,Exurban,14,12,Perennial Ice/Snow,#D1DDF9,2,medium,#a1d99b,0,2230
+567,014123,Residential,Exurban,14,12,Perennial Ice/Snow,#D1DDF9,3,high,#31a354,1,2230
+568,014210,Residential,Exurban,14,21,"Developed, Open Space",#DDC9C9,0,none,#ffffff,0,2230
+569,014211,Residential,Exurban,14,21,"Developed, Open Space",#DDC9C9,1,low,#e5f5e0,0,2230
+570,014212,Residential,Exurban,14,21,"Developed, Open Space",#DDC9C9,2,medium,#a1d99b,0,2230
+571,014213,Residential,Exurban,14,21,"Developed, Open Space",#DDC9C9,3,high,#31a354,1,2230
+572,014220,Residential,Exurban,14,22,"Developed, Low Intensity",#D89382,0,none,#ffffff,0,2230
+573,014221,Residential,Exurban,14,22,"Developed, Low Intensity",#D89382,1,low,#e5f5e0,0,2230
+574,014222,Residential,Exurban,14,22,"Developed, Low Intensity",#D89382,2,medium,#a1d99b,0,2230
+575,014223,Residential,Exurban,14,22,"Developed, Low Intensity",#D89382,3,high,#31a354,1,2230
+576,014230,Residential,Exurban,14,23,"Developed, Medium Intensity",#ED0000,0,none,#ffffff,0,2230
+577,014231,Residential,Exurban,14,23,"Developed, Medium Intensity",#ED0000,1,low,#e5f5e0,0,2230
+578,014232,Residential,Exurban,14,23,"Developed, Medium Intensity",#ED0000,2,medium,#a1d99b,0,2230
+579,014233,Residential,Exurban,14,23,"Developed, Medium Intensity",#ED0000,3,high,#31a354,1,2230
+580,014240,Residential,Exurban,14,24,"Developed, High Intensity",#AA0000,0,none,#ffffff,0,2230
+581,014241,Residential,Exurban,14,24,"Developed, High Intensity",#AA0000,1,low,#e5f5e0,0,2230
+582,014242,Residential,Exurban,14,24,"Developed, High Intensity",#AA0000,2,medium,#a1d99b,0,2230
+583,014243,Residential,Exurban,14,24,"Developed, High Intensity",#AA0000,3,high,#31a354,1,2230
+584,014310,Residential,Exurban,14,31,Barren Land (Rock/Sand/Clay),#B2ADA3,0,none,#ffffff,0,2230
+585,014311,Residential,Exurban,14,31,Barren Land (Rock/Sand/Clay),#B2ADA3,1,low,#e5f5e0,0,2230
+586,014312,Residential,Exurban,14,31,Barren Land (Rock/Sand/Clay),#B2ADA3,2,medium,#a1d99b,0,2230
+587,014313,Residential,Exurban,14,31,Barren Land (Rock/Sand/Clay),#B2ADA3,3,high,#31a354,1,2230
+588,014410,Residential,Exurban,14,41,Deciduous Forest,#68AA63,0,none,#ffffff,1,2230
+589,014411,Residential,Exurban,14,41,Deciduous Forest,#68AA63,1,low,#e5f5e0,1,2230
+590,014412,Residential,Exurban,14,41,Deciduous Forest,#68AA63,2,medium,#a1d99b,1,2230
+591,014413,Residential,Exurban,14,41,Deciduous Forest,#68AA63,3,high,#31a354,1,2230
+592,014420,Residential,Exurban,14,42,Evergreen Forest,#1C6330,0,none,#ffffff,1,2230
+593,014421,Residential,Exurban,14,42,Evergreen Forest,#1C6330,1,low,#e5f5e0,1,2230
+594,014422,Residential,Exurban,14,42,Evergreen Forest,#1C6330,2,medium,#a1d99b,1,2230
+595,014423,Residential,Exurban,14,42,Evergreen Forest,#1C6330,3,high,#31a354,1,2230
+596,014430,Residential,Exurban,14,43,Mixed Forest,#B5C98E,0,none,#ffffff,1,2230
+597,014431,Residential,Exurban,14,43,Mixed Forest,#B5C98E,1,low,#e5f5e0,1,2230
+598,014432,Residential,Exurban,14,43,Mixed Forest,#B5C98E,2,medium,#a1d99b,1,2230
+599,014433,Residential,Exurban,14,43,Mixed Forest,#B5C98E,3,high,#31a354,1,2230
+600,014510,Residential,Exurban,14,51,Dwarf Scrub,#A58C30,0,none,#ffffff,0,
+601,014511,Residential,Exurban,14,51,Dwarf Scrub,#A58C30,1,low,#e5f5e0,0,
+602,014512,Residential,Exurban,14,51,Dwarf Scrub,#A58C30,2,medium,#a1d99b,0,
+603,014513,Residential,Exurban,14,51,Dwarf Scrub,#A58C30,3,high,#31a354,1,
+604,014520,Residential,Exurban,14,52,Scrub/Shrub,#CCBA7C,0,none,#ffffff,1,2230
+605,014521,Residential,Exurban,14,52,Scrub/Shrub,#CCBA7C,1,low,#e5f5e0,1,2230
+606,014522,Residential,Exurban,14,52,Scrub/Shrub,#CCBA7C,2,medium,#a1d99b,1,2230
+607,014523,Residential,Exurban,14,52,Scrub/Shrub,#CCBA7C,3,high,#31a354,1,2230
+608,014710,Residential,Exurban,14,71,Grassland/Herbaceous,#E2E2C1,0,none,#ffffff,1,2230
+609,014711,Residential,Exurban,14,71,Grassland/Herbaceous,#E2E2C1,1,low,#e5f5e0,1,2230
+610,014712,Residential,Exurban,14,71,Grassland/Herbaceous,#E2E2C1,2,medium,#a1d99b,1,2230
+611,014713,Residential,Exurban,14,71,Grassland/Herbaceous,#E2E2C1,3,high,#31a354,1,2230
+612,014720,Residential,Exurban,14,72,Sedge/Herbaceuous,#C9C977,0,none,#ffffff,0,
+613,014721,Residential,Exurban,14,72,Sedge/Herbaceuous,#C9C977,1,low,#e5f5e0,0,
+614,014722,Residential,Exurban,14,72,Sedge/Herbaceuous,#C9C977,2,medium,#a1d99b,0,
+615,014723,Residential,Exurban,14,72,Sedge/Herbaceuous,#C9C977,3,high,#31a354,1,
+616,014730,Residential,Exurban,14,73,Lichens,#99C147,0,none,#ffffff,0,
+617,014731,Residential,Exurban,14,73,Lichens,#99C147,1,low,#e5f5e0,0,
+618,014732,Residential,Exurban,14,73,Lichens,#99C147,2,medium,#a1d99b,0,
+619,014733,Residential,Exurban,14,73,Lichens,#99C147,3,high,#31a354,1,
+620,014740,Residential,Exurban,14,74,Moss,#77AD93,0,none,#ffffff,0,
+621,014741,Residential,Exurban,14,74,Moss,#77AD93,1,low,#e5f5e0,0,
+622,014742,Residential,Exurban,14,74,Moss,#77AD93,2,medium,#a1d99b,0,
+623,014743,Residential,Exurban,14,74,Moss,#77AD93,3,high,#31a354,1,
+624,014810,Residential,Exurban,14,81,Pasture/Hay,#DBD83D,0,none,#ffffff,0,2230
+625,014811,Residential,Exurban,14,81,Pasture/Hay,#DBD83D,1,low,#e5f5e0,0,2230
+626,014812,Residential,Exurban,14,81,Pasture/Hay,#DBD83D,2,medium,#a1d99b,0,2230
+627,014813,Residential,Exurban,14,81,Pasture/Hay,#DBD83D,3,high,#31a354,1,2230
+628,014820,Residential,Exurban,14,82,Cultivated Crops,#AA7028,0,none,#ffffff,0,2230
+629,014821,Residential,Exurban,14,82,Cultivated Crops,#AA7028,1,low,#e5f5e0,0,2230
+630,014822,Residential,Exurban,14,82,Cultivated Crops,#AA7028,2,medium,#a1d99b,0,2230
+631,014823,Residential,Exurban,14,82,Cultivated Crops,#AA7028,3,high,#31a354,1,2230
+632,014900,Residential,Exurban,14,90,Woody Wetlands,#BAD8EA,0,none,#ffffff,1,2230
+633,014901,Residential,Exurban,14,90,Woody Wetlands,#BAD8EA,1,low,#e5f5e0,1,2230
+634,014902,Residential,Exurban,14,90,Woody Wetlands,#BAD8EA,2,medium,#a1d99b,1,2230
+635,014903,Residential,Exurban,14,90,Woody Wetlands,#BAD8EA,3,high,#31a354,1,2230
+636,014950,Residential,Exurban,14,95,Emergent Herbaceous Wetlands,#70A3BA,0,none,#ffffff,1,2230
+637,014951,Residential,Exurban,14,95,Emergent Herbaceous Wetlands,#70A3BA,1,low,#e5f5e0,1,2230
+638,014952,Residential,Exurban,14,95,Emergent Herbaceous Wetlands,#70A3BA,2,medium,#a1d99b,1,2230
+639,014953,Residential,Exurban,14,95,Emergent Herbaceous Wetlands,#70A3BA,3,high,#31a354,1,2230
+640,015110,Residential,Rural,15,11,Open Water,#476BA0,0,none,#ffffff,0,2230
+641,015111,Residential,Rural,15,11,Open Water,#476BA0,1,low,#e5f5e0,0,2230
+642,015112,Residential,Rural,15,11,Open Water,#476BA0,2,medium,#a1d99b,0,2230
+643,015113,Residential,Rural,15,11,Open Water,#476BA0,3,high,#31a354,1,2230
+644,015120,Residential,Rural,15,12,Perennial Ice/Snow,#D1DDF9,0,none,#ffffff,0,2230
+645,015121,Residential,Rural,15,12,Perennial Ice/Snow,#D1DDF9,1,low,#e5f5e0,0,2230
+646,015122,Residential,Rural,15,12,Perennial Ice/Snow,#D1DDF9,2,medium,#a1d99b,0,2230
+647,015123,Residential,Rural,15,12,Perennial Ice/Snow,#D1DDF9,3,high,#31a354,1,2230
+648,015210,Residential,Rural,15,21,"Developed, Open Space",#DDC9C9,0,none,#ffffff,0,2230
+649,015211,Residential,Rural,15,21,"Developed, Open Space",#DDC9C9,1,low,#e5f5e0,0,2230
+650,015212,Residential,Rural,15,21,"Developed, Open Space",#DDC9C9,2,medium,#a1d99b,0,2230
+651,015213,Residential,Rural,15,21,"Developed, Open Space",#DDC9C9,3,high,#31a354,1,2230
+652,015220,Residential,Rural,15,22,"Developed, Low Intensity",#D89382,0,none,#ffffff,0,2230
+653,015221,Residential,Rural,15,22,"Developed, Low Intensity",#D89382,1,low,#e5f5e0,0,2230
+654,015222,Residential,Rural,15,22,"Developed, Low Intensity",#D89382,2,medium,#a1d99b,0,2230
+655,015223,Residential,Rural,15,22,"Developed, Low Intensity",#D89382,3,high,#31a354,1,2230
+656,015230,Residential,Rural,15,23,"Developed, Medium Intensity",#ED0000,0,none,#ffffff,0,2230
+657,015231,Residential,Rural,15,23,"Developed, Medium Intensity",#ED0000,1,low,#e5f5e0,0,2230
+658,015232,Residential,Rural,15,23,"Developed, Medium Intensity",#ED0000,2,medium,#a1d99b,0,2230
+659,015233,Residential,Rural,15,23,"Developed, Medium Intensity",#ED0000,3,high,#31a354,1,2230
+660,015240,Residential,Rural,15,24,"Developed, High Intensity",#AA0000,0,none,#ffffff,0,2230
+661,015241,Residential,Rural,15,24,"Developed, High Intensity",#AA0000,1,low,#e5f5e0,0,2230
+662,015242,Residential,Rural,15,24,"Developed, High Intensity",#AA0000,2,medium,#a1d99b,0,2230
+663,015243,Residential,Rural,15,24,"Developed, High Intensity",#AA0000,3,high,#31a354,1,2230
+664,015310,Residential,Rural,15,31,Barren Land (Rock/Sand/Clay),#B2ADA3,0,none,#ffffff,0,2230
+665,015311,Residential,Rural,15,31,Barren Land (Rock/Sand/Clay),#B2ADA3,1,low,#e5f5e0,0,2230
+666,015312,Residential,Rural,15,31,Barren Land (Rock/Sand/Clay),#B2ADA3,2,medium,#a1d99b,0,2230
+667,015313,Residential,Rural,15,31,Barren Land (Rock/Sand/Clay),#B2ADA3,3,high,#31a354,1,2230
+668,015410,Residential,Rural,15,41,Deciduous Forest,#68AA63,0,none,#ffffff,1,2230
+669,015411,Residential,Rural,15,41,Deciduous Forest,#68AA63,1,low,#e5f5e0,1,2230
+670,015412,Residential,Rural,15,41,Deciduous Forest,#68AA63,2,medium,#a1d99b,1,2230
+671,015413,Residential,Rural,15,41,Deciduous Forest,#68AA63,3,high,#31a354,1,2230
+672,015420,Residential,Rural,15,42,Evergreen Forest,#1C6330,0,none,#ffffff,1,2230
+673,015421,Residential,Rural,15,42,Evergreen Forest,#1C6330,1,low,#e5f5e0,1,2230
+674,015422,Residential,Rural,15,42,Evergreen Forest,#1C6330,2,medium,#a1d99b,1,2230
+675,015423,Residential,Rural,15,42,Evergreen Forest,#1C6330,3,high,#31a354,1,2230
+676,015430,Residential,Rural,15,43,Mixed Forest,#B5C98E,0,none,#ffffff,1,2230
+677,015431,Residential,Rural,15,43,Mixed Forest,#B5C98E,1,low,#e5f5e0,1,2230
+678,015432,Residential,Rural,15,43,Mixed Forest,#B5C98E,2,medium,#a1d99b,1,2230
+679,015433,Residential,Rural,15,43,Mixed Forest,#B5C98E,3,high,#31a354,1,2230
+680,015510,Residential,Rural,15,51,Dwarf Scrub,#A58C30,0,none,#ffffff,0,
+681,015511,Residential,Rural,15,51,Dwarf Scrub,#A58C30,1,low,#e5f5e0,0,
+682,015512,Residential,Rural,15,51,Dwarf Scrub,#A58C30,2,medium,#a1d99b,0,
+683,015513,Residential,Rural,15,51,Dwarf Scrub,#A58C30,3,high,#31a354,1,
+684,015520,Residential,Rural,15,52,Scrub/Shrub,#CCBA7C,0,none,#ffffff,1,2230
+685,015521,Residential,Rural,15,52,Scrub/Shrub,#CCBA7C,1,low,#e5f5e0,1,2230
+686,015522,Residential,Rural,15,52,Scrub/Shrub,#CCBA7C,2,medium,#a1d99b,1,2230
+687,015523,Residential,Rural,15,52,Scrub/Shrub,#CCBA7C,3,high,#31a354,1,2230
+688,015710,Residential,Rural,15,71,Grassland/Herbaceous,#E2E2C1,0,none,#ffffff,1,2230
+689,015711,Residential,Rural,15,71,Grassland/Herbaceous,#E2E2C1,1,low,#e5f5e0,1,2230
+690,015712,Residential,Rural,15,71,Grassland/Herbaceous,#E2E2C1,2,medium,#a1d99b,1,2230
+691,015713,Residential,Rural,15,71,Grassland/Herbaceous,#E2E2C1,3,high,#31a354,1,2230
+692,015720,Residential,Rural,15,72,Sedge/Herbaceuous,#C9C977,0,none,#ffffff,0,
+693,015721,Residential,Rural,15,72,Sedge/Herbaceuous,#C9C977,1,low,#e5f5e0,0,
+694,015722,Residential,Rural,15,72,Sedge/Herbaceuous,#C9C977,2,medium,#a1d99b,0,
+695,015723,Residential,Rural,15,72,Sedge/Herbaceuous,#C9C977,3,high,#31a354,1,
+696,015730,Residential,Rural,15,73,Lichens,#99C147,0,none,#ffffff,0,
+697,015731,Residential,Rural,15,73,Lichens,#99C147,1,low,#e5f5e0,0,
+698,015732,Residential,Rural,15,73,Lichens,#99C147,2,medium,#a1d99b,0,
+699,015733,Residential,Rural,15,73,Lichens,#99C147,3,high,#31a354,1,
+700,015740,Residential,Rural,15,74,Moss,#77AD93,0,none,#ffffff,0,
+701,015741,Residential,Rural,15,74,Moss,#77AD93,1,low,#e5f5e0,0,
+702,015742,Residential,Rural,15,74,Moss,#77AD93,2,medium,#a1d99b,0,
+703,015743,Residential,Rural,15,74,Moss,#77AD93,3,high,#31a354,1,
+704,015810,Residential,Rural,15,81,Pasture/Hay,#DBD83D,0,none,#ffffff,0,2230
+705,015811,Residential,Rural,15,81,Pasture/Hay,#DBD83D,1,low,#e5f5e0,0,2230
+706,015812,Residential,Rural,15,81,Pasture/Hay,#DBD83D,2,medium,#a1d99b,0,2230
+707,015813,Residential,Rural,15,81,Pasture/Hay,#DBD83D,3,high,#31a354,1,2230
+708,015820,Residential,Rural,15,82,Cultivated Crops,#AA7028,0,none,#ffffff,0,2230
+709,015821,Residential,Rural,15,82,Cultivated Crops,#AA7028,1,low,#e5f5e0,0,2230
+710,015822,Residential,Rural,15,82,Cultivated Crops,#AA7028,2,medium,#a1d99b,0,2230
+711,015823,Residential,Rural,15,82,Cultivated Crops,#AA7028,3,high,#31a354,1,2230
+712,015900,Residential,Rural,15,90,Woody Wetlands,#BAD8EA,0,none,#ffffff,1,2230
+713,015901,Residential,Rural,15,90,Woody Wetlands,#BAD8EA,1,low,#e5f5e0,1,2230
+714,015902,Residential,Rural,15,90,Woody Wetlands,#BAD8EA,2,medium,#a1d99b,1,2230
+715,015903,Residential,Rural,15,90,Woody Wetlands,#BAD8EA,3,high,#31a354,1,2230
+716,015950,Residential,Rural,15,95,Emergent Herbaceous Wetlands,#70A3BA,0,none,#ffffff,1,2230
+717,015951,Residential,Rural,15,95,Emergent Herbaceous Wetlands,#70A3BA,1,low,#e5f5e0,1,2230
+718,015952,Residential,Rural,15,95,Emergent Herbaceous Wetlands,#70A3BA,2,medium,#a1d99b,1,2230
+719,015953,Residential,Rural,15,95,Emergent Herbaceous Wetlands,#70A3BA,3,high,#31a354,1,2230
+720,020110,Commercial,,20,11,Open Water,#476BA0,0,none,#ffffff,0,2230
+721,020111,Commercial,,20,11,Open Water,#476BA0,1,low,#e5f5e0,0,2230
+722,020112,Commercial,,20,11,Open Water,#476BA0,2,medium,#a1d99b,0,2230
+723,020113,Commercial,,20,11,Open Water,#476BA0,3,high,#31a354,1,2230
+724,020120,Commercial,,20,12,Perennial Ice/Snow,#D1DDF9,0,none,#ffffff,0,2230
+725,020121,Commercial,,20,12,Perennial Ice/Snow,#D1DDF9,1,low,#e5f5e0,0,2230
+726,020122,Commercial,,20,12,Perennial Ice/Snow,#D1DDF9,2,medium,#a1d99b,0,2230
+727,020123,Commercial,,20,12,Perennial Ice/Snow,#D1DDF9,3,high,#31a354,1,2230
+728,020210,Commercial,,20,21,"Developed, Open Space",#DDC9C9,0,none,#ffffff,0,2230
+729,020211,Commercial,,20,21,"Developed, Open Space",#DDC9C9,1,low,#e5f5e0,0,2230
+730,020212,Commercial,,20,21,"Developed, Open Space",#DDC9C9,2,medium,#a1d99b,0,2230
+731,020213,Commercial,,20,21,"Developed, Open Space",#DDC9C9,3,high,#31a354,1,2230
+732,020220,Commercial,,20,22,"Developed, Low Intensity",#D89382,0,none,#ffffff,0,2230
+733,020221,Commercial,,20,22,"Developed, Low Intensity",#D89382,1,low,#e5f5e0,0,2230
+734,020222,Commercial,,20,22,"Developed, Low Intensity",#D89382,2,medium,#a1d99b,0,2230
+735,020223,Commercial,,20,22,"Developed, Low Intensity",#D89382,3,high,#31a354,1,2230
+736,020230,Commercial,,20,23,"Developed, Medium Intensity",#ED0000,0,none,#ffffff,0,2230
+737,020231,Commercial,,20,23,"Developed, Medium Intensity",#ED0000,1,low,#e5f5e0,0,2230
+738,020232,Commercial,,20,23,"Developed, Medium Intensity",#ED0000,2,medium,#a1d99b,0,2230
+739,020233,Commercial,,20,23,"Developed, Medium Intensity",#ED0000,3,high,#31a354,1,2230
+740,020240,Commercial,,20,24,"Developed, High Intensity",#AA0000,0,none,#ffffff,0,2230
+741,020241,Commercial,,20,24,"Developed, High Intensity",#AA0000,1,low,#e5f5e0,0,2230
+742,020242,Commercial,,20,24,"Developed, High Intensity",#AA0000,2,medium,#a1d99b,0,2230
+743,020243,Commercial,,20,24,"Developed, High Intensity",#AA0000,3,high,#31a354,1,2230
+744,020310,Commercial,,20,31,Barren Land (Rock/Sand/Clay),#B2ADA3,0,none,#ffffff,0,2230
+745,020311,Commercial,,20,31,Barren Land (Rock/Sand/Clay),#B2ADA3,1,low,#e5f5e0,0,2230
+746,020312,Commercial,,20,31,Barren Land (Rock/Sand/Clay),#B2ADA3,2,medium,#a1d99b,0,2230
+747,020313,Commercial,,20,31,Barren Land (Rock/Sand/Clay),#B2ADA3,3,high,#31a354,1,2230
+748,020410,Commercial,,20,41,Deciduous Forest,#68AA63,0,none,#ffffff,1,2230
+749,020411,Commercial,,20,41,Deciduous Forest,#68AA63,1,low,#e5f5e0,1,2230
+750,020412,Commercial,,20,41,Deciduous Forest,#68AA63,2,medium,#a1d99b,1,2230
+751,020413,Commercial,,20,41,Deciduous Forest,#68AA63,3,high,#31a354,1,2230
+752,020420,Commercial,,20,42,Evergreen Forest,#1C6330,0,none,#ffffff,1,2230
+753,020421,Commercial,,20,42,Evergreen Forest,#1C6330,1,low,#e5f5e0,1,2230
+754,020422,Commercial,,20,42,Evergreen Forest,#1C6330,2,medium,#a1d99b,1,2230
+755,020423,Commercial,,20,42,Evergreen Forest,#1C6330,3,high,#31a354,1,2230
+756,020430,Commercial,,20,43,Mixed Forest,#B5C98E,0,none,#ffffff,1,2230
+757,020431,Commercial,,20,43,Mixed Forest,#B5C98E,1,low,#e5f5e0,1,2230
+758,020432,Commercial,,20,43,Mixed Forest,#B5C98E,2,medium,#a1d99b,1,2230
+759,020433,Commercial,,20,43,Mixed Forest,#B5C98E,3,high,#31a354,1,2230
+760,020510,Commercial,,20,51,Dwarf Scrub,#A58C30,0,none,#ffffff,0,
+761,020511,Commercial,,20,51,Dwarf Scrub,#A58C30,1,low,#e5f5e0,0,
+762,020512,Commercial,,20,51,Dwarf Scrub,#A58C30,2,medium,#a1d99b,0,
+763,020513,Commercial,,20,51,Dwarf Scrub,#A58C30,3,high,#31a354,1,
+764,020520,Commercial,,20,52,Scrub/Shrub,#CCBA7C,0,none,#ffffff,1,2230
+765,020521,Commercial,,20,52,Scrub/Shrub,#CCBA7C,1,low,#e5f5e0,1,2230
+766,020522,Commercial,,20,52,Scrub/Shrub,#CCBA7C,2,medium,#a1d99b,1,2230
+767,020523,Commercial,,20,52,Scrub/Shrub,#CCBA7C,3,high,#31a354,1,2230
+768,020710,Commercial,,20,71,Grassland/Herbaceous,#E2E2C1,0,none,#ffffff,1,2230
+769,020711,Commercial,,20,71,Grassland/Herbaceous,#E2E2C1,1,low,#e5f5e0,1,2230
+770,020712,Commercial,,20,71,Grassland/Herbaceous,#E2E2C1,2,medium,#a1d99b,1,2230
+771,020713,Commercial,,20,71,Grassland/Herbaceous,#E2E2C1,3,high,#31a354,1,2230
+772,020720,Commercial,,20,72,Sedge/Herbaceuous,#C9C977,0,none,#ffffff,0,
+773,020721,Commercial,,20,72,Sedge/Herbaceuous,#C9C977,1,low,#e5f5e0,0,
+774,020722,Commercial,,20,72,Sedge/Herbaceuous,#C9C977,2,medium,#a1d99b,0,
+775,020723,Commercial,,20,72,Sedge/Herbaceuous,#C9C977,3,high,#31a354,1,
+776,020730,Commercial,,20,73,Lichens,#99C147,0,none,#ffffff,0,
+777,020731,Commercial,,20,73,Lichens,#99C147,1,low,#e5f5e0,0,
+778,020732,Commercial,,20,73,Lichens,#99C147,2,medium,#a1d99b,0,
+779,020733,Commercial,,20,73,Lichens,#99C147,3,high,#31a354,1,
+780,020740,Commercial,,20,74,Moss,#77AD93,0,none,#ffffff,0,
+781,020741,Commercial,,20,74,Moss,#77AD93,1,low,#e5f5e0,0,
+782,020742,Commercial,,20,74,Moss,#77AD93,2,medium,#a1d99b,0,
+783,020743,Commercial,,20,74,Moss,#77AD93,3,high,#31a354,1,
+784,020810,Commercial,,20,81,Pasture/Hay,#DBD83D,0,none,#ffffff,0,2230
+785,020811,Commercial,,20,81,Pasture/Hay,#DBD83D,1,low,#e5f5e0,0,2230
+786,020812,Commercial,,20,81,Pasture/Hay,#DBD83D,2,medium,#a1d99b,0,2230
+787,020813,Commercial,,20,81,Pasture/Hay,#DBD83D,3,high,#31a354,1,2230
+788,020820,Commercial,,20,82,Cultivated Crops,#AA7028,0,none,#ffffff,0,2230
+789,020821,Commercial,,20,82,Cultivated Crops,#AA7028,1,low,#e5f5e0,0,2230
+790,020822,Commercial,,20,82,Cultivated Crops,#AA7028,2,medium,#a1d99b,0,2230
+791,020823,Commercial,,20,82,Cultivated Crops,#AA7028,3,high,#31a354,1,2230
+792,020900,Commercial,,20,90,Woody Wetlands,#BAD8EA,0,none,#ffffff,1,2230
+793,020901,Commercial,,20,90,Woody Wetlands,#BAD8EA,1,low,#e5f5e0,1,2230
+794,020902,Commercial,,20,90,Woody Wetlands,#BAD8EA,2,medium,#a1d99b,1,2230
+795,020903,Commercial,,20,90,Woody Wetlands,#BAD8EA,3,high,#31a354,1,2230
+796,020950,Commercial,,20,95,Emergent Herbaceous Wetlands,#70A3BA,0,none,#ffffff,1,2230
+797,020951,Commercial,,20,95,Emergent Herbaceous Wetlands,#70A3BA,1,low,#e5f5e0,1,2230
+798,020952,Commercial,,20,95,Emergent Herbaceous Wetlands,#70A3BA,2,medium,#a1d99b,1,2230
+799,020953,Commercial,,20,95,Emergent Herbaceous Wetlands,#70A3BA,3,high,#31a354,1,2230
+800,030110,Industrial,,30,11,Open Water,#476BA0,0,none,#ffffff,0,2230
+801,030111,Industrial,,30,11,Open Water,#476BA0,1,low,#e5f5e0,0,2230
+802,030112,Industrial,,30,11,Open Water,#476BA0,2,medium,#a1d99b,0,2230
+803,030113,Industrial,,30,11,Open Water,#476BA0,3,high,#31a354,1,2230
+804,030120,Industrial,,30,12,Perennial Ice/Snow,#D1DDF9,0,none,#ffffff,0,2230
+805,030121,Industrial,,30,12,Perennial Ice/Snow,#D1DDF9,1,low,#e5f5e0,0,2230
+806,030122,Industrial,,30,12,Perennial Ice/Snow,#D1DDF9,2,medium,#a1d99b,0,2230
+807,030123,Industrial,,30,12,Perennial Ice/Snow,#D1DDF9,3,high,#31a354,1,2230
+808,030210,Industrial,,30,21,"Developed, Open Space",#DDC9C9,0,none,#ffffff,0,2230
+809,030211,Industrial,,30,21,"Developed, Open Space",#DDC9C9,1,low,#e5f5e0,0,2230
+810,030212,Industrial,,30,21,"Developed, Open Space",#DDC9C9,2,medium,#a1d99b,0,2230
+811,030213,Industrial,,30,21,"Developed, Open Space",#DDC9C9,3,high,#31a354,1,2230
+812,030220,Industrial,,30,22,"Developed, Low Intensity",#D89382,0,none,#ffffff,0,2230
+813,030221,Industrial,,30,22,"Developed, Low Intensity",#D89382,1,low,#e5f5e0,0,2230
+814,030222,Industrial,,30,22,"Developed, Low Intensity",#D89382,2,medium,#a1d99b,0,2230
+815,030223,Industrial,,30,22,"Developed, Low Intensity",#D89382,3,high,#31a354,1,2230
+816,030230,Industrial,,30,23,"Developed, Medium Intensity",#ED0000,0,none,#ffffff,0,2230
+817,030231,Industrial,,30,23,"Developed, Medium Intensity",#ED0000,1,low,#e5f5e0,0,2230
+818,030232,Industrial,,30,23,"Developed, Medium Intensity",#ED0000,2,medium,#a1d99b,0,2230
+819,030233,Industrial,,30,23,"Developed, Medium Intensity",#ED0000,3,high,#31a354,1,2230
+820,030240,Industrial,,30,24,"Developed, High Intensity",#AA0000,0,none,#ffffff,0,2230
+821,030241,Industrial,,30,24,"Developed, High Intensity",#AA0000,1,low,#e5f5e0,0,2230
+822,030242,Industrial,,30,24,"Developed, High Intensity",#AA0000,2,medium,#a1d99b,0,2230
+823,030243,Industrial,,30,24,"Developed, High Intensity",#AA0000,3,high,#31a354,1,2230
+824,030310,Industrial,,30,31,Barren Land (Rock/Sand/Clay),#B2ADA3,0,none,#ffffff,0,2230
+825,030311,Industrial,,30,31,Barren Land (Rock/Sand/Clay),#B2ADA3,1,low,#e5f5e0,0,2230
+826,030312,Industrial,,30,31,Barren Land (Rock/Sand/Clay),#B2ADA3,2,medium,#a1d99b,0,2230
+827,030313,Industrial,,30,31,Barren Land (Rock/Sand/Clay),#B2ADA3,3,high,#31a354,1,2230
+828,030410,Industrial,,30,41,Deciduous Forest,#68AA63,0,none,#ffffff,1,2230
+829,030411,Industrial,,30,41,Deciduous Forest,#68AA63,1,low,#e5f5e0,1,2230
+830,030412,Industrial,,30,41,Deciduous Forest,#68AA63,2,medium,#a1d99b,1,2230
+831,030413,Industrial,,30,41,Deciduous Forest,#68AA63,3,high,#31a354,1,2230
+832,030420,Industrial,,30,42,Evergreen Forest,#1C6330,0,none,#ffffff,1,2230
+833,030421,Industrial,,30,42,Evergreen Forest,#1C6330,1,low,#e5f5e0,1,2230
+834,030422,Industrial,,30,42,Evergreen Forest,#1C6330,2,medium,#a1d99b,1,2230
+835,030423,Industrial,,30,42,Evergreen Forest,#1C6330,3,high,#31a354,1,2230
+836,030430,Industrial,,30,43,Mixed Forest,#B5C98E,0,none,#ffffff,1,2230
+837,030431,Industrial,,30,43,Mixed Forest,#B5C98E,1,low,#e5f5e0,1,2230
+838,030432,Industrial,,30,43,Mixed Forest,#B5C98E,2,medium,#a1d99b,1,2230
+839,030433,Industrial,,30,43,Mixed Forest,#B5C98E,3,high,#31a354,1,2230
+840,030510,Industrial,,30,51,Dwarf Scrub,#A58C30,0,none,#ffffff,0,
+841,030511,Industrial,,30,51,Dwarf Scrub,#A58C30,1,low,#e5f5e0,0,
+842,030512,Industrial,,30,51,Dwarf Scrub,#A58C30,2,medium,#a1d99b,0,
+843,030513,Industrial,,30,51,Dwarf Scrub,#A58C30,3,high,#31a354,1,
+844,030520,Industrial,,30,52,Scrub/Shrub,#CCBA7C,0,none,#ffffff,1,2230
+845,030521,Industrial,,30,52,Scrub/Shrub,#CCBA7C,1,low,#e5f5e0,1,2230
+846,030522,Industrial,,30,52,Scrub/Shrub,#CCBA7C,2,medium,#a1d99b,1,2230
+847,030523,Industrial,,30,52,Scrub/Shrub,#CCBA7C,3,high,#31a354,1,2230
+848,030710,Industrial,,30,71,Grassland/Herbaceous,#E2E2C1,0,none,#ffffff,1,2230
+849,030711,Industrial,,30,71,Grassland/Herbaceous,#E2E2C1,1,low,#e5f5e0,1,2230
+850,030712,Industrial,,30,71,Grassland/Herbaceous,#E2E2C1,2,medium,#a1d99b,1,2230
+851,030713,Industrial,,30,71,Grassland/Herbaceous,#E2E2C1,3,high,#31a354,1,2230
+852,030720,Industrial,,30,72,Sedge/Herbaceuous,#C9C977,0,none,#ffffff,0,
+853,030721,Industrial,,30,72,Sedge/Herbaceuous,#C9C977,1,low,#e5f5e0,0,
+854,030722,Industrial,,30,72,Sedge/Herbaceuous,#C9C977,2,medium,#a1d99b,0,
+855,030723,Industrial,,30,72,Sedge/Herbaceuous,#C9C977,3,high,#31a354,1,
+856,030730,Industrial,,30,73,Lichens,#99C147,0,none,#ffffff,0,
+857,030731,Industrial,,30,73,Lichens,#99C147,1,low,#e5f5e0,0,
+858,030732,Industrial,,30,73,Lichens,#99C147,2,medium,#a1d99b,0,
+859,030733,Industrial,,30,73,Lichens,#99C147,3,high,#31a354,1,
+860,030740,Industrial,,30,74,Moss,#77AD93,0,none,#ffffff,0,
+861,030741,Industrial,,30,74,Moss,#77AD93,1,low,#e5f5e0,0,
+862,030742,Industrial,,30,74,Moss,#77AD93,2,medium,#a1d99b,0,
+863,030743,Industrial,,30,74,Moss,#77AD93,3,high,#31a354,1,
+864,030810,Industrial,,30,81,Pasture/Hay,#DBD83D,0,none,#ffffff,0,2230
+865,030811,Industrial,,30,81,Pasture/Hay,#DBD83D,1,low,#e5f5e0,0,2230
+866,030812,Industrial,,30,81,Pasture/Hay,#DBD83D,2,medium,#a1d99b,0,2230
+867,030813,Industrial,,30,81,Pasture/Hay,#DBD83D,3,high,#31a354,1,2230
+868,030820,Industrial,,30,82,Cultivated Crops,#AA7028,0,none,#ffffff,0,2230
+869,030821,Industrial,,30,82,Cultivated Crops,#AA7028,1,low,#e5f5e0,0,2230
+870,030822,Industrial,,30,82,Cultivated Crops,#AA7028,2,medium,#a1d99b,0,2230
+871,030823,Industrial,,30,82,Cultivated Crops,#AA7028,3,high,#31a354,1,2230
+872,030900,Industrial,,30,90,Woody Wetlands,#BAD8EA,0,none,#ffffff,1,2230
+873,030901,Industrial,,30,90,Woody Wetlands,#BAD8EA,1,low,#e5f5e0,1,2230
+874,030902,Industrial,,30,90,Woody Wetlands,#BAD8EA,2,medium,#a1d99b,1,2230
+875,030903,Industrial,,30,90,Woody Wetlands,#BAD8EA,3,high,#31a354,1,2230
+876,030950,Industrial,,30,95,Emergent Herbaceous Wetlands,#70A3BA,0,none,#ffffff,1,2230
+877,030951,Industrial,,30,95,Emergent Herbaceous Wetlands,#70A3BA,1,low,#e5f5e0,1,2230
+878,030952,Industrial,,30,95,Emergent Herbaceous Wetlands,#70A3BA,2,medium,#a1d99b,1,2230
+879,030953,Industrial,,30,95,Emergent Herbaceous Wetlands,#70A3BA,3,high,#31a354,1,2230
+880,040110,Institutional,,40,11,Open Water,#476BA0,0,none,#ffffff,0,2230
+881,040111,Institutional,,40,11,Open Water,#476BA0,1,low,#e5f5e0,0,2230
+882,040112,Institutional,,40,11,Open Water,#476BA0,2,medium,#a1d99b,0,2230
+883,040113,Institutional,,40,11,Open Water,#476BA0,3,high,#31a354,1,2230
+884,040120,Institutional,,40,12,Perennial Ice/Snow,#D1DDF9,0,none,#ffffff,0,2230
+885,040121,Institutional,,40,12,Perennial Ice/Snow,#D1DDF9,1,low,#e5f5e0,0,2230
+886,040122,Institutional,,40,12,Perennial Ice/Snow,#D1DDF9,2,medium,#a1d99b,0,2230
+887,040123,Institutional,,40,12,Perennial Ice/Snow,#D1DDF9,3,high,#31a354,1,2230
+888,040210,Institutional,,40,21,"Developed, Open Space",#DDC9C9,0,none,#ffffff,0,2230
+889,040211,Institutional,,40,21,"Developed, Open Space",#DDC9C9,1,low,#e5f5e0,0,2230
+890,040212,Institutional,,40,21,"Developed, Open Space",#DDC9C9,2,medium,#a1d99b,0,2230
+891,040213,Institutional,,40,21,"Developed, Open Space",#DDC9C9,3,high,#31a354,1,2230
+892,040220,Institutional,,40,22,"Developed, Low Intensity",#D89382,0,none,#ffffff,0,2230
+893,040221,Institutional,,40,22,"Developed, Low Intensity",#D89382,1,low,#e5f5e0,0,2230
+894,040222,Institutional,,40,22,"Developed, Low Intensity",#D89382,2,medium,#a1d99b,0,2230
+895,040223,Institutional,,40,22,"Developed, Low Intensity",#D89382,3,high,#31a354,1,2230
+896,040230,Institutional,,40,23,"Developed, Medium Intensity",#ED0000,0,none,#ffffff,0,2230
+897,040231,Institutional,,40,23,"Developed, Medium Intensity",#ED0000,1,low,#e5f5e0,0,2230
+898,040232,Institutional,,40,23,"Developed, Medium Intensity",#ED0000,2,medium,#a1d99b,0,2230
+899,040233,Institutional,,40,23,"Developed, Medium Intensity",#ED0000,3,high,#31a354,1,2230
+900,040240,Institutional,,40,24,"Developed, High Intensity",#AA0000,0,none,#ffffff,0,2230
+901,040241,Institutional,,40,24,"Developed, High Intensity",#AA0000,1,low,#e5f5e0,0,2230
+902,040242,Institutional,,40,24,"Developed, High Intensity",#AA0000,2,medium,#a1d99b,0,2230
+903,040243,Institutional,,40,24,"Developed, High Intensity",#AA0000,3,high,#31a354,1,2230
+904,040310,Institutional,,40,31,Barren Land (Rock/Sand/Clay),#B2ADA3,0,none,#ffffff,0,2230
+905,040311,Institutional,,40,31,Barren Land (Rock/Sand/Clay),#B2ADA3,1,low,#e5f5e0,0,2230
+906,040312,Institutional,,40,31,Barren Land (Rock/Sand/Clay),#B2ADA3,2,medium,#a1d99b,0,2230
+907,040313,Institutional,,40,31,Barren Land (Rock/Sand/Clay),#B2ADA3,3,high,#31a354,1,2230
+908,040410,Institutional,,40,41,Deciduous Forest,#68AA63,0,none,#ffffff,1,2230
+909,040411,Institutional,,40,41,Deciduous Forest,#68AA63,1,low,#e5f5e0,1,2230
+910,040412,Institutional,,40,41,Deciduous Forest,#68AA63,2,medium,#a1d99b,1,2230
+911,040413,Institutional,,40,41,Deciduous Forest,#68AA63,3,high,#31a354,1,2230
+912,040420,Institutional,,40,42,Evergreen Forest,#1C6330,0,none,#ffffff,1,2230
+913,040421,Institutional,,40,42,Evergreen Forest,#1C6330,1,low,#e5f5e0,1,2230
+914,040422,Institutional,,40,42,Evergreen Forest,#1C6330,2,medium,#a1d99b,1,2230
+915,040423,Institutional,,40,42,Evergreen Forest,#1C6330,3,high,#31a354,1,2230
+916,040430,Institutional,,40,43,Mixed Forest,#B5C98E,0,none,#ffffff,1,2230
+917,040431,Institutional,,40,43,Mixed Forest,#B5C98E,1,low,#e5f5e0,1,2230
+918,040432,Institutional,,40,43,Mixed Forest,#B5C98E,2,medium,#a1d99b,1,2230
+919,040433,Institutional,,40,43,Mixed Forest,#B5C98E,3,high,#31a354,1,2230
+920,040510,Institutional,,40,51,Dwarf Scrub,#A58C30,0,none,#ffffff,0,
+921,040511,Institutional,,40,51,Dwarf Scrub,#A58C30,1,low,#e5f5e0,0,
+922,040512,Institutional,,40,51,Dwarf Scrub,#A58C30,2,medium,#a1d99b,0,
+923,040513,Institutional,,40,51,Dwarf Scrub,#A58C30,3,high,#31a354,1,
+924,040520,Institutional,,40,52,Scrub/Shrub,#CCBA7C,0,none,#ffffff,1,2230
+925,040521,Institutional,,40,52,Scrub/Shrub,#CCBA7C,1,low,#e5f5e0,1,2230
+926,040522,Institutional,,40,52,Scrub/Shrub,#CCBA7C,2,medium,#a1d99b,1,2230
+927,040523,Institutional,,40,52,Scrub/Shrub,#CCBA7C,3,high,#31a354,1,2230
+928,040710,Institutional,,40,71,Grassland/Herbaceous,#E2E2C1,0,none,#ffffff,1,2230
+929,040711,Institutional,,40,71,Grassland/Herbaceous,#E2E2C1,1,low,#e5f5e0,1,2230
+930,040712,Institutional,,40,71,Grassland/Herbaceous,#E2E2C1,2,medium,#a1d99b,1,2230
+931,040713,Institutional,,40,71,Grassland/Herbaceous,#E2E2C1,3,high,#31a354,1,2230
+932,040720,Institutional,,40,72,Sedge/Herbaceuous,#C9C977,0,none,#ffffff,0,
+933,040721,Institutional,,40,72,Sedge/Herbaceuous,#C9C977,1,low,#e5f5e0,0,
+934,040722,Institutional,,40,72,Sedge/Herbaceuous,#C9C977,2,medium,#a1d99b,0,
+935,040723,Institutional,,40,72,Sedge/Herbaceuous,#C9C977,3,high,#31a354,1,
+936,040730,Institutional,,40,73,Lichens,#99C147,0,none,#ffffff,0,
+937,040731,Institutional,,40,73,Lichens,#99C147,1,low,#e5f5e0,0,
+938,040732,Institutional,,40,73,Lichens,#99C147,2,medium,#a1d99b,0,
+939,040733,Institutional,,40,73,Lichens,#99C147,3,high,#31a354,1,
+940,040740,Institutional,,40,74,Moss,#77AD93,0,none,#ffffff,0,
+941,040741,Institutional,,40,74,Moss,#77AD93,1,low,#e5f5e0,0,
+942,040742,Institutional,,40,74,Moss,#77AD93,2,medium,#a1d99b,0,
+943,040743,Institutional,,40,74,Moss,#77AD93,3,high,#31a354,1,
+944,040810,Institutional,,40,81,Pasture/Hay,#DBD83D,0,none,#ffffff,0,2230
+945,040811,Institutional,,40,81,Pasture/Hay,#DBD83D,1,low,#e5f5e0,0,2230
+946,040812,Institutional,,40,81,Pasture/Hay,#DBD83D,2,medium,#a1d99b,0,2230
+947,040813,Institutional,,40,81,Pasture/Hay,#DBD83D,3,high,#31a354,1,2230
+948,040820,Institutional,,40,82,Cultivated Crops,#AA7028,0,none,#ffffff,0,2230
+949,040821,Institutional,,40,82,Cultivated Crops,#AA7028,1,low,#e5f5e0,0,2230
+950,040822,Institutional,,40,82,Cultivated Crops,#AA7028,2,medium,#a1d99b,0,2230
+951,040823,Institutional,,40,82,Cultivated Crops,#AA7028,3,high,#31a354,1,2230
+952,040900,Institutional,,40,90,Woody Wetlands,#BAD8EA,0,none,#ffffff,1,2230
+953,040901,Institutional,,40,90,Woody Wetlands,#BAD8EA,1,low,#e5f5e0,1,2230
+954,040902,Institutional,,40,90,Woody Wetlands,#BAD8EA,2,medium,#a1d99b,1,2230
+955,040903,Institutional,,40,90,Woody Wetlands,#BAD8EA,3,high,#31a354,1,2230
+956,040950,Institutional,,40,95,Emergent Herbaceous Wetlands,#70A3BA,0,none,#ffffff,1,2230
+957,040951,Institutional,,40,95,Emergent Herbaceous Wetlands,#70A3BA,1,low,#e5f5e0,1,2230
+958,040952,Institutional,,40,95,Emergent Herbaceous Wetlands,#70A3BA,2,medium,#a1d99b,1,2230
+959,040953,Institutional,,40,95,Emergent Herbaceous Wetlands,#70A3BA,3,high,#31a354,1,2230
+960,051110,Transportation,Airport,51,11,Open Water,#476BA0,0,none,#ffffff,0,2230
+961,051111,Transportation,Airport,51,11,Open Water,#476BA0,1,low,#e5f5e0,0,2230
+962,051112,Transportation,Airport,51,11,Open Water,#476BA0,2,medium,#a1d99b,0,2230
+963,051113,Transportation,Airport,51,11,Open Water,#476BA0,3,high,#31a354,1,2230
+964,051120,Transportation,Airport,51,12,Perennial Ice/Snow,#D1DDF9,0,none,#ffffff,0,2230
+965,051121,Transportation,Airport,51,12,Perennial Ice/Snow,#D1DDF9,1,low,#e5f5e0,0,2230
+966,051122,Transportation,Airport,51,12,Perennial Ice/Snow,#D1DDF9,2,medium,#a1d99b,0,2230
+967,051123,Transportation,Airport,51,12,Perennial Ice/Snow,#D1DDF9,3,high,#31a354,1,2230
+968,051210,Transportation,Airport,51,21,"Developed, Open Space",#DDC9C9,0,none,#ffffff,0,2230
+969,051211,Transportation,Airport,51,21,"Developed, Open Space",#DDC9C9,1,low,#e5f5e0,0,2230
+970,051212,Transportation,Airport,51,21,"Developed, Open Space",#DDC9C9,2,medium,#a1d99b,0,2230
+971,051213,Transportation,Airport,51,21,"Developed, Open Space",#DDC9C9,3,high,#31a354,1,2230
+972,051220,Transportation,Airport,51,22,"Developed, Low Intensity",#D89382,0,none,#ffffff,0,2230
+973,051221,Transportation,Airport,51,22,"Developed, Low Intensity",#D89382,1,low,#e5f5e0,0,2230
+974,051222,Transportation,Airport,51,22,"Developed, Low Intensity",#D89382,2,medium,#a1d99b,0,2230
+975,051223,Transportation,Airport,51,22,"Developed, Low Intensity",#D89382,3,high,#31a354,1,2230
+976,051230,Transportation,Airport,51,23,"Developed, Medium Intensity",#ED0000,0,none,#ffffff,0,2230
+977,051231,Transportation,Airport,51,23,"Developed, Medium Intensity",#ED0000,1,low,#e5f5e0,0,2230
+978,051232,Transportation,Airport,51,23,"Developed, Medium Intensity",#ED0000,2,medium,#a1d99b,0,2230
+979,051233,Transportation,Airport,51,23,"Developed, Medium Intensity",#ED0000,3,high,#31a354,1,2230
+980,051240,Transportation,Airport,51,24,"Developed, High Intensity",#AA0000,0,none,#ffffff,0,2230
+981,051241,Transportation,Airport,51,24,"Developed, High Intensity",#AA0000,1,low,#e5f5e0,0,2230
+982,051242,Transportation,Airport,51,24,"Developed, High Intensity",#AA0000,2,medium,#a1d99b,0,2230
+983,051243,Transportation,Airport,51,24,"Developed, High Intensity",#AA0000,3,high,#31a354,1,2230
+984,051310,Transportation,Airport,51,31,Barren Land (Rock/Sand/Clay),#B2ADA3,0,none,#ffffff,0,2230
+985,051311,Transportation,Airport,51,31,Barren Land (Rock/Sand/Clay),#B2ADA3,1,low,#e5f5e0,0,2230
+986,051312,Transportation,Airport,51,31,Barren Land (Rock/Sand/Clay),#B2ADA3,2,medium,#a1d99b,0,2230
+987,051313,Transportation,Airport,51,31,Barren Land (Rock/Sand/Clay),#B2ADA3,3,high,#31a354,1,2230
+988,051410,Transportation,Airport,51,41,Deciduous Forest,#68AA63,0,none,#ffffff,1,2230
+989,051411,Transportation,Airport,51,41,Deciduous Forest,#68AA63,1,low,#e5f5e0,1,2230
+990,051412,Transportation,Airport,51,41,Deciduous Forest,#68AA63,2,medium,#a1d99b,1,2230
+991,051413,Transportation,Airport,51,41,Deciduous Forest,#68AA63,3,high,#31a354,1,2230
+992,051420,Transportation,Airport,51,42,Evergreen Forest,#1C6330,0,none,#ffffff,1,2230
+993,051421,Transportation,Airport,51,42,Evergreen Forest,#1C6330,1,low,#e5f5e0,1,2230
+994,051422,Transportation,Airport,51,42,Evergreen Forest,#1C6330,2,medium,#a1d99b,1,2230
+995,051423,Transportation,Airport,51,42,Evergreen Forest,#1C6330,3,high,#31a354,1,2230
+996,051430,Transportation,Airport,51,43,Mixed Forest,#B5C98E,0,none,#ffffff,1,2230
+997,051431,Transportation,Airport,51,43,Mixed Forest,#B5C98E,1,low,#e5f5e0,1,2230
+998,051432,Transportation,Airport,51,43,Mixed Forest,#B5C98E,2,medium,#a1d99b,1,2230
+999,051433,Transportation,Airport,51,43,Mixed Forest,#B5C98E,3,high,#31a354,1,2230
+1000,051510,Transportation,Airport,51,51,Dwarf Scrub,#A58C30,0,none,#ffffff,0,
+1001,051511,Transportation,Airport,51,51,Dwarf Scrub,#A58C30,1,low,#e5f5e0,0,
+1002,051512,Transportation,Airport,51,51,Dwarf Scrub,#A58C30,2,medium,#a1d99b,0,
+1003,051513,Transportation,Airport,51,51,Dwarf Scrub,#A58C30,3,high,#31a354,1,
+1004,051520,Transportation,Airport,51,52,Scrub/Shrub,#CCBA7C,0,none,#ffffff,1,2230
+1005,051521,Transportation,Airport,51,52,Scrub/Shrub,#CCBA7C,1,low,#e5f5e0,1,2230
+1006,051522,Transportation,Airport,51,52,Scrub/Shrub,#CCBA7C,2,medium,#a1d99b,1,2230
+1007,051523,Transportation,Airport,51,52,Scrub/Shrub,#CCBA7C,3,high,#31a354,1,2230
+1008,051710,Transportation,Airport,51,71,Grassland/Herbaceous,#E2E2C1,0,none,#ffffff,1,2230
+1009,051711,Transportation,Airport,51,71,Grassland/Herbaceous,#E2E2C1,1,low,#e5f5e0,1,2230
+1010,051712,Transportation,Airport,51,71,Grassland/Herbaceous,#E2E2C1,2,medium,#a1d99b,1,2230
+1011,051713,Transportation,Airport,51,71,Grassland/Herbaceous,#E2E2C1,3,high,#31a354,1,2230
+1012,051720,Transportation,Airport,51,72,Sedge/Herbaceuous,#C9C977,0,none,#ffffff,0,
+1013,051721,Transportation,Airport,51,72,Sedge/Herbaceuous,#C9C977,1,low,#e5f5e0,0,
+1014,051722,Transportation,Airport,51,72,Sedge/Herbaceuous,#C9C977,2,medium,#a1d99b,0,
+1015,051723,Transportation,Airport,51,72,Sedge/Herbaceuous,#C9C977,3,high,#31a354,1,
+1016,051730,Transportation,Airport,51,73,Lichens,#99C147,0,none,#ffffff,0,
+1017,051731,Transportation,Airport,51,73,Lichens,#99C147,1,low,#e5f5e0,0,
+1018,051732,Transportation,Airport,51,73,Lichens,#99C147,2,medium,#a1d99b,0,
+1019,051733,Transportation,Airport,51,73,Lichens,#99C147,3,high,#31a354,1,
+1020,051740,Transportation,Airport,51,74,Moss,#77AD93,0,none,#ffffff,0,
+1021,051741,Transportation,Airport,51,74,Moss,#77AD93,1,low,#e5f5e0,0,
+1022,051742,Transportation,Airport,51,74,Moss,#77AD93,2,medium,#a1d99b,0,
+1023,051743,Transportation,Airport,51,74,Moss,#77AD93,3,high,#31a354,1,
+1024,051810,Transportation,Airport,51,81,Pasture/Hay,#DBD83D,0,none,#ffffff,0,2230
+1025,051811,Transportation,Airport,51,81,Pasture/Hay,#DBD83D,1,low,#e5f5e0,0,2230
+1026,051812,Transportation,Airport,51,81,Pasture/Hay,#DBD83D,2,medium,#a1d99b,0,2230
+1027,051813,Transportation,Airport,51,81,Pasture/Hay,#DBD83D,3,high,#31a354,1,2230
+1028,051820,Transportation,Airport,51,82,Cultivated Crops,#AA7028,0,none,#ffffff,0,2230
+1029,051821,Transportation,Airport,51,82,Cultivated Crops,#AA7028,1,low,#e5f5e0,0,2230
+1030,051822,Transportation,Airport,51,82,Cultivated Crops,#AA7028,2,medium,#a1d99b,0,2230
+1031,051823,Transportation,Airport,51,82,Cultivated Crops,#AA7028,3,high,#31a354,1,2230
+1032,051900,Transportation,Airport,51,90,Woody Wetlands,#BAD8EA,0,none,#ffffff,1,2230
+1033,051901,Transportation,Airport,51,90,Woody Wetlands,#BAD8EA,1,low,#e5f5e0,1,2230
+1034,051902,Transportation,Airport,51,90,Woody Wetlands,#BAD8EA,2,medium,#a1d99b,1,2230
+1035,051903,Transportation,Airport,51,90,Woody Wetlands,#BAD8EA,3,high,#31a354,1,2230
+1036,051950,Transportation,Airport,51,95,Emergent Herbaceous Wetlands,#70A3BA,0,none,#ffffff,1,2230
+1037,051951,Transportation,Airport,51,95,Emergent Herbaceous Wetlands,#70A3BA,1,low,#e5f5e0,1,2230
+1038,051952,Transportation,Airport,51,95,Emergent Herbaceous Wetlands,#70A3BA,2,medium,#a1d99b,1,2230
+1039,051953,Transportation,Airport,51,95,Emergent Herbaceous Wetlands,#70A3BA,3,high,#31a354,1,2230
+1040,052110,Transportation,Road and Rail,52,11,Open Water,#476BA0,0,none,#ffffff,0,2230
+1041,052111,Transportation,Road and Rail,52,11,Open Water,#476BA0,1,low,#e5f5e0,0,2230
+1042,052112,Transportation,Road and Rail,52,11,Open Water,#476BA0,2,medium,#a1d99b,0,2230
+1043,052113,Transportation,Road and Rail,52,11,Open Water,#476BA0,3,high,#31a354,1,2230
+1044,052120,Transportation,Road and Rail,52,12,Perennial Ice/Snow,#D1DDF9,0,none,#ffffff,0,2230
+1045,052121,Transportation,Road and Rail,52,12,Perennial Ice/Snow,#D1DDF9,1,low,#e5f5e0,0,2230
+1046,052122,Transportation,Road and Rail,52,12,Perennial Ice/Snow,#D1DDF9,2,medium,#a1d99b,0,2230
+1047,052123,Transportation,Road and Rail,52,12,Perennial Ice/Snow,#D1DDF9,3,high,#31a354,1,2230
+1048,052210,Transportation,Road and Rail,52,21,"Developed, Open Space",#DDC9C9,0,none,#ffffff,0,2230
+1049,052211,Transportation,Road and Rail,52,21,"Developed, Open Space",#DDC9C9,1,low,#e5f5e0,0,2230
+1050,052212,Transportation,Road and Rail,52,21,"Developed, Open Space",#DDC9C9,2,medium,#a1d99b,0,2230
+1051,052213,Transportation,Road and Rail,52,21,"Developed, Open Space",#DDC9C9,3,high,#31a354,1,2230
+1052,052220,Transportation,Road and Rail,52,22,"Developed, Low Intensity",#D89382,0,none,#ffffff,0,2230
+1053,052221,Transportation,Road and Rail,52,22,"Developed, Low Intensity",#D89382,1,low,#e5f5e0,0,2230
+1054,052222,Transportation,Road and Rail,52,22,"Developed, Low Intensity",#D89382,2,medium,#a1d99b,0,2230
+1055,052223,Transportation,Road and Rail,52,22,"Developed, Low Intensity",#D89382,3,high,#31a354,1,2230
+1056,052230,Transportation,Road and Rail,52,23,"Developed, Medium Intensity",#ED0000,0,none,#ffffff,0,2230
+1057,052231,Transportation,Road and Rail,52,23,"Developed, Medium Intensity",#ED0000,1,low,#e5f5e0,0,2230
+1058,052232,Transportation,Road and Rail,52,23,"Developed, Medium Intensity",#ED0000,2,medium,#a1d99b,0,2230
+1059,052233,Transportation,Road and Rail,52,23,"Developed, Medium Intensity",#ED0000,3,high,#31a354,1,2230
+1060,052240,Transportation,Road and Rail,52,24,"Developed, High Intensity",#AA0000,0,none,#ffffff,0,2230
+1061,052241,Transportation,Road and Rail,52,24,"Developed, High Intensity",#AA0000,1,low,#e5f5e0,0,2230
+1062,052242,Transportation,Road and Rail,52,24,"Developed, High Intensity",#AA0000,2,medium,#a1d99b,0,2230
+1063,052243,Transportation,Road and Rail,52,24,"Developed, High Intensity",#AA0000,3,high,#31a354,1,2230
+1064,052310,Transportation,Road and Rail,52,31,Barren Land (Rock/Sand/Clay),#B2ADA3,0,none,#ffffff,0,2230
+1065,052311,Transportation,Road and Rail,52,31,Barren Land (Rock/Sand/Clay),#B2ADA3,1,low,#e5f5e0,0,2230
+1066,052312,Transportation,Road and Rail,52,31,Barren Land (Rock/Sand/Clay),#B2ADA3,2,medium,#a1d99b,0,2230
+1067,052313,Transportation,Road and Rail,52,31,Barren Land (Rock/Sand/Clay),#B2ADA3,3,high,#31a354,1,2230
+1068,052410,Transportation,Road and Rail,52,41,Deciduous Forest,#68AA63,0,none,#ffffff,1,2230
+1069,052411,Transportation,Road and Rail,52,41,Deciduous Forest,#68AA63,1,low,#e5f5e0,1,2230
+1070,052412,Transportation,Road and Rail,52,41,Deciduous Forest,#68AA63,2,medium,#a1d99b,1,2230
+1071,052413,Transportation,Road and Rail,52,41,Deciduous Forest,#68AA63,3,high,#31a354,1,2230
+1072,052420,Transportation,Road and Rail,52,42,Evergreen Forest,#1C6330,0,none,#ffffff,1,2230
+1073,052421,Transportation,Road and Rail,52,42,Evergreen Forest,#1C6330,1,low,#e5f5e0,1,2230
+1074,052422,Transportation,Road and Rail,52,42,Evergreen Forest,#1C6330,2,medium,#a1d99b,1,2230
+1075,052423,Transportation,Road and Rail,52,42,Evergreen Forest,#1C6330,3,high,#31a354,1,2230
+1076,052430,Transportation,Road and Rail,52,43,Mixed Forest,#B5C98E,0,none,#ffffff,1,2230
+1077,052431,Transportation,Road and Rail,52,43,Mixed Forest,#B5C98E,1,low,#e5f5e0,1,2230
+1078,052432,Transportation,Road and Rail,52,43,Mixed Forest,#B5C98E,2,medium,#a1d99b,1,2230
+1079,052433,Transportation,Road and Rail,52,43,Mixed Forest,#B5C98E,3,high,#31a354,1,2230
+1080,052510,Transportation,Road and Rail,52,51,Dwarf Scrub,#A58C30,0,none,#ffffff,0,
+1081,052511,Transportation,Road and Rail,52,51,Dwarf Scrub,#A58C30,1,low,#e5f5e0,0,
+1082,052512,Transportation,Road and Rail,52,51,Dwarf Scrub,#A58C30,2,medium,#a1d99b,0,
+1083,052513,Transportation,Road and Rail,52,51,Dwarf Scrub,#A58C30,3,high,#31a354,1,
+1084,052520,Transportation,Road and Rail,52,52,Scrub/Shrub,#CCBA7C,0,none,#ffffff,1,2230
+1085,052521,Transportation,Road and Rail,52,52,Scrub/Shrub,#CCBA7C,1,low,#e5f5e0,1,2230
+1086,052522,Transportation,Road and Rail,52,52,Scrub/Shrub,#CCBA7C,2,medium,#a1d99b,1,2230
+1087,052523,Transportation,Road and Rail,52,52,Scrub/Shrub,#CCBA7C,3,high,#31a354,1,2230
+1088,052710,Transportation,Road and Rail,52,71,Grassland/Herbaceous,#E2E2C1,0,none,#ffffff,1,2230
+1089,052711,Transportation,Road and Rail,52,71,Grassland/Herbaceous,#E2E2C1,1,low,#e5f5e0,1,2230
+1090,052712,Transportation,Road and Rail,52,71,Grassland/Herbaceous,#E2E2C1,2,medium,#a1d99b,1,2230
+1091,052713,Transportation,Road and Rail,52,71,Grassland/Herbaceous,#E2E2C1,3,high,#31a354,1,2230
+1092,052720,Transportation,Road and Rail,52,72,Sedge/Herbaceuous,#C9C977,0,none,#ffffff,0,
+1093,052721,Transportation,Road and Rail,52,72,Sedge/Herbaceuous,#C9C977,1,low,#e5f5e0,0,
+1094,052722,Transportation,Road and Rail,52,72,Sedge/Herbaceuous,#C9C977,2,medium,#a1d99b,0,
+1095,052723,Transportation,Road and Rail,52,72,Sedge/Herbaceuous,#C9C977,3,high,#31a354,1,
+1096,052730,Transportation,Road and Rail,52,73,Lichens,#99C147,0,none,#ffffff,0,
+1097,052731,Transportation,Road and Rail,52,73,Lichens,#99C147,1,low,#e5f5e0,0,
+1098,052732,Transportation,Road and Rail,52,73,Lichens,#99C147,2,medium,#a1d99b,0,
+1099,052733,Transportation,Road and Rail,52,73,Lichens,#99C147,3,high,#31a354,1,
+1100,052740,Transportation,Road and Rail,52,74,Moss,#77AD93,0,none,#ffffff,0,
+1101,052741,Transportation,Road and Rail,52,74,Moss,#77AD93,1,low,#e5f5e0,0,
+1102,052742,Transportation,Road and Rail,52,74,Moss,#77AD93,2,medium,#a1d99b,0,
+1103,052743,Transportation,Road and Rail,52,74,Moss,#77AD93,3,high,#31a354,1,
+1104,052810,Transportation,Road and Rail,52,81,Pasture/Hay,#DBD83D,0,none,#ffffff,0,2230
+1105,052811,Transportation,Road and Rail,52,81,Pasture/Hay,#DBD83D,1,low,#e5f5e0,0,2230
+1106,052812,Transportation,Road and Rail,52,81,Pasture/Hay,#DBD83D,2,medium,#a1d99b,0,2230
+1107,052813,Transportation,Road and Rail,52,81,Pasture/Hay,#DBD83D,3,high,#31a354,1,2230
+1108,052820,Transportation,Road and Rail,52,82,Cultivated Crops,#AA7028,0,none,#ffffff,0,2230
+1109,052821,Transportation,Road and Rail,52,82,Cultivated Crops,#AA7028,1,low,#e5f5e0,0,2230
+1110,052822,Transportation,Road and Rail,52,82,Cultivated Crops,#AA7028,2,medium,#a1d99b,0,2230
+1111,052823,Transportation,Road and Rail,52,82,Cultivated Crops,#AA7028,3,high,#31a354,1,2230
+1112,052900,Transportation,Road and Rail,52,90,Woody Wetlands,#BAD8EA,0,none,#ffffff,1,2230
+1113,052901,Transportation,Road and Rail,52,90,Woody Wetlands,#BAD8EA,1,low,#e5f5e0,1,2230
+1114,052902,Transportation,Road and Rail,52,90,Woody Wetlands,#BAD8EA,2,medium,#a1d99b,1,2230
+1115,052903,Transportation,Road and Rail,52,90,Woody Wetlands,#BAD8EA,3,high,#31a354,1,2230
+1116,052950,Transportation,Road and Rail,52,95,Emergent Herbaceous Wetlands,#70A3BA,0,none,#ffffff,1,2230
+1117,052951,Transportation,Road and Rail,52,95,Emergent Herbaceous Wetlands,#70A3BA,1,low,#e5f5e0,1,2230
+1118,052952,Transportation,Road and Rail,52,95,Emergent Herbaceous Wetlands,#70A3BA,2,medium,#a1d99b,1,2230
+1119,052953,Transportation,Road and Rail,52,95,Emergent Herbaceous Wetlands,#70A3BA,3,high,#31a354,1,2230
+1120,053110,Transportation,Other,53,11,Open Water,#476BA0,0,none,#ffffff,0,2230
+1121,053111,Transportation,Other,53,11,Open Water,#476BA0,1,low,#e5f5e0,0,2230
+1122,053112,Transportation,Other,53,11,Open Water,#476BA0,2,medium,#a1d99b,0,2230
+1123,053113,Transportation,Other,53,11,Open Water,#476BA0,3,high,#31a354,1,2230
+1124,053120,Transportation,Other,53,12,Perennial Ice/Snow,#D1DDF9,0,none,#ffffff,0,2230
+1125,053121,Transportation,Other,53,12,Perennial Ice/Snow,#D1DDF9,1,low,#e5f5e0,0,2230
+1126,053122,Transportation,Other,53,12,Perennial Ice/Snow,#D1DDF9,2,medium,#a1d99b,0,2230
+1127,053123,Transportation,Other,53,12,Perennial Ice/Snow,#D1DDF9,3,high,#31a354,1,2230
+1128,053210,Transportation,Other,53,21,"Developed, Open Space",#DDC9C9,0,none,#ffffff,0,2230
+1129,053211,Transportation,Other,53,21,"Developed, Open Space",#DDC9C9,1,low,#e5f5e0,0,2230
+1130,053212,Transportation,Other,53,21,"Developed, Open Space",#DDC9C9,2,medium,#a1d99b,0,2230
+1131,053213,Transportation,Other,53,21,"Developed, Open Space",#DDC9C9,3,high,#31a354,1,2230
+1132,053220,Transportation,Other,53,22,"Developed, Low Intensity",#D89382,0,none,#ffffff,0,2230
+1133,053221,Transportation,Other,53,22,"Developed, Low Intensity",#D89382,1,low,#e5f5e0,0,2230
+1134,053222,Transportation,Other,53,22,"Developed, Low Intensity",#D89382,2,medium,#a1d99b,0,2230
+1135,053223,Transportation,Other,53,22,"Developed, Low Intensity",#D89382,3,high,#31a354,1,2230
+1136,053230,Transportation,Other,53,23,"Developed, Medium Intensity",#ED0000,0,none,#ffffff,0,2230
+1137,053231,Transportation,Other,53,23,"Developed, Medium Intensity",#ED0000,1,low,#e5f5e0,0,2230
+1138,053232,Transportation,Other,53,23,"Developed, Medium Intensity",#ED0000,2,medium,#a1d99b,0,2230
+1139,053233,Transportation,Other,53,23,"Developed, Medium Intensity",#ED0000,3,high,#31a354,1,2230
+1140,053240,Transportation,Other,53,24,"Developed, High Intensity",#AA0000,0,none,#ffffff,0,2230
+1141,053241,Transportation,Other,53,24,"Developed, High Intensity",#AA0000,1,low,#e5f5e0,0,2230
+1142,053242,Transportation,Other,53,24,"Developed, High Intensity",#AA0000,2,medium,#a1d99b,0,2230
+1143,053243,Transportation,Other,53,24,"Developed, High Intensity",#AA0000,3,high,#31a354,1,2230
+1144,053310,Transportation,Other,53,31,Barren Land (Rock/Sand/Clay),#B2ADA3,0,none,#ffffff,0,2230
+1145,053311,Transportation,Other,53,31,Barren Land (Rock/Sand/Clay),#B2ADA3,1,low,#e5f5e0,0,2230
+1146,053312,Transportation,Other,53,31,Barren Land (Rock/Sand/Clay),#B2ADA3,2,medium,#a1d99b,0,2230
+1147,053313,Transportation,Other,53,31,Barren Land (Rock/Sand/Clay),#B2ADA3,3,high,#31a354,1,2230
+1148,053410,Transportation,Other,53,41,Deciduous Forest,#68AA63,0,none,#ffffff,1,2230
+1149,053411,Transportation,Other,53,41,Deciduous Forest,#68AA63,1,low,#e5f5e0,1,2230
+1150,053412,Transportation,Other,53,41,Deciduous Forest,#68AA63,2,medium,#a1d99b,1,2230
+1151,053413,Transportation,Other,53,41,Deciduous Forest,#68AA63,3,high,#31a354,1,2230
+1152,053420,Transportation,Other,53,42,Evergreen Forest,#1C6330,0,none,#ffffff,1,2230
+1153,053421,Transportation,Other,53,42,Evergreen Forest,#1C6330,1,low,#e5f5e0,1,2230
+1154,053422,Transportation,Other,53,42,Evergreen Forest,#1C6330,2,medium,#a1d99b,1,2230
+1155,053423,Transportation,Other,53,42,Evergreen Forest,#1C6330,3,high,#31a354,1,2230
+1156,053430,Transportation,Other,53,43,Mixed Forest,#B5C98E,0,none,#ffffff,1,2230
+1157,053431,Transportation,Other,53,43,Mixed Forest,#B5C98E,1,low,#e5f5e0,1,2230
+1158,053432,Transportation,Other,53,43,Mixed Forest,#B5C98E,2,medium,#a1d99b,1,2230
+1159,053433,Transportation,Other,53,43,Mixed Forest,#B5C98E,3,high,#31a354,1,2230
+1160,053510,Transportation,Other,53,51,Dwarf Scrub,#A58C30,0,none,#ffffff,0,
+1161,053511,Transportation,Other,53,51,Dwarf Scrub,#A58C30,1,low,#e5f5e0,0,
+1162,053512,Transportation,Other,53,51,Dwarf Scrub,#A58C30,2,medium,#a1d99b,0,
+1163,053513,Transportation,Other,53,51,Dwarf Scrub,#A58C30,3,high,#31a354,1,
+1164,053520,Transportation,Other,53,52,Scrub/Shrub,#CCBA7C,0,none,#ffffff,1,2230
+1165,053521,Transportation,Other,53,52,Scrub/Shrub,#CCBA7C,1,low,#e5f5e0,1,2230
+1166,053522,Transportation,Other,53,52,Scrub/Shrub,#CCBA7C,2,medium,#a1d99b,1,2230
+1167,053523,Transportation,Other,53,52,Scrub/Shrub,#CCBA7C,3,high,#31a354,1,2230
+1168,053710,Transportation,Other,53,71,Grassland/Herbaceous,#E2E2C1,0,none,#ffffff,1,2230
+1169,053711,Transportation,Other,53,71,Grassland/Herbaceous,#E2E2C1,1,low,#e5f5e0,1,2230
+1170,053712,Transportation,Other,53,71,Grassland/Herbaceous,#E2E2C1,2,medium,#a1d99b,1,2230
+1171,053713,Transportation,Other,53,71,Grassland/Herbaceous,#E2E2C1,3,high,#31a354,1,2230
+1172,053720,Transportation,Other,53,72,Sedge/Herbaceuous,#C9C977,0,none,#ffffff,0,
+1173,053721,Transportation,Other,53,72,Sedge/Herbaceuous,#C9C977,1,low,#e5f5e0,0,
+1174,053722,Transportation,Other,53,72,Sedge/Herbaceuous,#C9C977,2,medium,#a1d99b,0,
+1175,053723,Transportation,Other,53,72,Sedge/Herbaceuous,#C9C977,3,high,#31a354,1,
+1176,053730,Transportation,Other,53,73,Lichens,#99C147,0,none,#ffffff,0,
+1177,053731,Transportation,Other,53,73,Lichens,#99C147,1,low,#e5f5e0,0,
+1178,053732,Transportation,Other,53,73,Lichens,#99C147,2,medium,#a1d99b,0,
+1179,053733,Transportation,Other,53,73,Lichens,#99C147,3,high,#31a354,1,
+1180,053740,Transportation,Other,53,74,Moss,#77AD93,0,none,#ffffff,0,
+1181,053741,Transportation,Other,53,74,Moss,#77AD93,1,low,#e5f5e0,0,
+1182,053742,Transportation,Other,53,74,Moss,#77AD93,2,medium,#a1d99b,0,
+1183,053743,Transportation,Other,53,74,Moss,#77AD93,3,high,#31a354,1,
+1184,053810,Transportation,Other,53,81,Pasture/Hay,#DBD83D,0,none,#ffffff,0,2230
+1185,053811,Transportation,Other,53,81,Pasture/Hay,#DBD83D,1,low,#e5f5e0,0,2230
+1186,053812,Transportation,Other,53,81,Pasture/Hay,#DBD83D,2,medium,#a1d99b,0,2230
+1187,053813,Transportation,Other,53,81,Pasture/Hay,#DBD83D,3,high,#31a354,1,2230
+1188,053820,Transportation,Other,53,82,Cultivated Crops,#AA7028,0,none,#ffffff,0,2230
+1189,053821,Transportation,Other,53,82,Cultivated Crops,#AA7028,1,low,#e5f5e0,0,2230
+1190,053822,Transportation,Other,53,82,Cultivated Crops,#AA7028,2,medium,#a1d99b,0,2230
+1191,053823,Transportation,Other,53,82,Cultivated Crops,#AA7028,3,high,#31a354,1,2230
+1192,053900,Transportation,Other,53,90,Woody Wetlands,#BAD8EA,0,none,#ffffff,1,2230
+1193,053901,Transportation,Other,53,90,Woody Wetlands,#BAD8EA,1,low,#e5f5e0,1,2230
+1194,053902,Transportation,Other,53,90,Woody Wetlands,#BAD8EA,2,medium,#a1d99b,1,2230
+1195,053903,Transportation,Other,53,90,Woody Wetlands,#BAD8EA,3,high,#31a354,1,2230
+1196,053950,Transportation,Other,53,95,Emergent Herbaceous Wetlands,#70A3BA,0,none,#ffffff,1,2230
+1197,053951,Transportation,Other,53,95,Emergent Herbaceous Wetlands,#70A3BA,1,low,#e5f5e0,1,2230
+1198,053952,Transportation,Other,53,95,Emergent Herbaceous Wetlands,#70A3BA,2,medium,#a1d99b,1,2230
+1199,053953,Transportation,Other,53,95,Emergent Herbaceous Wetlands,#70A3BA,3,high,#31a354,1,2230
+1200,060110,Other Development,,60,11,Open Water,#476BA0,0,none,#ffffff,0,2230
+1201,060111,Other Development,,60,11,Open Water,#476BA0,1,low,#e5f5e0,0,2230
+1202,060112,Other Development,,60,11,Open Water,#476BA0,2,medium,#a1d99b,0,2230
+1203,060113,Other Development,,60,11,Open Water,#476BA0,3,high,#31a354,1,2230
+1204,060120,Other Development,,60,12,Perennial Ice/Snow,#D1DDF9,0,none,#ffffff,0,2230
+1205,060121,Other Development,,60,12,Perennial Ice/Snow,#D1DDF9,1,low,#e5f5e0,0,2230
+1206,060122,Other Development,,60,12,Perennial Ice/Snow,#D1DDF9,2,medium,#a1d99b,0,2230
+1207,060123,Other Development,,60,12,Perennial Ice/Snow,#D1DDF9,3,high,#31a354,1,2230
+1208,060210,Other Development,,60,21,"Developed, Open Space",#DDC9C9,0,none,#ffffff,0,2230
+1209,060211,Other Development,,60,21,"Developed, Open Space",#DDC9C9,1,low,#e5f5e0,0,2230
+1210,060212,Other Development,,60,21,"Developed, Open Space",#DDC9C9,2,medium,#a1d99b,0,2230
+1211,060213,Other Development,,60,21,"Developed, Open Space",#DDC9C9,3,high,#31a354,1,2230
+1212,060220,Other Development,,60,22,"Developed, Low Intensity",#D89382,0,none,#ffffff,0,2230
+1213,060221,Other Development,,60,22,"Developed, Low Intensity",#D89382,1,low,#e5f5e0,0,2230
+1214,060222,Other Development,,60,22,"Developed, Low Intensity",#D89382,2,medium,#a1d99b,0,2230
+1215,060223,Other Development,,60,22,"Developed, Low Intensity",#D89382,3,high,#31a354,1,2230
+1216,060230,Other Development,,60,23,"Developed, Medium Intensity",#ED0000,0,none,#ffffff,0,2230
+1217,060231,Other Development,,60,23,"Developed, Medium Intensity",#ED0000,1,low,#e5f5e0,0,2230
+1218,060232,Other Development,,60,23,"Developed, Medium Intensity",#ED0000,2,medium,#a1d99b,0,2230
+1219,060233,Other Development,,60,23,"Developed, Medium Intensity",#ED0000,3,high,#31a354,1,2230
+1220,060240,Other Development,,60,24,"Developed, High Intensity",#AA0000,0,none,#ffffff,0,2230
+1221,060241,Other Development,,60,24,"Developed, High Intensity",#AA0000,1,low,#e5f5e0,0,2230
+1222,060242,Other Development,,60,24,"Developed, High Intensity",#AA0000,2,medium,#a1d99b,0,2230
+1223,060243,Other Development,,60,24,"Developed, High Intensity",#AA0000,3,high,#31a354,1,2230
+1224,060310,Other Development,,60,31,Barren Land (Rock/Sand/Clay),#B2ADA3,0,none,#ffffff,0,2230
+1225,060311,Other Development,,60,31,Barren Land (Rock/Sand/Clay),#B2ADA3,1,low,#e5f5e0,0,2230
+1226,060312,Other Development,,60,31,Barren Land (Rock/Sand/Clay),#B2ADA3,2,medium,#a1d99b,0,2230
+1227,060313,Other Development,,60,31,Barren Land (Rock/Sand/Clay),#B2ADA3,3,high,#31a354,1,2230
+1228,060410,Other Development,,60,41,Deciduous Forest,#68AA63,0,none,#ffffff,1,2230
+1229,060411,Other Development,,60,41,Deciduous Forest,#68AA63,1,low,#e5f5e0,1,2230
+1230,060412,Other Development,,60,41,Deciduous Forest,#68AA63,2,medium,#a1d99b,1,2230
+1231,060413,Other Development,,60,41,Deciduous Forest,#68AA63,3,high,#31a354,1,2230
+1232,060420,Other Development,,60,42,Evergreen Forest,#1C6330,0,none,#ffffff,1,2230
+1233,060421,Other Development,,60,42,Evergreen Forest,#1C6330,1,low,#e5f5e0,1,2230
+1234,060422,Other Development,,60,42,Evergreen Forest,#1C6330,2,medium,#a1d99b,1,2230
+1235,060423,Other Development,,60,42,Evergreen Forest,#1C6330,3,high,#31a354,1,2230
+1236,060430,Other Development,,60,43,Mixed Forest,#B5C98E,0,none,#ffffff,1,2230
+1237,060431,Other Development,,60,43,Mixed Forest,#B5C98E,1,low,#e5f5e0,1,2230
+1238,060432,Other Development,,60,43,Mixed Forest,#B5C98E,2,medium,#a1d99b,1,2230
+1239,060433,Other Development,,60,43,Mixed Forest,#B5C98E,3,high,#31a354,1,2230
+1240,060510,Other Development,,60,51,Dwarf Scrub,#A58C30,0,none,#ffffff,0,
+1241,060511,Other Development,,60,51,Dwarf Scrub,#A58C30,1,low,#e5f5e0,0,
+1242,060512,Other Development,,60,51,Dwarf Scrub,#A58C30,2,medium,#a1d99b,0,
+1243,060513,Other Development,,60,51,Dwarf Scrub,#A58C30,3,high,#31a354,1,
+1244,060520,Other Development,,60,52,Scrub/Shrub,#CCBA7C,0,none,#ffffff,1,2230
+1245,060521,Other Development,,60,52,Scrub/Shrub,#CCBA7C,1,low,#e5f5e0,1,2230
+1246,060522,Other Development,,60,52,Scrub/Shrub,#CCBA7C,2,medium,#a1d99b,1,2230
+1247,060523,Other Development,,60,52,Scrub/Shrub,#CCBA7C,3,high,#31a354,1,2230
+1248,060710,Other Development,,60,71,Grassland/Herbaceous,#E2E2C1,0,none,#ffffff,1,2230
+1249,060711,Other Development,,60,71,Grassland/Herbaceous,#E2E2C1,1,low,#e5f5e0,1,2230
+1250,060712,Other Development,,60,71,Grassland/Herbaceous,#E2E2C1,2,medium,#a1d99b,1,2230
+1251,060713,Other Development,,60,71,Grassland/Herbaceous,#E2E2C1,3,high,#31a354,1,2230
+1252,060720,Other Development,,60,72,Sedge/Herbaceuous,#C9C977,0,none,#ffffff,0,
+1253,060721,Other Development,,60,72,Sedge/Herbaceuous,#C9C977,1,low,#e5f5e0,0,
+1254,060722,Other Development,,60,72,Sedge/Herbaceuous,#C9C977,2,medium,#a1d99b,0,
+1255,060723,Other Development,,60,72,Sedge/Herbaceuous,#C9C977,3,high,#31a354,1,
+1256,060730,Other Development,,60,73,Lichens,#99C147,0,none,#ffffff,0,
+1257,060731,Other Development,,60,73,Lichens,#99C147,1,low,#e5f5e0,0,
+1258,060732,Other Development,,60,73,Lichens,#99C147,2,medium,#a1d99b,0,
+1259,060733,Other Development,,60,73,Lichens,#99C147,3,high,#31a354,1,
+1260,060740,Other Development,,60,74,Moss,#77AD93,0,none,#ffffff,0,
+1261,060741,Other Development,,60,74,Moss,#77AD93,1,low,#e5f5e0,0,
+1262,060742,Other Development,,60,74,Moss,#77AD93,2,medium,#a1d99b,0,
+1263,060743,Other Development,,60,74,Moss,#77AD93,3,high,#31a354,1,
+1264,060810,Other Development,,60,81,Pasture/Hay,#DBD83D,0,none,#ffffff,0,2230
+1265,060811,Other Development,,60,81,Pasture/Hay,#DBD83D,1,low,#e5f5e0,0,2230
+1266,060812,Other Development,,60,81,Pasture/Hay,#DBD83D,2,medium,#a1d99b,0,2230
+1267,060813,Other Development,,60,81,Pasture/Hay,#DBD83D,3,high,#31a354,1,2230
+1268,060820,Other Development,,60,82,Cultivated Crops,#AA7028,0,none,#ffffff,0,2230
+1269,060821,Other Development,,60,82,Cultivated Crops,#AA7028,1,low,#e5f5e0,0,2230
+1270,060822,Other Development,,60,82,Cultivated Crops,#AA7028,2,medium,#a1d99b,0,2230
+1271,060823,Other Development,,60,82,Cultivated Crops,#AA7028,3,high,#31a354,1,2230
+1272,060900,Other Development,,60,90,Woody Wetlands,#BAD8EA,0,none,#ffffff,1,2230
+1273,060901,Other Development,,60,90,Woody Wetlands,#BAD8EA,1,low,#e5f5e0,1,2230
+1274,060902,Other Development,,60,90,Woody Wetlands,#BAD8EA,2,medium,#a1d99b,1,2230
+1275,060903,Other Development,,60,90,Woody Wetlands,#BAD8EA,3,high,#31a354,1,2230
+1276,060950,Other Development,,60,95,Emergent Herbaceous Wetlands,#70A3BA,0,none,#ffffff,1,2230
+1277,060951,Other Development,,60,95,Emergent Herbaceous Wetlands,#70A3BA,1,low,#e5f5e0,1,2230
+1278,060952,Other Development,,60,95,Emergent Herbaceous Wetlands,#70A3BA,2,medium,#a1d99b,1,2230
+1279,060953,Other Development,,60,95,Emergent Herbaceous Wetlands,#70A3BA,3,high,#31a354,1,2230
+1280,070110,Agriculture,,70,11,Open Water,#476BA0,0,none,#ffffff,0,2230
+1281,070111,Agriculture,,70,11,Open Water,#476BA0,1,low,#e5f5e0,0,2230
+1282,070112,Agriculture,,70,11,Open Water,#476BA0,2,medium,#a1d99b,0,2230
+1283,070113,Agriculture,,70,11,Open Water,#476BA0,3,high,#31a354,1,2230
+1284,070120,Agriculture,,70,12,Perennial Ice/Snow,#D1DDF9,0,none,#ffffff,0,2230
+1285,070121,Agriculture,,70,12,Perennial Ice/Snow,#D1DDF9,1,low,#e5f5e0,0,2230
+1286,070122,Agriculture,,70,12,Perennial Ice/Snow,#D1DDF9,2,medium,#a1d99b,0,2230
+1287,070123,Agriculture,,70,12,Perennial Ice/Snow,#D1DDF9,3,high,#31a354,1,2230
+1288,070210,Agriculture,,70,21,"Developed, Open Space",#DDC9C9,0,none,#ffffff,0,2230
+1289,070211,Agriculture,,70,21,"Developed, Open Space",#DDC9C9,1,low,#e5f5e0,0,2230
+1290,070212,Agriculture,,70,21,"Developed, Open Space",#DDC9C9,2,medium,#a1d99b,0,2230
+1291,070213,Agriculture,,70,21,"Developed, Open Space",#DDC9C9,3,high,#31a354,1,2230
+1292,070220,Agriculture,,70,22,"Developed, Low Intensity",#D89382,0,none,#ffffff,0,2230
+1293,070221,Agriculture,,70,22,"Developed, Low Intensity",#D89382,1,low,#e5f5e0,0,2230
+1294,070222,Agriculture,,70,22,"Developed, Low Intensity",#D89382,2,medium,#a1d99b,0,2230
+1295,070223,Agriculture,,70,22,"Developed, Low Intensity",#D89382,3,high,#31a354,1,2230
+1296,070230,Agriculture,,70,23,"Developed, Medium Intensity",#ED0000,0,none,#ffffff,0,2230
+1297,070231,Agriculture,,70,23,"Developed, Medium Intensity",#ED0000,1,low,#e5f5e0,0,2230
+1298,070232,Agriculture,,70,23,"Developed, Medium Intensity",#ED0000,2,medium,#a1d99b,0,2230
+1299,070233,Agriculture,,70,23,"Developed, Medium Intensity",#ED0000,3,high,#31a354,1,2230
+1300,070240,Agriculture,,70,24,"Developed, High Intensity",#AA0000,0,none,#ffffff,0,2230
+1301,070241,Agriculture,,70,24,"Developed, High Intensity",#AA0000,1,low,#e5f5e0,0,2230
+1302,070242,Agriculture,,70,24,"Developed, High Intensity",#AA0000,2,medium,#a1d99b,0,2230
+1303,070243,Agriculture,,70,24,"Developed, High Intensity",#AA0000,3,high,#31a354,1,2230
+1304,070310,Agriculture,,70,31,Barren Land (Rock/Sand/Clay),#B2ADA3,0,none,#ffffff,0,2230
+1305,070311,Agriculture,,70,31,Barren Land (Rock/Sand/Clay),#B2ADA3,1,low,#e5f5e0,0,2230
+1306,070312,Agriculture,,70,31,Barren Land (Rock/Sand/Clay),#B2ADA3,2,medium,#a1d99b,0,2230
+1307,070313,Agriculture,,70,31,Barren Land (Rock/Sand/Clay),#B2ADA3,3,high,#31a354,1,2230
+1308,070410,Agriculture,,70,41,Deciduous Forest,#68AA63,0,none,#ffffff,1,2230
+1309,070411,Agriculture,,70,41,Deciduous Forest,#68AA63,1,low,#e5f5e0,1,2230
+1310,070412,Agriculture,,70,41,Deciduous Forest,#68AA63,2,medium,#a1d99b,1,2230
+1311,070413,Agriculture,,70,41,Deciduous Forest,#68AA63,3,high,#31a354,1,2230
+1312,070420,Agriculture,,70,42,Evergreen Forest,#1C6330,0,none,#ffffff,1,2230
+1313,070421,Agriculture,,70,42,Evergreen Forest,#1C6330,1,low,#e5f5e0,1,2230
+1314,070422,Agriculture,,70,42,Evergreen Forest,#1C6330,2,medium,#a1d99b,1,2230
+1315,070423,Agriculture,,70,42,Evergreen Forest,#1C6330,3,high,#31a354,1,2230
+1316,070430,Agriculture,,70,43,Mixed Forest,#B5C98E,0,none,#ffffff,1,2230
+1317,070431,Agriculture,,70,43,Mixed Forest,#B5C98E,1,low,#e5f5e0,1,2230
+1318,070432,Agriculture,,70,43,Mixed Forest,#B5C98E,2,medium,#a1d99b,1,2230
+1319,070433,Agriculture,,70,43,Mixed Forest,#B5C98E,3,high,#31a354,1,2230
+1320,070510,Agriculture,,70,51,Dwarf Scrub,#A58C30,0,none,#ffffff,0,
+1321,070511,Agriculture,,70,51,Dwarf Scrub,#A58C30,1,low,#e5f5e0,0,
+1322,070512,Agriculture,,70,51,Dwarf Scrub,#A58C30,2,medium,#a1d99b,0,
+1323,070513,Agriculture,,70,51,Dwarf Scrub,#A58C30,3,high,#31a354,1,
+1324,070520,Agriculture,,70,52,Scrub/Shrub,#CCBA7C,0,none,#ffffff,1,2230
+1325,070521,Agriculture,,70,52,Scrub/Shrub,#CCBA7C,1,low,#e5f5e0,1,2230
+1326,070522,Agriculture,,70,52,Scrub/Shrub,#CCBA7C,2,medium,#a1d99b,1,2230
+1327,070523,Agriculture,,70,52,Scrub/Shrub,#CCBA7C,3,high,#31a354,1,2230
+1328,070710,Agriculture,,70,71,Grassland/Herbaceous,#E2E2C1,0,none,#ffffff,1,2230
+1329,070711,Agriculture,,70,71,Grassland/Herbaceous,#E2E2C1,1,low,#e5f5e0,1,2230
+1330,070712,Agriculture,,70,71,Grassland/Herbaceous,#E2E2C1,2,medium,#a1d99b,1,2230
+1331,070713,Agriculture,,70,71,Grassland/Herbaceous,#E2E2C1,3,high,#31a354,1,2230
+1332,070720,Agriculture,,70,72,Sedge/Herbaceuous,#C9C977,0,none,#ffffff,0,
+1333,070721,Agriculture,,70,72,Sedge/Herbaceuous,#C9C977,1,low,#e5f5e0,0,
+1334,070722,Agriculture,,70,72,Sedge/Herbaceuous,#C9C977,2,medium,#a1d99b,0,
+1335,070723,Agriculture,,70,72,Sedge/Herbaceuous,#C9C977,3,high,#31a354,1,
+1336,070730,Agriculture,,70,73,Lichens,#99C147,0,none,#ffffff,0,
+1337,070731,Agriculture,,70,73,Lichens,#99C147,1,low,#e5f5e0,0,
+1338,070732,Agriculture,,70,73,Lichens,#99C147,2,medium,#a1d99b,0,
+1339,070733,Agriculture,,70,73,Lichens,#99C147,3,high,#31a354,1,
+1340,070740,Agriculture,,70,74,Moss,#77AD93,0,none,#ffffff,0,
+1341,070741,Agriculture,,70,74,Moss,#77AD93,1,low,#e5f5e0,0,
+1342,070742,Agriculture,,70,74,Moss,#77AD93,2,medium,#a1d99b,0,
+1343,070743,Agriculture,,70,74,Moss,#77AD93,3,high,#31a354,1,
+1344,070810,Agriculture,,70,81,Pasture/Hay,#DBD83D,0,none,#ffffff,0,2230
+1345,070811,Agriculture,,70,81,Pasture/Hay,#DBD83D,1,low,#e5f5e0,0,2230
+1346,070812,Agriculture,,70,81,Pasture/Hay,#DBD83D,2,medium,#a1d99b,0,2230
+1347,070813,Agriculture,,70,81,Pasture/Hay,#DBD83D,3,high,#31a354,1,2230
+1348,070820,Agriculture,,70,82,Cultivated Crops,#AA7028,0,none,#ffffff,0,2230
+1349,070821,Agriculture,,70,82,Cultivated Crops,#AA7028,1,low,#e5f5e0,0,2230
+1350,070822,Agriculture,,70,82,Cultivated Crops,#AA7028,2,medium,#a1d99b,0,2230
+1351,070823,Agriculture,,70,82,Cultivated Crops,#AA7028,3,high,#31a354,1,2230
+1352,070900,Agriculture,,70,90,Woody Wetlands,#BAD8EA,0,none,#ffffff,1,2230
+1353,070901,Agriculture,,70,90,Woody Wetlands,#BAD8EA,1,low,#e5f5e0,1,2230
+1354,070902,Agriculture,,70,90,Woody Wetlands,#BAD8EA,2,medium,#a1d99b,1,2230
+1355,070903,Agriculture,,70,90,Woody Wetlands,#BAD8EA,3,high,#31a354,1,2230
+1356,070950,Agriculture,,70,95,Emergent Herbaceous Wetlands,#70A3BA,0,none,#ffffff,1,2230
+1357,070951,Agriculture,,70,95,Emergent Herbaceous Wetlands,#70A3BA,1,low,#e5f5e0,1,2230
+1358,070952,Agriculture,,70,95,Emergent Herbaceous Wetlands,#70A3BA,2,medium,#a1d99b,1,2230
+1359,070953,Agriculture,,70,95,Emergent Herbaceous Wetlands,#70A3BA,3,high,#31a354,1,2230
+1360,080110,Rangeland,,80,11,Open Water,#476BA0,0,none,#ffffff,0,2230
+1361,080111,Rangeland,,80,11,Open Water,#476BA0,1,low,#e5f5e0,0,2230
+1362,080112,Rangeland,,80,11,Open Water,#476BA0,2,medium,#a1d99b,0,2230
+1363,080113,Rangeland,,80,11,Open Water,#476BA0,3,high,#31a354,1,2230
+1364,080120,Rangeland,,80,12,Perennial Ice/Snow,#D1DDF9,0,none,#ffffff,0,2230
+1365,080121,Rangeland,,80,12,Perennial Ice/Snow,#D1DDF9,1,low,#e5f5e0,0,2230
+1366,080122,Rangeland,,80,12,Perennial Ice/Snow,#D1DDF9,2,medium,#a1d99b,0,2230
+1367,080123,Rangeland,,80,12,Perennial Ice/Snow,#D1DDF9,3,high,#31a354,1,2230
+1368,080210,Rangeland,,80,21,"Developed, Open Space",#DDC9C9,0,none,#ffffff,0,2230
+1369,080211,Rangeland,,80,21,"Developed, Open Space",#DDC9C9,1,low,#e5f5e0,0,2230
+1370,080212,Rangeland,,80,21,"Developed, Open Space",#DDC9C9,2,medium,#a1d99b,0,2230
+1371,080213,Rangeland,,80,21,"Developed, Open Space",#DDC9C9,3,high,#31a354,1,2230
+1372,080220,Rangeland,,80,22,"Developed, Low Intensity",#D89382,0,none,#ffffff,0,2230
+1373,080221,Rangeland,,80,22,"Developed, Low Intensity",#D89382,1,low,#e5f5e0,0,2230
+1374,080222,Rangeland,,80,22,"Developed, Low Intensity",#D89382,2,medium,#a1d99b,0,2230
+1375,080223,Rangeland,,80,22,"Developed, Low Intensity",#D89382,3,high,#31a354,1,2230
+1376,080230,Rangeland,,80,23,"Developed, Medium Intensity",#ED0000,0,none,#ffffff,0,2230
+1377,080231,Rangeland,,80,23,"Developed, Medium Intensity",#ED0000,1,low,#e5f5e0,0,2230
+1378,080232,Rangeland,,80,23,"Developed, Medium Intensity",#ED0000,2,medium,#a1d99b,0,2230
+1379,080233,Rangeland,,80,23,"Developed, Medium Intensity",#ED0000,3,high,#31a354,1,2230
+1380,080240,Rangeland,,80,24,"Developed, High Intensity",#AA0000,0,none,#ffffff,0,2230
+1381,080241,Rangeland,,80,24,"Developed, High Intensity",#AA0000,1,low,#e5f5e0,0,2230
+1382,080242,Rangeland,,80,24,"Developed, High Intensity",#AA0000,2,medium,#a1d99b,0,2230
+1383,080243,Rangeland,,80,24,"Developed, High Intensity",#AA0000,3,high,#31a354,1,2230
+1384,080310,Rangeland,,80,31,Barren Land (Rock/Sand/Clay),#B2ADA3,0,none,#ffffff,0,2230
+1385,080311,Rangeland,,80,31,Barren Land (Rock/Sand/Clay),#B2ADA3,1,low,#e5f5e0,0,2230
+1386,080312,Rangeland,,80,31,Barren Land (Rock/Sand/Clay),#B2ADA3,2,medium,#a1d99b,0,2230
+1387,080313,Rangeland,,80,31,Barren Land (Rock/Sand/Clay),#B2ADA3,3,high,#31a354,1,2230
+1388,080410,Rangeland,,80,41,Deciduous Forest,#68AA63,0,none,#ffffff,1,2230
+1389,080411,Rangeland,,80,41,Deciduous Forest,#68AA63,1,low,#e5f5e0,1,2230
+1390,080412,Rangeland,,80,41,Deciduous Forest,#68AA63,2,medium,#a1d99b,1,2230
+1391,080413,Rangeland,,80,41,Deciduous Forest,#68AA63,3,high,#31a354,1,2230
+1392,080420,Rangeland,,80,42,Evergreen Forest,#1C6330,0,none,#ffffff,1,2230
+1393,080421,Rangeland,,80,42,Evergreen Forest,#1C6330,1,low,#e5f5e0,1,2230
+1394,080422,Rangeland,,80,42,Evergreen Forest,#1C6330,2,medium,#a1d99b,1,2230
+1395,080423,Rangeland,,80,42,Evergreen Forest,#1C6330,3,high,#31a354,1,2230
+1396,080430,Rangeland,,80,43,Mixed Forest,#B5C98E,0,none,#ffffff,1,2230
+1397,080431,Rangeland,,80,43,Mixed Forest,#B5C98E,1,low,#e5f5e0,1,2230
+1398,080432,Rangeland,,80,43,Mixed Forest,#B5C98E,2,medium,#a1d99b,1,2230
+1399,080433,Rangeland,,80,43,Mixed Forest,#B5C98E,3,high,#31a354,1,2230
+1400,080510,Rangeland,,80,51,Dwarf Scrub,#A58C30,0,none,#ffffff,0,
+1401,080511,Rangeland,,80,51,Dwarf Scrub,#A58C30,1,low,#e5f5e0,0,
+1402,080512,Rangeland,,80,51,Dwarf Scrub,#A58C30,2,medium,#a1d99b,0,
+1403,080513,Rangeland,,80,51,Dwarf Scrub,#A58C30,3,high,#31a354,1,
+1404,080520,Rangeland,,80,52,Scrub/Shrub,#CCBA7C,0,none,#ffffff,1,2230
+1405,080521,Rangeland,,80,52,Scrub/Shrub,#CCBA7C,1,low,#e5f5e0,1,2230
+1406,080522,Rangeland,,80,52,Scrub/Shrub,#CCBA7C,2,medium,#a1d99b,1,2230
+1407,080523,Rangeland,,80,52,Scrub/Shrub,#CCBA7C,3,high,#31a354,1,2230
+1408,080710,Rangeland,,80,71,Grassland/Herbaceous,#E2E2C1,0,none,#ffffff,1,2230
+1409,080711,Rangeland,,80,71,Grassland/Herbaceous,#E2E2C1,1,low,#e5f5e0,1,2230
+1410,080712,Rangeland,,80,71,Grassland/Herbaceous,#E2E2C1,2,medium,#a1d99b,1,2230
+1411,080713,Rangeland,,80,71,Grassland/Herbaceous,#E2E2C1,3,high,#31a354,1,2230
+1412,080720,Rangeland,,80,72,Sedge/Herbaceuous,#C9C977,0,none,#ffffff,0,
+1413,080721,Rangeland,,80,72,Sedge/Herbaceuous,#C9C977,1,low,#e5f5e0,0,
+1414,080722,Rangeland,,80,72,Sedge/Herbaceuous,#C9C977,2,medium,#a1d99b,0,
+1415,080723,Rangeland,,80,72,Sedge/Herbaceuous,#C9C977,3,high,#31a354,1,
+1416,080730,Rangeland,,80,73,Lichens,#99C147,0,none,#ffffff,0,
+1417,080731,Rangeland,,80,73,Lichens,#99C147,1,low,#e5f5e0,0,
+1418,080732,Rangeland,,80,73,Lichens,#99C147,2,medium,#a1d99b,0,
+1419,080733,Rangeland,,80,73,Lichens,#99C147,3,high,#31a354,1,
+1420,080740,Rangeland,,80,74,Moss,#77AD93,0,none,#ffffff,0,
+1421,080741,Rangeland,,80,74,Moss,#77AD93,1,low,#e5f5e0,0,
+1422,080742,Rangeland,,80,74,Moss,#77AD93,2,medium,#a1d99b,0,
+1423,080743,Rangeland,,80,74,Moss,#77AD93,3,high,#31a354,1,
+1424,080810,Rangeland,,80,81,Pasture/Hay,#DBD83D,0,none,#ffffff,0,2230
+1425,080811,Rangeland,,80,81,Pasture/Hay,#DBD83D,1,low,#e5f5e0,0,2230
+1426,080812,Rangeland,,80,81,Pasture/Hay,#DBD83D,2,medium,#a1d99b,0,2230
+1427,080813,Rangeland,,80,81,Pasture/Hay,#DBD83D,3,high,#31a354,1,2230
+1428,080820,Rangeland,,80,82,Cultivated Crops,#AA7028,0,none,#ffffff,0,2230
+1429,080821,Rangeland,,80,82,Cultivated Crops,#AA7028,1,low,#e5f5e0,0,2230
+1430,080822,Rangeland,,80,82,Cultivated Crops,#AA7028,2,medium,#a1d99b,0,2230
+1431,080823,Rangeland,,80,82,Cultivated Crops,#AA7028,3,high,#31a354,1,2230
+1432,080900,Rangeland,,80,90,Woody Wetlands,#BAD8EA,0,none,#ffffff,1,2230
+1433,080901,Rangeland,,80,90,Woody Wetlands,#BAD8EA,1,low,#e5f5e0,1,2230
+1434,080902,Rangeland,,80,90,Woody Wetlands,#BAD8EA,2,medium,#a1d99b,1,2230
+1435,080903,Rangeland,,80,90,Woody Wetlands,#BAD8EA,3,high,#31a354,1,2230
+1436,080950,Rangeland,,80,95,Emergent Herbaceous Wetlands,#70A3BA,0,none,#ffffff,1,2230
+1437,080951,Rangeland,,80,95,Emergent Herbaceous Wetlands,#70A3BA,1,low,#e5f5e0,1,2230
+1438,080952,Rangeland,,80,95,Emergent Herbaceous Wetlands,#70A3BA,2,medium,#a1d99b,1,2230
+1439,080953,Rangeland,,80,95,Emergent Herbaceous Wetlands,#70A3BA,3,high,#31a354,1,2230
+1440,090110,Extractive/Mining,,90,11,Open Water,#476BA0,0,none,#ffffff,0,2230
+1441,090111,Extractive/Mining,,90,11,Open Water,#476BA0,1,low,#e5f5e0,0,2230
+1442,090112,Extractive/Mining,,90,11,Open Water,#476BA0,2,medium,#a1d99b,0,2230
+1443,090113,Extractive/Mining,,90,11,Open Water,#476BA0,3,high,#31a354,1,2230
+1444,090120,Extractive/Mining,,90,12,Perennial Ice/Snow,#D1DDF9,0,none,#ffffff,0,2230
+1445,090121,Extractive/Mining,,90,12,Perennial Ice/Snow,#D1DDF9,1,low,#e5f5e0,0,2230
+1446,090122,Extractive/Mining,,90,12,Perennial Ice/Snow,#D1DDF9,2,medium,#a1d99b,0,2230
+1447,090123,Extractive/Mining,,90,12,Perennial Ice/Snow,#D1DDF9,3,high,#31a354,1,2230
+1448,090210,Extractive/Mining,,90,21,"Developed, Open Space",#DDC9C9,0,none,#ffffff,0,2230
+1449,090211,Extractive/Mining,,90,21,"Developed, Open Space",#DDC9C9,1,low,#e5f5e0,0,2230
+1450,090212,Extractive/Mining,,90,21,"Developed, Open Space",#DDC9C9,2,medium,#a1d99b,0,2230
+1451,090213,Extractive/Mining,,90,21,"Developed, Open Space",#DDC9C9,3,high,#31a354,1,2230
+1452,090220,Extractive/Mining,,90,22,"Developed, Low Intensity",#D89382,0,none,#ffffff,0,2230
+1453,090221,Extractive/Mining,,90,22,"Developed, Low Intensity",#D89382,1,low,#e5f5e0,0,2230
+1454,090222,Extractive/Mining,,90,22,"Developed, Low Intensity",#D89382,2,medium,#a1d99b,0,2230
+1455,090223,Extractive/Mining,,90,22,"Developed, Low Intensity",#D89382,3,high,#31a354,1,2230
+1456,090230,Extractive/Mining,,90,23,"Developed, Medium Intensity",#ED0000,0,none,#ffffff,0,2230
+1457,090231,Extractive/Mining,,90,23,"Developed, Medium Intensity",#ED0000,1,low,#e5f5e0,0,2230
+1458,090232,Extractive/Mining,,90,23,"Developed, Medium Intensity",#ED0000,2,medium,#a1d99b,0,2230
+1459,090233,Extractive/Mining,,90,23,"Developed, Medium Intensity",#ED0000,3,high,#31a354,1,2230
+1460,090240,Extractive/Mining,,90,24,"Developed, High Intensity",#AA0000,0,none,#ffffff,0,2230
+1461,090241,Extractive/Mining,,90,24,"Developed, High Intensity",#AA0000,1,low,#e5f5e0,0,2230
+1462,090242,Extractive/Mining,,90,24,"Developed, High Intensity",#AA0000,2,medium,#a1d99b,0,2230
+1463,090243,Extractive/Mining,,90,24,"Developed, High Intensity",#AA0000,3,high,#31a354,1,2230
+1464,090310,Extractive/Mining,,90,31,Barren Land (Rock/Sand/Clay),#B2ADA3,0,none,#ffffff,0,2230
+1465,090311,Extractive/Mining,,90,31,Barren Land (Rock/Sand/Clay),#B2ADA3,1,low,#e5f5e0,0,2230
+1466,090312,Extractive/Mining,,90,31,Barren Land (Rock/Sand/Clay),#B2ADA3,2,medium,#a1d99b,0,2230
+1467,090313,Extractive/Mining,,90,31,Barren Land (Rock/Sand/Clay),#B2ADA3,3,high,#31a354,1,2230
+1468,090410,Extractive/Mining,,90,41,Deciduous Forest,#68AA63,0,none,#ffffff,1,2230
+1469,090411,Extractive/Mining,,90,41,Deciduous Forest,#68AA63,1,low,#e5f5e0,1,2230
+1470,090412,Extractive/Mining,,90,41,Deciduous Forest,#68AA63,2,medium,#a1d99b,1,2230
+1471,090413,Extractive/Mining,,90,41,Deciduous Forest,#68AA63,3,high,#31a354,1,2230
+1472,090420,Extractive/Mining,,90,42,Evergreen Forest,#1C6330,0,none,#ffffff,1,2230
+1473,090421,Extractive/Mining,,90,42,Evergreen Forest,#1C6330,1,low,#e5f5e0,1,2230
+1474,090422,Extractive/Mining,,90,42,Evergreen Forest,#1C6330,2,medium,#a1d99b,1,2230
+1475,090423,Extractive/Mining,,90,42,Evergreen Forest,#1C6330,3,high,#31a354,1,2230
+1476,090430,Extractive/Mining,,90,43,Mixed Forest,#B5C98E,0,none,#ffffff,1,2230
+1477,090431,Extractive/Mining,,90,43,Mixed Forest,#B5C98E,1,low,#e5f5e0,1,2230
+1478,090432,Extractive/Mining,,90,43,Mixed Forest,#B5C98E,2,medium,#a1d99b,1,2230
+1479,090433,Extractive/Mining,,90,43,Mixed Forest,#B5C98E,3,high,#31a354,1,2230
+1480,090510,Extractive/Mining,,90,51,Dwarf Scrub,#A58C30,0,none,#ffffff,0,
+1481,090511,Extractive/Mining,,90,51,Dwarf Scrub,#A58C30,1,low,#e5f5e0,0,
+1482,090512,Extractive/Mining,,90,51,Dwarf Scrub,#A58C30,2,medium,#a1d99b,0,
+1483,090513,Extractive/Mining,,90,51,Dwarf Scrub,#A58C30,3,high,#31a354,1,
+1484,090520,Extractive/Mining,,90,52,Scrub/Shrub,#CCBA7C,0,none,#ffffff,1,2230
+1485,090521,Extractive/Mining,,90,52,Scrub/Shrub,#CCBA7C,1,low,#e5f5e0,1,2230
+1486,090522,Extractive/Mining,,90,52,Scrub/Shrub,#CCBA7C,2,medium,#a1d99b,1,2230
+1487,090523,Extractive/Mining,,90,52,Scrub/Shrub,#CCBA7C,3,high,#31a354,1,2230
+1488,090710,Extractive/Mining,,90,71,Grassland/Herbaceous,#E2E2C1,0,none,#ffffff,1,2230
+1489,090711,Extractive/Mining,,90,71,Grassland/Herbaceous,#E2E2C1,1,low,#e5f5e0,1,2230
+1490,090712,Extractive/Mining,,90,71,Grassland/Herbaceous,#E2E2C1,2,medium,#a1d99b,1,2230
+1491,090713,Extractive/Mining,,90,71,Grassland/Herbaceous,#E2E2C1,3,high,#31a354,1,2230
+1492,090720,Extractive/Mining,,90,72,Sedge/Herbaceuous,#C9C977,0,none,#ffffff,0,
+1493,090721,Extractive/Mining,,90,72,Sedge/Herbaceuous,#C9C977,1,low,#e5f5e0,0,
+1494,090722,Extractive/Mining,,90,72,Sedge/Herbaceuous,#C9C977,2,medium,#a1d99b,0,
+1495,090723,Extractive/Mining,,90,72,Sedge/Herbaceuous,#C9C977,3,high,#31a354,1,
+1496,090730,Extractive/Mining,,90,73,Lichens,#99C147,0,none,#ffffff,0,
+1497,090731,Extractive/Mining,,90,73,Lichens,#99C147,1,low,#e5f5e0,0,
+1498,090732,Extractive/Mining,,90,73,Lichens,#99C147,2,medium,#a1d99b,0,
+1499,090733,Extractive/Mining,,90,73,Lichens,#99C147,3,high,#31a354,1,
+1500,090740,Extractive/Mining,,90,74,Moss,#77AD93,0,none,#ffffff,0,
+1501,090741,Extractive/Mining,,90,74,Moss,#77AD93,1,low,#e5f5e0,0,
+1502,090742,Extractive/Mining,,90,74,Moss,#77AD93,2,medium,#a1d99b,0,
+1503,090743,Extractive/Mining,,90,74,Moss,#77AD93,3,high,#31a354,1,
+1504,090810,Extractive/Mining,,90,81,Pasture/Hay,#DBD83D,0,none,#ffffff,0,2230
+1505,090811,Extractive/Mining,,90,81,Pasture/Hay,#DBD83D,1,low,#e5f5e0,0,2230
+1506,090812,Extractive/Mining,,90,81,Pasture/Hay,#DBD83D,2,medium,#a1d99b,0,2230
+1507,090813,Extractive/Mining,,90,81,Pasture/Hay,#DBD83D,3,high,#31a354,1,2230
+1508,090820,Extractive/Mining,,90,82,Cultivated Crops,#AA7028,0,none,#ffffff,0,2230
+1509,090821,Extractive/Mining,,90,82,Cultivated Crops,#AA7028,1,low,#e5f5e0,0,2230
+1510,090822,Extractive/Mining,,90,82,Cultivated Crops,#AA7028,2,medium,#a1d99b,0,2230
+1511,090823,Extractive/Mining,,90,82,Cultivated Crops,#AA7028,3,high,#31a354,1,2230
+1512,090900,Extractive/Mining,,90,90,Woody Wetlands,#BAD8EA,0,none,#ffffff,1,2230
+1513,090901,Extractive/Mining,,90,90,Woody Wetlands,#BAD8EA,1,low,#e5f5e0,1,2230
+1514,090902,Extractive/Mining,,90,90,Woody Wetlands,#BAD8EA,2,medium,#a1d99b,1,2230
+1515,090903,Extractive/Mining,,90,90,Woody Wetlands,#BAD8EA,3,high,#31a354,1,2230
+1516,090950,Extractive/Mining,,90,95,Emergent Herbaceous Wetlands,#70A3BA,0,none,#ffffff,1,2230
+1517,090951,Extractive/Mining,,90,95,Emergent Herbaceous Wetlands,#70A3BA,1,low,#e5f5e0,1,2230
+1518,090952,Extractive/Mining,,90,95,Emergent Herbaceous Wetlands,#70A3BA,2,medium,#a1d99b,1,2230
+1519,090953,Extractive/Mining,,90,95,Emergent Herbaceous Wetlands,#70A3BA,3,high,#31a354,1,2230
+1520,100110,Timber,,100,11,Open Water,#476BA0,0,none,#ffffff,0,2230
+1521,100111,Timber,,100,11,Open Water,#476BA0,1,low,#e5f5e0,0,2230
+1522,100112,Timber,,100,11,Open Water,#476BA0,2,medium,#a1d99b,0,2230
+1523,100113,Timber,,100,11,Open Water,#476BA0,3,high,#31a354,1,2230
+1524,100120,Timber,,100,12,Perennial Ice/Snow,#D1DDF9,0,none,#ffffff,0,2230
+1525,100121,Timber,,100,12,Perennial Ice/Snow,#D1DDF9,1,low,#e5f5e0,0,2230
+1526,100122,Timber,,100,12,Perennial Ice/Snow,#D1DDF9,2,medium,#a1d99b,0,2230
+1527,100123,Timber,,100,12,Perennial Ice/Snow,#D1DDF9,3,high,#31a354,1,2230
+1528,100210,Timber,,100,21,"Developed, Open Space",#DDC9C9,0,none,#ffffff,0,2230
+1529,100211,Timber,,100,21,"Developed, Open Space",#DDC9C9,1,low,#e5f5e0,0,2230
+1530,100212,Timber,,100,21,"Developed, Open Space",#DDC9C9,2,medium,#a1d99b,0,2230
+1531,100213,Timber,,100,21,"Developed, Open Space",#DDC9C9,3,high,#31a354,1,2230
+1532,100220,Timber,,100,22,"Developed, Low Intensity",#D89382,0,none,#ffffff,0,2230
+1533,100221,Timber,,100,22,"Developed, Low Intensity",#D89382,1,low,#e5f5e0,0,2230
+1534,100222,Timber,,100,22,"Developed, Low Intensity",#D89382,2,medium,#a1d99b,0,2230
+1535,100223,Timber,,100,22,"Developed, Low Intensity",#D89382,3,high,#31a354,1,2230
+1536,100230,Timber,,100,23,"Developed, Medium Intensity",#ED0000,0,none,#ffffff,0,2230
+1537,100231,Timber,,100,23,"Developed, Medium Intensity",#ED0000,1,low,#e5f5e0,0,2230
+1538,100232,Timber,,100,23,"Developed, Medium Intensity",#ED0000,2,medium,#a1d99b,0,2230
+1539,100233,Timber,,100,23,"Developed, Medium Intensity",#ED0000,3,high,#31a354,1,2230
+1540,100240,Timber,,100,24,"Developed, High Intensity",#AA0000,0,none,#ffffff,0,2230
+1541,100241,Timber,,100,24,"Developed, High Intensity",#AA0000,1,low,#e5f5e0,0,2230
+1542,100242,Timber,,100,24,"Developed, High Intensity",#AA0000,2,medium,#a1d99b,0,2230
+1543,100243,Timber,,100,24,"Developed, High Intensity",#AA0000,3,high,#31a354,1,2230
+1544,100310,Timber,,100,31,Barren Land (Rock/Sand/Clay),#B2ADA3,0,none,#ffffff,0,2230
+1545,100311,Timber,,100,31,Barren Land (Rock/Sand/Clay),#B2ADA3,1,low,#e5f5e0,0,2230
+1546,100312,Timber,,100,31,Barren Land (Rock/Sand/Clay),#B2ADA3,2,medium,#a1d99b,0,2230
+1547,100313,Timber,,100,31,Barren Land (Rock/Sand/Clay),#B2ADA3,3,high,#31a354,1,2230
+1548,100410,Timber,,100,41,Deciduous Forest,#68AA63,0,none,#ffffff,1,2230
+1549,100411,Timber,,100,41,Deciduous Forest,#68AA63,1,low,#e5f5e0,1,2230
+1550,100412,Timber,,100,41,Deciduous Forest,#68AA63,2,medium,#a1d99b,1,2230
+1551,100413,Timber,,100,41,Deciduous Forest,#68AA63,3,high,#31a354,1,2230
+1552,100420,Timber,,100,42,Evergreen Forest,#1C6330,0,none,#ffffff,1,2230
+1553,100421,Timber,,100,42,Evergreen Forest,#1C6330,1,low,#e5f5e0,1,2230
+1554,100422,Timber,,100,42,Evergreen Forest,#1C6330,2,medium,#a1d99b,1,2230
+1555,100423,Timber,,100,42,Evergreen Forest,#1C6330,3,high,#31a354,1,2230
+1556,100430,Timber,,100,43,Mixed Forest,#B5C98E,0,none,#ffffff,1,2230
+1557,100431,Timber,,100,43,Mixed Forest,#B5C98E,1,low,#e5f5e0,1,2230
+1558,100432,Timber,,100,43,Mixed Forest,#B5C98E,2,medium,#a1d99b,1,2230
+1559,100433,Timber,,100,43,Mixed Forest,#B5C98E,3,high,#31a354,1,2230
+1560,100510,Timber,,100,51,Dwarf Scrub,#A58C30,0,none,#ffffff,0,
+1561,100511,Timber,,100,51,Dwarf Scrub,#A58C30,1,low,#e5f5e0,0,
+1562,100512,Timber,,100,51,Dwarf Scrub,#A58C30,2,medium,#a1d99b,0,
+1563,100513,Timber,,100,51,Dwarf Scrub,#A58C30,3,high,#31a354,1,
+1564,100520,Timber,,100,52,Scrub/Shrub,#CCBA7C,0,none,#ffffff,1,2230
+1565,100521,Timber,,100,52,Scrub/Shrub,#CCBA7C,1,low,#e5f5e0,1,2230
+1566,100522,Timber,,100,52,Scrub/Shrub,#CCBA7C,2,medium,#a1d99b,1,2230
+1567,100523,Timber,,100,52,Scrub/Shrub,#CCBA7C,3,high,#31a354,1,2230
+1568,100710,Timber,,100,71,Grassland/Herbaceous,#E2E2C1,0,none,#ffffff,1,2230
+1569,100711,Timber,,100,71,Grassland/Herbaceous,#E2E2C1,1,low,#e5f5e0,1,2230
+1570,100712,Timber,,100,71,Grassland/Herbaceous,#E2E2C1,2,medium,#a1d99b,1,2230
+1571,100713,Timber,,100,71,Grassland/Herbaceous,#E2E2C1,3,high,#31a354,1,2230
+1572,100720,Timber,,100,72,Sedge/Herbaceuous,#C9C977,0,none,#ffffff,0,
+1573,100721,Timber,,100,72,Sedge/Herbaceuous,#C9C977,1,low,#e5f5e0,0,
+1574,100722,Timber,,100,72,Sedge/Herbaceuous,#C9C977,2,medium,#a1d99b,0,
+1575,100723,Timber,,100,72,Sedge/Herbaceuous,#C9C977,3,high,#31a354,1,
+1576,100730,Timber,,100,73,Lichens,#99C147,0,none,#ffffff,0,
+1577,100731,Timber,,100,73,Lichens,#99C147,1,low,#e5f5e0,0,
+1578,100732,Timber,,100,73,Lichens,#99C147,2,medium,#a1d99b,0,
+1579,100733,Timber,,100,73,Lichens,#99C147,3,high,#31a354,1,
+1580,100740,Timber,,100,74,Moss,#77AD93,0,none,#ffffff,0,
+1581,100741,Timber,,100,74,Moss,#77AD93,1,low,#e5f5e0,0,
+1582,100742,Timber,,100,74,Moss,#77AD93,2,medium,#a1d99b,0,
+1583,100743,Timber,,100,74,Moss,#77AD93,3,high,#31a354,1,
+1584,100810,Timber,,100,81,Pasture/Hay,#DBD83D,0,none,#ffffff,0,2230
+1585,100811,Timber,,100,81,Pasture/Hay,#DBD83D,1,low,#e5f5e0,0,2230
+1586,100812,Timber,,100,81,Pasture/Hay,#DBD83D,2,medium,#a1d99b,0,2230
+1587,100813,Timber,,100,81,Pasture/Hay,#DBD83D,3,high,#31a354,1,2230
+1588,100820,Timber,,100,82,Cultivated Crops,#AA7028,0,none,#ffffff,0,2230
+1589,100821,Timber,,100,82,Cultivated Crops,#AA7028,1,low,#e5f5e0,0,2230
+1590,100822,Timber,,100,82,Cultivated Crops,#AA7028,2,medium,#a1d99b,0,2230
+1591,100823,Timber,,100,82,Cultivated Crops,#AA7028,3,high,#31a354,1,2230
+1592,100900,Timber,,100,90,Woody Wetlands,#BAD8EA,0,none,#ffffff,1,2230
+1593,100901,Timber,,100,90,Woody Wetlands,#BAD8EA,1,low,#e5f5e0,1,2230
+1594,100902,Timber,,100,90,Woody Wetlands,#BAD8EA,2,medium,#a1d99b,1,2230
+1595,100903,Timber,,100,90,Woody Wetlands,#BAD8EA,3,high,#31a354,1,2230
+1596,100950,Timber,,100,95,Emergent Herbaceous Wetlands,#70A3BA,0,none,#ffffff,1,2230
+1597,100951,Timber,,100,95,Emergent Herbaceous Wetlands,#70A3BA,1,low,#e5f5e0,1,2230
+1598,100952,Timber,,100,95,Emergent Herbaceous Wetlands,#70A3BA,2,medium,#a1d99b,1,2230
+1599,100953,Timber,,100,95,Emergent Herbaceous Wetlands,#70A3BA,3,high,#31a354,1,2230
+1600,110110,Barren,,110,11,Open Water,#476BA0,0,none,#ffffff,0,2230
+1601,110111,Barren,,110,11,Open Water,#476BA0,1,low,#e5f5e0,0,2230
+1602,110112,Barren,,110,11,Open Water,#476BA0,2,medium,#a1d99b,0,2230
+1603,110113,Barren,,110,11,Open Water,#476BA0,3,high,#31a354,1,2230
+1604,110120,Barren,,110,12,Perennial Ice/Snow,#D1DDF9,0,none,#ffffff,0,2230
+1605,110121,Barren,,110,12,Perennial Ice/Snow,#D1DDF9,1,low,#e5f5e0,0,2230
+1606,110122,Barren,,110,12,Perennial Ice/Snow,#D1DDF9,2,medium,#a1d99b,0,2230
+1607,110123,Barren,,110,12,Perennial Ice/Snow,#D1DDF9,3,high,#31a354,1,2230
+1608,110210,Barren,,110,21,"Developed, Open Space",#DDC9C9,0,none,#ffffff,0,2230
+1609,110211,Barren,,110,21,"Developed, Open Space",#DDC9C9,1,low,#e5f5e0,0,2230
+1610,110212,Barren,,110,21,"Developed, Open Space",#DDC9C9,2,medium,#a1d99b,0,2230
+1611,110213,Barren,,110,21,"Developed, Open Space",#DDC9C9,3,high,#31a354,1,2230
+1612,110220,Barren,,110,22,"Developed, Low Intensity",#D89382,0,none,#ffffff,0,2230
+1613,110221,Barren,,110,22,"Developed, Low Intensity",#D89382,1,low,#e5f5e0,0,2230
+1614,110222,Barren,,110,22,"Developed, Low Intensity",#D89382,2,medium,#a1d99b,0,2230
+1615,110223,Barren,,110,22,"Developed, Low Intensity",#D89382,3,high,#31a354,1,2230
+1616,110230,Barren,,110,23,"Developed, Medium Intensity",#ED0000,0,none,#ffffff,0,2230
+1617,110231,Barren,,110,23,"Developed, Medium Intensity",#ED0000,1,low,#e5f5e0,0,2230
+1618,110232,Barren,,110,23,"Developed, Medium Intensity",#ED0000,2,medium,#a1d99b,0,2230
+1619,110233,Barren,,110,23,"Developed, Medium Intensity",#ED0000,3,high,#31a354,1,2230
+1620,110240,Barren,,110,24,"Developed, High Intensity",#AA0000,0,none,#ffffff,0,2230
+1621,110241,Barren,,110,24,"Developed, High Intensity",#AA0000,1,low,#e5f5e0,0,2230
+1622,110242,Barren,,110,24,"Developed, High Intensity",#AA0000,2,medium,#a1d99b,0,2230
+1623,110243,Barren,,110,24,"Developed, High Intensity",#AA0000,3,high,#31a354,1,2230
+1624,110310,Barren,,110,31,Barren Land (Rock/Sand/Clay),#B2ADA3,0,none,#ffffff,0,2230
+1625,110311,Barren,,110,31,Barren Land (Rock/Sand/Clay),#B2ADA3,1,low,#e5f5e0,0,2230
+1626,110312,Barren,,110,31,Barren Land (Rock/Sand/Clay),#B2ADA3,2,medium,#a1d99b,0,2230
+1627,110313,Barren,,110,31,Barren Land (Rock/Sand/Clay),#B2ADA3,3,high,#31a354,1,2230
+1628,110410,Barren,,110,41,Deciduous Forest,#68AA63,0,none,#ffffff,1,2230
+1629,110411,Barren,,110,41,Deciduous Forest,#68AA63,1,low,#e5f5e0,1,2230
+1630,110412,Barren,,110,41,Deciduous Forest,#68AA63,2,medium,#a1d99b,1,2230
+1631,110413,Barren,,110,41,Deciduous Forest,#68AA63,3,high,#31a354,1,2230
+1632,110420,Barren,,110,42,Evergreen Forest,#1C6330,0,none,#ffffff,1,2230
+1633,110421,Barren,,110,42,Evergreen Forest,#1C6330,1,low,#e5f5e0,1,2230
+1634,110422,Barren,,110,42,Evergreen Forest,#1C6330,2,medium,#a1d99b,1,2230
+1635,110423,Barren,,110,42,Evergreen Forest,#1C6330,3,high,#31a354,1,2230
+1636,110430,Barren,,110,43,Mixed Forest,#B5C98E,0,none,#ffffff,1,2230
+1637,110431,Barren,,110,43,Mixed Forest,#B5C98E,1,low,#e5f5e0,1,2230
+1638,110432,Barren,,110,43,Mixed Forest,#B5C98E,2,medium,#a1d99b,1,2230
+1639,110433,Barren,,110,43,Mixed Forest,#B5C98E,3,high,#31a354,1,2230
+1640,110510,Barren,,110,51,Dwarf Scrub,#A58C30,0,none,#ffffff,0,
+1641,110511,Barren,,110,51,Dwarf Scrub,#A58C30,1,low,#e5f5e0,0,
+1642,110512,Barren,,110,51,Dwarf Scrub,#A58C30,2,medium,#a1d99b,0,
+1643,110513,Barren,,110,51,Dwarf Scrub,#A58C30,3,high,#31a354,1,
+1644,110520,Barren,,110,52,Scrub/Shrub,#CCBA7C,0,none,#ffffff,1,2230
+1645,110521,Barren,,110,52,Scrub/Shrub,#CCBA7C,1,low,#e5f5e0,1,2230
+1646,110522,Barren,,110,52,Scrub/Shrub,#CCBA7C,2,medium,#a1d99b,1,2230
+1647,110523,Barren,,110,52,Scrub/Shrub,#CCBA7C,3,high,#31a354,1,2230
+1648,110710,Barren,,110,71,Grassland/Herbaceous,#E2E2C1,0,none,#ffffff,1,2230
+1649,110711,Barren,,110,71,Grassland/Herbaceous,#E2E2C1,1,low,#e5f5e0,1,2230
+1650,110712,Barren,,110,71,Grassland/Herbaceous,#E2E2C1,2,medium,#a1d99b,1,2230
+1651,110713,Barren,,110,71,Grassland/Herbaceous,#E2E2C1,3,high,#31a354,1,2230
+1652,110720,Barren,,110,72,Sedge/Herbaceuous,#C9C977,0,none,#ffffff,0,
+1653,110721,Barren,,110,72,Sedge/Herbaceuous,#C9C977,1,low,#e5f5e0,0,
+1654,110722,Barren,,110,72,Sedge/Herbaceuous,#C9C977,2,medium,#a1d99b,0,
+1655,110723,Barren,,110,72,Sedge/Herbaceuous,#C9C977,3,high,#31a354,1,
+1656,110730,Barren,,110,73,Lichens,#99C147,0,none,#ffffff,0,
+1657,110731,Barren,,110,73,Lichens,#99C147,1,low,#e5f5e0,0,
+1658,110732,Barren,,110,73,Lichens,#99C147,2,medium,#a1d99b,0,
+1659,110733,Barren,,110,73,Lichens,#99C147,3,high,#31a354,1,
+1660,110740,Barren,,110,74,Moss,#77AD93,0,none,#ffffff,0,
+1661,110741,Barren,,110,74,Moss,#77AD93,1,low,#e5f5e0,0,
+1662,110742,Barren,,110,74,Moss,#77AD93,2,medium,#a1d99b,0,
+1663,110743,Barren,,110,74,Moss,#77AD93,3,high,#31a354,1,
+1664,110810,Barren,,110,81,Pasture/Hay,#DBD83D,0,none,#ffffff,0,2230
+1665,110811,Barren,,110,81,Pasture/Hay,#DBD83D,1,low,#e5f5e0,0,2230
+1666,110812,Barren,,110,81,Pasture/Hay,#DBD83D,2,medium,#a1d99b,0,2230
+1667,110813,Barren,,110,81,Pasture/Hay,#DBD83D,3,high,#31a354,1,2230
+1668,110820,Barren,,110,82,Cultivated Crops,#AA7028,0,none,#ffffff,0,2230
+1669,110821,Barren,,110,82,Cultivated Crops,#AA7028,1,low,#e5f5e0,0,2230
+1670,110822,Barren,,110,82,Cultivated Crops,#AA7028,2,medium,#a1d99b,0,2230
+1671,110823,Barren,,110,82,Cultivated Crops,#AA7028,3,high,#31a354,1,2230
+1672,110900,Barren,,110,90,Woody Wetlands,#BAD8EA,0,none,#ffffff,1,2230
+1673,110901,Barren,,110,90,Woody Wetlands,#BAD8EA,1,low,#e5f5e0,1,2230
+1674,110902,Barren,,110,90,Woody Wetlands,#BAD8EA,2,medium,#a1d99b,1,2230
+1675,110903,Barren,,110,90,Woody Wetlands,#BAD8EA,3,high,#31a354,1,2230
+1676,110950,Barren,,110,95,Emergent Herbaceous Wetlands,#70A3BA,0,none,#ffffff,1,2230
+1677,110951,Barren,,110,95,Emergent Herbaceous Wetlands,#70A3BA,1,low,#e5f5e0,1,2230
+1678,110952,Barren,,110,95,Emergent Herbaceous Wetlands,#70A3BA,2,medium,#a1d99b,1,2230
+1679,110953,Barren,,110,95,Emergent Herbaceous Wetlands,#70A3BA,3,high,#31a354,1,2230
+1680,120110,Undifferentiated park,,120,11,Open Water,#476BA0,0,none,#ffffff,0,2230
+1681,120111,Undifferentiated park,,120,11,Open Water,#476BA0,1,low,#e5f5e0,0,2230
+1682,120112,Undifferentiated park,,120,11,Open Water,#476BA0,2,medium,#a1d99b,0,2230
+1683,120113,Undifferentiated park,,120,11,Open Water,#476BA0,3,high,#31a354,1,2230
+1684,120120,Undifferentiated park,,120,12,Perennial Ice/Snow,#D1DDF9,0,none,#ffffff,0,2230
+1685,120121,Undifferentiated park,,120,12,Perennial Ice/Snow,#D1DDF9,1,low,#e5f5e0,0,2230
+1686,120122,Undifferentiated park,,120,12,Perennial Ice/Snow,#D1DDF9,2,medium,#a1d99b,0,2230
+1687,120123,Undifferentiated park,,120,12,Perennial Ice/Snow,#D1DDF9,3,high,#31a354,1,2230
+1688,120210,Undifferentiated park,,120,21,"Developed, Open Space",#DDC9C9,0,none,#ffffff,0,2230
+1689,120211,Undifferentiated park,,120,21,"Developed, Open Space",#DDC9C9,1,low,#e5f5e0,0,2230
+1690,120212,Undifferentiated park,,120,21,"Developed, Open Space",#DDC9C9,2,medium,#a1d99b,0,2230
+1691,120213,Undifferentiated park,,120,21,"Developed, Open Space",#DDC9C9,3,high,#31a354,1,2230
+1692,120220,Undifferentiated park,,120,22,"Developed, Low Intensity",#D89382,0,none,#ffffff,0,2230
+1693,120221,Undifferentiated park,,120,22,"Developed, Low Intensity",#D89382,1,low,#e5f5e0,0,2230
+1694,120222,Undifferentiated park,,120,22,"Developed, Low Intensity",#D89382,2,medium,#a1d99b,0,2230
+1695,120223,Undifferentiated park,,120,22,"Developed, Low Intensity",#D89382,3,high,#31a354,1,2230
+1696,120230,Undifferentiated park,,120,23,"Developed, Medium Intensity",#ED0000,0,none,#ffffff,0,2230
+1697,120231,Undifferentiated park,,120,23,"Developed, Medium Intensity",#ED0000,1,low,#e5f5e0,0,2230
+1698,120232,Undifferentiated park,,120,23,"Developed, Medium Intensity",#ED0000,2,medium,#a1d99b,0,2230
+1699,120233,Undifferentiated park,,120,23,"Developed, Medium Intensity",#ED0000,3,high,#31a354,1,2230
+1700,120240,Undifferentiated park,,120,24,"Developed, High Intensity",#AA0000,0,none,#ffffff,0,2230
+1701,120241,Undifferentiated park,,120,24,"Developed, High Intensity",#AA0000,1,low,#e5f5e0,0,2230
+1702,120242,Undifferentiated park,,120,24,"Developed, High Intensity",#AA0000,2,medium,#a1d99b,0,2230
+1703,120243,Undifferentiated park,,120,24,"Developed, High Intensity",#AA0000,3,high,#31a354,1,2230
+1704,120310,Undifferentiated park,,120,31,Barren Land (Rock/Sand/Clay),#B2ADA3,0,none,#ffffff,0,2230
+1705,120311,Undifferentiated park,,120,31,Barren Land (Rock/Sand/Clay),#B2ADA3,1,low,#e5f5e0,0,2230
+1706,120312,Undifferentiated park,,120,31,Barren Land (Rock/Sand/Clay),#B2ADA3,2,medium,#a1d99b,0,2230
+1707,120313,Undifferentiated park,,120,31,Barren Land (Rock/Sand/Clay),#B2ADA3,3,high,#31a354,1,2230
+1708,120410,Undifferentiated park,,120,41,Deciduous Forest,#68AA63,0,none,#ffffff,1,2230
+1709,120411,Undifferentiated park,,120,41,Deciduous Forest,#68AA63,1,low,#e5f5e0,1,2230
+1710,120412,Undifferentiated park,,120,41,Deciduous Forest,#68AA63,2,medium,#a1d99b,1,2230
+1711,120413,Undifferentiated park,,120,41,Deciduous Forest,#68AA63,3,high,#31a354,1,2230
+1712,120420,Undifferentiated park,,120,42,Evergreen Forest,#1C6330,0,none,#ffffff,1,2230
+1713,120421,Undifferentiated park,,120,42,Evergreen Forest,#1C6330,1,low,#e5f5e0,1,2230
+1714,120422,Undifferentiated park,,120,42,Evergreen Forest,#1C6330,2,medium,#a1d99b,1,2230
+1715,120423,Undifferentiated park,,120,42,Evergreen Forest,#1C6330,3,high,#31a354,1,2230
+1716,120430,Undifferentiated park,,120,43,Mixed Forest,#B5C98E,0,none,#ffffff,1,2230
+1717,120431,Undifferentiated park,,120,43,Mixed Forest,#B5C98E,1,low,#e5f5e0,1,2230
+1718,120432,Undifferentiated park,,120,43,Mixed Forest,#B5C98E,2,medium,#a1d99b,1,2230
+1719,120433,Undifferentiated park,,120,43,Mixed Forest,#B5C98E,3,high,#31a354,1,2230
+1720,120510,Undifferentiated park,,120,51,Dwarf Scrub,#A58C30,0,none,#ffffff,0,
+1721,120511,Undifferentiated park,,120,51,Dwarf Scrub,#A58C30,1,low,#e5f5e0,0,
+1722,120512,Undifferentiated park,,120,51,Dwarf Scrub,#A58C30,2,medium,#a1d99b,0,
+1723,120513,Undifferentiated park,,120,51,Dwarf Scrub,#A58C30,3,high,#31a354,1,
+1724,120520,Undifferentiated park,,120,52,Scrub/Shrub,#CCBA7C,0,none,#ffffff,1,2230
+1725,120521,Undifferentiated park,,120,52,Scrub/Shrub,#CCBA7C,1,low,#e5f5e0,1,2230
+1726,120522,Undifferentiated park,,120,52,Scrub/Shrub,#CCBA7C,2,medium,#a1d99b,1,2230
+1727,120523,Undifferentiated park,,120,52,Scrub/Shrub,#CCBA7C,3,high,#31a354,1,2230
+1728,120710,Undifferentiated park,,120,71,Grassland/Herbaceous,#E2E2C1,0,none,#ffffff,1,2230
+1729,120711,Undifferentiated park,,120,71,Grassland/Herbaceous,#E2E2C1,1,low,#e5f5e0,1,2230
+1730,120712,Undifferentiated park,,120,71,Grassland/Herbaceous,#E2E2C1,2,medium,#a1d99b,1,2230
+1731,120713,Undifferentiated park,,120,71,Grassland/Herbaceous,#E2E2C1,3,high,#31a354,1,2230
+1732,120720,Undifferentiated park,,120,72,Sedge/Herbaceuous,#C9C977,0,none,#ffffff,0,
+1733,120721,Undifferentiated park,,120,72,Sedge/Herbaceuous,#C9C977,1,low,#e5f5e0,0,
+1734,120722,Undifferentiated park,,120,72,Sedge/Herbaceuous,#C9C977,2,medium,#a1d99b,0,
+1735,120723,Undifferentiated park,,120,72,Sedge/Herbaceuous,#C9C977,3,high,#31a354,1,
+1736,120730,Undifferentiated park,,120,73,Lichens,#99C147,0,none,#ffffff,0,
+1737,120731,Undifferentiated park,,120,73,Lichens,#99C147,1,low,#e5f5e0,0,
+1738,120732,Undifferentiated park,,120,73,Lichens,#99C147,2,medium,#a1d99b,0,
+1739,120733,Undifferentiated park,,120,73,Lichens,#99C147,3,high,#31a354,1,
+1740,120740,Undifferentiated park,,120,74,Moss,#77AD93,0,none,#ffffff,0,
+1741,120741,Undifferentiated park,,120,74,Moss,#77AD93,1,low,#e5f5e0,0,
+1742,120742,Undifferentiated park,,120,74,Moss,#77AD93,2,medium,#a1d99b,0,
+1743,120743,Undifferentiated park,,120,74,Moss,#77AD93,3,high,#31a354,1,
+1744,120810,Undifferentiated park,,120,81,Pasture/Hay,#DBD83D,0,none,#ffffff,0,2230
+1745,120811,Undifferentiated park,,120,81,Pasture/Hay,#DBD83D,1,low,#e5f5e0,0,2230
+1746,120812,Undifferentiated park,,120,81,Pasture/Hay,#DBD83D,2,medium,#a1d99b,0,2230
+1747,120813,Undifferentiated park,,120,81,Pasture/Hay,#DBD83D,3,high,#31a354,1,2230
+1748,120820,Undifferentiated park,,120,82,Cultivated Crops,#AA7028,0,none,#ffffff,0,2230
+1749,120821,Undifferentiated park,,120,82,Cultivated Crops,#AA7028,1,low,#e5f5e0,0,2230
+1750,120822,Undifferentiated park,,120,82,Cultivated Crops,#AA7028,2,medium,#a1d99b,0,2230
+1751,120823,Undifferentiated park,,120,82,Cultivated Crops,#AA7028,3,high,#31a354,1,2230
+1752,120900,Undifferentiated park,,120,90,Woody Wetlands,#BAD8EA,0,none,#ffffff,1,2230
+1753,120901,Undifferentiated park,,120,90,Woody Wetlands,#BAD8EA,1,low,#e5f5e0,1,2230
+1754,120902,Undifferentiated park,,120,90,Woody Wetlands,#BAD8EA,2,medium,#a1d99b,1,2230
+1755,120903,Undifferentiated park,,120,90,Woody Wetlands,#BAD8EA,3,high,#31a354,1,2230
+1756,120950,Undifferentiated park,,120,95,Emergent Herbaceous Wetlands,#70A3BA,0,none,#ffffff,1,2230
+1757,120951,Undifferentiated park,,120,95,Emergent Herbaceous Wetlands,#70A3BA,1,low,#e5f5e0,1,2230
+1758,120952,Undifferentiated park,,120,95,Emergent Herbaceous Wetlands,#70A3BA,2,medium,#a1d99b,1,2230
+1759,120953,Undifferentiated park,,120,95,Emergent Herbaceous Wetlands,#70A3BA,3,high,#31a354,1,2230
+1760,131110,Developed park,Urban park,131,11,Open Water,#476BA0,0,none,#ffffff,0,2230
+1761,131111,Developed park,Urban park,131,11,Open Water,#476BA0,1,low,#e5f5e0,0,2230
+1762,131112,Developed park,Urban park,131,11,Open Water,#476BA0,2,medium,#a1d99b,0,2230
+1763,131113,Developed park,Urban park,131,11,Open Water,#476BA0,3,high,#31a354,1,2230
+1764,131120,Developed park,Urban park,131,12,Perennial Ice/Snow,#D1DDF9,0,none,#ffffff,0,2230
+1765,131121,Developed park,Urban park,131,12,Perennial Ice/Snow,#D1DDF9,1,low,#e5f5e0,0,2230
+1766,131122,Developed park,Urban park,131,12,Perennial Ice/Snow,#D1DDF9,2,medium,#a1d99b,0,2230
+1767,131123,Developed park,Urban park,131,12,Perennial Ice/Snow,#D1DDF9,3,high,#31a354,1,2230
+1768,131210,Developed park,Urban park,131,21,"Developed, Open Space",#DDC9C9,0,none,#ffffff,0,2230
+1769,131211,Developed park,Urban park,131,21,"Developed, Open Space",#DDC9C9,1,low,#e5f5e0,0,2230
+1770,131212,Developed park,Urban park,131,21,"Developed, Open Space",#DDC9C9,2,medium,#a1d99b,0,2230
+1771,131213,Developed park,Urban park,131,21,"Developed, Open Space",#DDC9C9,3,high,#31a354,1,2230
+1772,131220,Developed park,Urban park,131,22,"Developed, Low Intensity",#D89382,0,none,#ffffff,0,2230
+1773,131221,Developed park,Urban park,131,22,"Developed, Low Intensity",#D89382,1,low,#e5f5e0,0,2230
+1774,131222,Developed park,Urban park,131,22,"Developed, Low Intensity",#D89382,2,medium,#a1d99b,0,2230
+1775,131223,Developed park,Urban park,131,22,"Developed, Low Intensity",#D89382,3,high,#31a354,1,2230
+1776,131230,Developed park,Urban park,131,23,"Developed, Medium Intensity",#ED0000,0,none,#ffffff,0,2230
+1777,131231,Developed park,Urban park,131,23,"Developed, Medium Intensity",#ED0000,1,low,#e5f5e0,0,2230
+1778,131232,Developed park,Urban park,131,23,"Developed, Medium Intensity",#ED0000,2,medium,#a1d99b,0,2230
+1779,131233,Developed park,Urban park,131,23,"Developed, Medium Intensity",#ED0000,3,high,#31a354,1,2230
+1780,131240,Developed park,Urban park,131,24,"Developed, High Intensity",#AA0000,0,none,#ffffff,0,2230
+1781,131241,Developed park,Urban park,131,24,"Developed, High Intensity",#AA0000,1,low,#e5f5e0,0,2230
+1782,131242,Developed park,Urban park,131,24,"Developed, High Intensity",#AA0000,2,medium,#a1d99b,0,2230
+1783,131243,Developed park,Urban park,131,24,"Developed, High Intensity",#AA0000,3,high,#31a354,1,2230
+1784,131310,Developed park,Urban park,131,31,Barren Land (Rock/Sand/Clay),#B2ADA3,0,none,#ffffff,0,2230
+1785,131311,Developed park,Urban park,131,31,Barren Land (Rock/Sand/Clay),#B2ADA3,1,low,#e5f5e0,0,2230
+1786,131312,Developed park,Urban park,131,31,Barren Land (Rock/Sand/Clay),#B2ADA3,2,medium,#a1d99b,0,2230
+1787,131313,Developed park,Urban park,131,31,Barren Land (Rock/Sand/Clay),#B2ADA3,3,high,#31a354,1,2230
+1788,131410,Developed park,Urban park,131,41,Deciduous Forest,#68AA63,0,none,#ffffff,1,2230
+1789,131411,Developed park,Urban park,131,41,Deciduous Forest,#68AA63,1,low,#e5f5e0,1,2230
+1790,131412,Developed park,Urban park,131,41,Deciduous Forest,#68AA63,2,medium,#a1d99b,1,2230
+1791,131413,Developed park,Urban park,131,41,Deciduous Forest,#68AA63,3,high,#31a354,1,2230
+1792,131420,Developed park,Urban park,131,42,Evergreen Forest,#1C6330,0,none,#ffffff,1,2230
+1793,131421,Developed park,Urban park,131,42,Evergreen Forest,#1C6330,1,low,#e5f5e0,1,2230
+1794,131422,Developed park,Urban park,131,42,Evergreen Forest,#1C6330,2,medium,#a1d99b,1,2230
+1795,131423,Developed park,Urban park,131,42,Evergreen Forest,#1C6330,3,high,#31a354,1,2230
+1796,131430,Developed park,Urban park,131,43,Mixed Forest,#B5C98E,0,none,#ffffff,1,2230
+1797,131431,Developed park,Urban park,131,43,Mixed Forest,#B5C98E,1,low,#e5f5e0,1,2230
+1798,131432,Developed park,Urban park,131,43,Mixed Forest,#B5C98E,2,medium,#a1d99b,1,2230
+1799,131433,Developed park,Urban park,131,43,Mixed Forest,#B5C98E,3,high,#31a354,1,2230
+1800,131510,Developed park,Urban park,131,51,Dwarf Scrub,#A58C30,0,none,#ffffff,0,
+1801,131511,Developed park,Urban park,131,51,Dwarf Scrub,#A58C30,1,low,#e5f5e0,0,
+1802,131512,Developed park,Urban park,131,51,Dwarf Scrub,#A58C30,2,medium,#a1d99b,0,
+1803,131513,Developed park,Urban park,131,51,Dwarf Scrub,#A58C30,3,high,#31a354,1,
+1804,131520,Developed park,Urban park,131,52,Scrub/Shrub,#CCBA7C,0,none,#ffffff,1,2230
+1805,131521,Developed park,Urban park,131,52,Scrub/Shrub,#CCBA7C,1,low,#e5f5e0,1,2230
+1806,131522,Developed park,Urban park,131,52,Scrub/Shrub,#CCBA7C,2,medium,#a1d99b,1,2230
+1807,131523,Developed park,Urban park,131,52,Scrub/Shrub,#CCBA7C,3,high,#31a354,1,2230
+1808,131710,Developed park,Urban park,131,71,Grassland/Herbaceous,#E2E2C1,0,none,#ffffff,1,2230
+1809,131711,Developed park,Urban park,131,71,Grassland/Herbaceous,#E2E2C1,1,low,#e5f5e0,1,2230
+1810,131712,Developed park,Urban park,131,71,Grassland/Herbaceous,#E2E2C1,2,medium,#a1d99b,1,2230
+1811,131713,Developed park,Urban park,131,71,Grassland/Herbaceous,#E2E2C1,3,high,#31a354,1,2230
+1812,131720,Developed park,Urban park,131,72,Sedge/Herbaceuous,#C9C977,0,none,#ffffff,0,
+1813,131721,Developed park,Urban park,131,72,Sedge/Herbaceuous,#C9C977,1,low,#e5f5e0,0,
+1814,131722,Developed park,Urban park,131,72,Sedge/Herbaceuous,#C9C977,2,medium,#a1d99b,0,
+1815,131723,Developed park,Urban park,131,72,Sedge/Herbaceuous,#C9C977,3,high,#31a354,1,
+1816,131730,Developed park,Urban park,131,73,Lichens,#99C147,0,none,#ffffff,0,
+1817,131731,Developed park,Urban park,131,73,Lichens,#99C147,1,low,#e5f5e0,0,
+1818,131732,Developed park,Urban park,131,73,Lichens,#99C147,2,medium,#a1d99b,0,
+1819,131733,Developed park,Urban park,131,73,Lichens,#99C147,3,high,#31a354,1,
+1820,131740,Developed park,Urban park,131,74,Moss,#77AD93,0,none,#ffffff,0,
+1821,131741,Developed park,Urban park,131,74,Moss,#77AD93,1,low,#e5f5e0,0,
+1822,131742,Developed park,Urban park,131,74,Moss,#77AD93,2,medium,#a1d99b,0,
+1823,131743,Developed park,Urban park,131,74,Moss,#77AD93,3,high,#31a354,1,
+1824,131810,Developed park,Urban park,131,81,Pasture/Hay,#DBD83D,0,none,#ffffff,0,2230
+1825,131811,Developed park,Urban park,131,81,Pasture/Hay,#DBD83D,1,low,#e5f5e0,0,2230
+1826,131812,Developed park,Urban park,131,81,Pasture/Hay,#DBD83D,2,medium,#a1d99b,0,2230
+1827,131813,Developed park,Urban park,131,81,Pasture/Hay,#DBD83D,3,high,#31a354,1,2230
+1828,131820,Developed park,Urban park,131,82,Cultivated Crops,#AA7028,0,none,#ffffff,0,2230
+1829,131821,Developed park,Urban park,131,82,Cultivated Crops,#AA7028,1,low,#e5f5e0,0,2230
+1830,131822,Developed park,Urban park,131,82,Cultivated Crops,#AA7028,2,medium,#a1d99b,0,2230
+1831,131823,Developed park,Urban park,131,82,Cultivated Crops,#AA7028,3,high,#31a354,1,2230
+1832,131900,Developed park,Urban park,131,90,Woody Wetlands,#BAD8EA,0,none,#ffffff,1,2230
+1833,131901,Developed park,Urban park,131,90,Woody Wetlands,#BAD8EA,1,low,#e5f5e0,1,2230
+1834,131902,Developed park,Urban park,131,90,Woody Wetlands,#BAD8EA,2,medium,#a1d99b,1,2230
+1835,131903,Developed park,Urban park,131,90,Woody Wetlands,#BAD8EA,3,high,#31a354,1,2230
+1836,131950,Developed park,Urban park,131,95,Emergent Herbaceous Wetlands,#70A3BA,0,none,#ffffff,1,2230
+1837,131951,Developed park,Urban park,131,95,Emergent Herbaceous Wetlands,#70A3BA,1,low,#e5f5e0,1,2230
+1838,131952,Developed park,Urban park,131,95,Emergent Herbaceous Wetlands,#70A3BA,2,medium,#a1d99b,1,2230
+1839,131953,Developed park,Urban park,131,95,Emergent Herbaceous Wetlands,#70A3BA,3,high,#31a354,1,2230
+1840,132110,Developed park,Golf course,132,11,Open Water,#476BA0,0,none,#ffffff,0,2230
+1841,132111,Developed park,Golf course,132,11,Open Water,#476BA0,1,low,#e5f5e0,0,2230
+1842,132112,Developed park,Golf course,132,11,Open Water,#476BA0,2,medium,#a1d99b,0,2230
+1843,132113,Developed park,Golf course,132,11,Open Water,#476BA0,3,high,#31a354,1,2230
+1844,132120,Developed park,Golf course,132,12,Perennial Ice/Snow,#D1DDF9,0,none,#ffffff,0,2230
+1845,132121,Developed park,Golf course,132,12,Perennial Ice/Snow,#D1DDF9,1,low,#e5f5e0,0,2230
+1846,132122,Developed park,Golf course,132,12,Perennial Ice/Snow,#D1DDF9,2,medium,#a1d99b,0,2230
+1847,132123,Developed park,Golf course,132,12,Perennial Ice/Snow,#D1DDF9,3,high,#31a354,1,2230
+1848,132210,Developed park,Golf course,132,21,"Developed, Open Space",#DDC9C9,0,none,#ffffff,0,2230
+1849,132211,Developed park,Golf course,132,21,"Developed, Open Space",#DDC9C9,1,low,#e5f5e0,0,2230
+1850,132212,Developed park,Golf course,132,21,"Developed, Open Space",#DDC9C9,2,medium,#a1d99b,0,2230
+1851,132213,Developed park,Golf course,132,21,"Developed, Open Space",#DDC9C9,3,high,#31a354,1,2230
+1852,132220,Developed park,Golf course,132,22,"Developed, Low Intensity",#D89382,0,none,#ffffff,0,2230
+1853,132221,Developed park,Golf course,132,22,"Developed, Low Intensity",#D89382,1,low,#e5f5e0,0,2230
+1854,132222,Developed park,Golf course,132,22,"Developed, Low Intensity",#D89382,2,medium,#a1d99b,0,2230
+1855,132223,Developed park,Golf course,132,22,"Developed, Low Intensity",#D89382,3,high,#31a354,1,2230
+1856,132230,Developed park,Golf course,132,23,"Developed, Medium Intensity",#ED0000,0,none,#ffffff,0,2230
+1857,132231,Developed park,Golf course,132,23,"Developed, Medium Intensity",#ED0000,1,low,#e5f5e0,0,2230
+1858,132232,Developed park,Golf course,132,23,"Developed, Medium Intensity",#ED0000,2,medium,#a1d99b,0,2230
+1859,132233,Developed park,Golf course,132,23,"Developed, Medium Intensity",#ED0000,3,high,#31a354,1,2230
+1860,132240,Developed park,Golf course,132,24,"Developed, High Intensity",#AA0000,0,none,#ffffff,0,2230
+1861,132241,Developed park,Golf course,132,24,"Developed, High Intensity",#AA0000,1,low,#e5f5e0,0,2230
+1862,132242,Developed park,Golf course,132,24,"Developed, High Intensity",#AA0000,2,medium,#a1d99b,0,2230
+1863,132243,Developed park,Golf course,132,24,"Developed, High Intensity",#AA0000,3,high,#31a354,1,2230
+1864,132310,Developed park,Golf course,132,31,Barren Land (Rock/Sand/Clay),#B2ADA3,0,none,#ffffff,0,2230
+1865,132311,Developed park,Golf course,132,31,Barren Land (Rock/Sand/Clay),#B2ADA3,1,low,#e5f5e0,0,2230
+1866,132312,Developed park,Golf course,132,31,Barren Land (Rock/Sand/Clay),#B2ADA3,2,medium,#a1d99b,0,2230
+1867,132313,Developed park,Golf course,132,31,Barren Land (Rock/Sand/Clay),#B2ADA3,3,high,#31a354,1,2230
+1868,132410,Developed park,Golf course,132,41,Deciduous Forest,#68AA63,0,none,#ffffff,1,2230
+1869,132411,Developed park,Golf course,132,41,Deciduous Forest,#68AA63,1,low,#e5f5e0,1,2230
+1870,132412,Developed park,Golf course,132,41,Deciduous Forest,#68AA63,2,medium,#a1d99b,1,2230
+1871,132413,Developed park,Golf course,132,41,Deciduous Forest,#68AA63,3,high,#31a354,1,2230
+1872,132420,Developed park,Golf course,132,42,Evergreen Forest,#1C6330,0,none,#ffffff,1,2230
+1873,132421,Developed park,Golf course,132,42,Evergreen Forest,#1C6330,1,low,#e5f5e0,1,2230
+1874,132422,Developed park,Golf course,132,42,Evergreen Forest,#1C6330,2,medium,#a1d99b,1,2230
+1875,132423,Developed park,Golf course,132,42,Evergreen Forest,#1C6330,3,high,#31a354,1,2230
+1876,132430,Developed park,Golf course,132,43,Mixed Forest,#B5C98E,0,none,#ffffff,1,2230
+1877,132431,Developed park,Golf course,132,43,Mixed Forest,#B5C98E,1,low,#e5f5e0,1,2230
+1878,132432,Developed park,Golf course,132,43,Mixed Forest,#B5C98E,2,medium,#a1d99b,1,2230
+1879,132433,Developed park,Golf course,132,43,Mixed Forest,#B5C98E,3,high,#31a354,1,2230
+1880,132510,Developed park,Golf course,132,51,Dwarf Scrub,#A58C30,0,none,#ffffff,0,
+1881,132511,Developed park,Golf course,132,51,Dwarf Scrub,#A58C30,1,low,#e5f5e0,0,
+1882,132512,Developed park,Golf course,132,51,Dwarf Scrub,#A58C30,2,medium,#a1d99b,0,
+1883,132513,Developed park,Golf course,132,51,Dwarf Scrub,#A58C30,3,high,#31a354,1,
+1884,132520,Developed park,Golf course,132,52,Scrub/Shrub,#CCBA7C,0,none,#ffffff,1,2230
+1885,132521,Developed park,Golf course,132,52,Scrub/Shrub,#CCBA7C,1,low,#e5f5e0,1,2230
+1886,132522,Developed park,Golf course,132,52,Scrub/Shrub,#CCBA7C,2,medium,#a1d99b,1,2230
+1887,132523,Developed park,Golf course,132,52,Scrub/Shrub,#CCBA7C,3,high,#31a354,1,2230
+1888,132710,Developed park,Golf course,132,71,Grassland/Herbaceous,#E2E2C1,0,none,#ffffff,1,2230
+1889,132711,Developed park,Golf course,132,71,Grassland/Herbaceous,#E2E2C1,1,low,#e5f5e0,1,2230
+1890,132712,Developed park,Golf course,132,71,Grassland/Herbaceous,#E2E2C1,2,medium,#a1d99b,1,2230
+1891,132713,Developed park,Golf course,132,71,Grassland/Herbaceous,#E2E2C1,3,high,#31a354,1,2230
+1892,132720,Developed park,Golf course,132,72,Sedge/Herbaceuous,#C9C977,0,none,#ffffff,0,
+1893,132721,Developed park,Golf course,132,72,Sedge/Herbaceuous,#C9C977,1,low,#e5f5e0,0,
+1894,132722,Developed park,Golf course,132,72,Sedge/Herbaceuous,#C9C977,2,medium,#a1d99b,0,
+1895,132723,Developed park,Golf course,132,72,Sedge/Herbaceuous,#C9C977,3,high,#31a354,1,
+1896,132730,Developed park,Golf course,132,73,Lichens,#99C147,0,none,#ffffff,0,
+1897,132731,Developed park,Golf course,132,73,Lichens,#99C147,1,low,#e5f5e0,0,
+1898,132732,Developed park,Golf course,132,73,Lichens,#99C147,2,medium,#a1d99b,0,
+1899,132733,Developed park,Golf course,132,73,Lichens,#99C147,3,high,#31a354,1,
+1900,132740,Developed park,Golf course,132,74,Moss,#77AD93,0,none,#ffffff,0,
+1901,132741,Developed park,Golf course,132,74,Moss,#77AD93,1,low,#e5f5e0,0,
+1902,132742,Developed park,Golf course,132,74,Moss,#77AD93,2,medium,#a1d99b,0,
+1903,132743,Developed park,Golf course,132,74,Moss,#77AD93,3,high,#31a354,1,
+1904,132810,Developed park,Golf course,132,81,Pasture/Hay,#DBD83D,0,none,#ffffff,0,2230
+1905,132811,Developed park,Golf course,132,81,Pasture/Hay,#DBD83D,1,low,#e5f5e0,0,2230
+1906,132812,Developed park,Golf course,132,81,Pasture/Hay,#DBD83D,2,medium,#a1d99b,0,2230
+1907,132813,Developed park,Golf course,132,81,Pasture/Hay,#DBD83D,3,high,#31a354,1,2230
+1908,132820,Developed park,Golf course,132,82,Cultivated Crops,#AA7028,0,none,#ffffff,0,2230
+1909,132821,Developed park,Golf course,132,82,Cultivated Crops,#AA7028,1,low,#e5f5e0,0,2230
+1910,132822,Developed park,Golf course,132,82,Cultivated Crops,#AA7028,2,medium,#a1d99b,0,2230
+1911,132823,Developed park,Golf course,132,82,Cultivated Crops,#AA7028,3,high,#31a354,1,2230
+1912,132900,Developed park,Golf course,132,90,Woody Wetlands,#BAD8EA,0,none,#ffffff,1,2230
+1913,132901,Developed park,Golf course,132,90,Woody Wetlands,#BAD8EA,1,low,#e5f5e0,1,2230
+1914,132902,Developed park,Golf course,132,90,Woody Wetlands,#BAD8EA,2,medium,#a1d99b,1,2230
+1915,132903,Developed park,Golf course,132,90,Woody Wetlands,#BAD8EA,3,high,#31a354,1,2230
+1916,132950,Developed park,Golf course,132,95,Emergent Herbaceous Wetlands,#70A3BA,0,none,#ffffff,1,2230
+1917,132951,Developed park,Golf course,132,95,Emergent Herbaceous Wetlands,#70A3BA,1,low,#e5f5e0,1,2230
+1918,132952,Developed park,Golf course,132,95,Emergent Herbaceous Wetlands,#70A3BA,2,medium,#a1d99b,1,2230
+1919,132953,Developed park,Golf course,132,95,Emergent Herbaceous Wetlands,#70A3BA,3,high,#31a354,1,2230
+1920,133110,Developed park,Resort/ski area,133,11,Open Water,#476BA0,0,none,#ffffff,0,2230
+1921,133111,Developed park,Resort/ski area,133,11,Open Water,#476BA0,1,low,#e5f5e0,0,2230
+1922,133112,Developed park,Resort/ski area,133,11,Open Water,#476BA0,2,medium,#a1d99b,0,2230
+1923,133113,Developed park,Resort/ski area,133,11,Open Water,#476BA0,3,high,#31a354,1,2230
+1924,133120,Developed park,Resort/ski area,133,12,Perennial Ice/Snow,#D1DDF9,0,none,#ffffff,0,2230
+1925,133121,Developed park,Resort/ski area,133,12,Perennial Ice/Snow,#D1DDF9,1,low,#e5f5e0,0,2230
+1926,133122,Developed park,Resort/ski area,133,12,Perennial Ice/Snow,#D1DDF9,2,medium,#a1d99b,0,2230
+1927,133123,Developed park,Resort/ski area,133,12,Perennial Ice/Snow,#D1DDF9,3,high,#31a354,1,2230
+1928,133210,Developed park,Resort/ski area,133,21,"Developed, Open Space",#DDC9C9,0,none,#ffffff,0,2230
+1929,133211,Developed park,Resort/ski area,133,21,"Developed, Open Space",#DDC9C9,1,low,#e5f5e0,0,2230
+1930,133212,Developed park,Resort/ski area,133,21,"Developed, Open Space",#DDC9C9,2,medium,#a1d99b,0,2230
+1931,133213,Developed park,Resort/ski area,133,21,"Developed, Open Space",#DDC9C9,3,high,#31a354,1,2230
+1932,133220,Developed park,Resort/ski area,133,22,"Developed, Low Intensity",#D89382,0,none,#ffffff,0,2230
+1933,133221,Developed park,Resort/ski area,133,22,"Developed, Low Intensity",#D89382,1,low,#e5f5e0,0,2230
+1934,133222,Developed park,Resort/ski area,133,22,"Developed, Low Intensity",#D89382,2,medium,#a1d99b,0,2230
+1935,133223,Developed park,Resort/ski area,133,22,"Developed, Low Intensity",#D89382,3,high,#31a354,1,2230
+1936,133230,Developed park,Resort/ski area,133,23,"Developed, Medium Intensity",#ED0000,0,none,#ffffff,0,2230
+1937,133231,Developed park,Resort/ski area,133,23,"Developed, Medium Intensity",#ED0000,1,low,#e5f5e0,0,2230
+1938,133232,Developed park,Resort/ski area,133,23,"Developed, Medium Intensity",#ED0000,2,medium,#a1d99b,0,2230
+1939,133233,Developed park,Resort/ski area,133,23,"Developed, Medium Intensity",#ED0000,3,high,#31a354,1,2230
+1940,133240,Developed park,Resort/ski area,133,24,"Developed, High Intensity",#AA0000,0,none,#ffffff,0,2230
+1941,133241,Developed park,Resort/ski area,133,24,"Developed, High Intensity",#AA0000,1,low,#e5f5e0,0,2230
+1942,133242,Developed park,Resort/ski area,133,24,"Developed, High Intensity",#AA0000,2,medium,#a1d99b,0,2230
+1943,133243,Developed park,Resort/ski area,133,24,"Developed, High Intensity",#AA0000,3,high,#31a354,1,2230
+1944,133310,Developed park,Resort/ski area,133,31,Barren Land (Rock/Sand/Clay),#B2ADA3,0,none,#ffffff,0,2230
+1945,133311,Developed park,Resort/ski area,133,31,Barren Land (Rock/Sand/Clay),#B2ADA3,1,low,#e5f5e0,0,2230
+1946,133312,Developed park,Resort/ski area,133,31,Barren Land (Rock/Sand/Clay),#B2ADA3,2,medium,#a1d99b,0,2230
+1947,133313,Developed park,Resort/ski area,133,31,Barren Land (Rock/Sand/Clay),#B2ADA3,3,high,#31a354,1,2230
+1948,133410,Developed park,Resort/ski area,133,41,Deciduous Forest,#68AA63,0,none,#ffffff,1,2230
+1949,133411,Developed park,Resort/ski area,133,41,Deciduous Forest,#68AA63,1,low,#e5f5e0,1,2230
+1950,133412,Developed park,Resort/ski area,133,41,Deciduous Forest,#68AA63,2,medium,#a1d99b,1,2230
+1951,133413,Developed park,Resort/ski area,133,41,Deciduous Forest,#68AA63,3,high,#31a354,1,2230
+1952,133420,Developed park,Resort/ski area,133,42,Evergreen Forest,#1C6330,0,none,#ffffff,1,2230
+1953,133421,Developed park,Resort/ski area,133,42,Evergreen Forest,#1C6330,1,low,#e5f5e0,1,2230
+1954,133422,Developed park,Resort/ski area,133,42,Evergreen Forest,#1C6330,2,medium,#a1d99b,1,2230
+1955,133423,Developed park,Resort/ski area,133,42,Evergreen Forest,#1C6330,3,high,#31a354,1,2230
+1956,133430,Developed park,Resort/ski area,133,43,Mixed Forest,#B5C98E,0,none,#ffffff,1,2230
+1957,133431,Developed park,Resort/ski area,133,43,Mixed Forest,#B5C98E,1,low,#e5f5e0,1,2230
+1958,133432,Developed park,Resort/ski area,133,43,Mixed Forest,#B5C98E,2,medium,#a1d99b,1,2230
+1959,133433,Developed park,Resort/ski area,133,43,Mixed Forest,#B5C98E,3,high,#31a354,1,2230
+1960,133510,Developed park,Resort/ski area,133,51,Dwarf Scrub,#A58C30,0,none,#ffffff,0,
+1961,133511,Developed park,Resort/ski area,133,51,Dwarf Scrub,#A58C30,1,low,#e5f5e0,0,
+1962,133512,Developed park,Resort/ski area,133,51,Dwarf Scrub,#A58C30,2,medium,#a1d99b,0,
+1963,133513,Developed park,Resort/ski area,133,51,Dwarf Scrub,#A58C30,3,high,#31a354,1,
+1964,133520,Developed park,Resort/ski area,133,52,Scrub/Shrub,#CCBA7C,0,none,#ffffff,1,2230
+1965,133521,Developed park,Resort/ski area,133,52,Scrub/Shrub,#CCBA7C,1,low,#e5f5e0,1,2230
+1966,133522,Developed park,Resort/ski area,133,52,Scrub/Shrub,#CCBA7C,2,medium,#a1d99b,1,2230
+1967,133523,Developed park,Resort/ski area,133,52,Scrub/Shrub,#CCBA7C,3,high,#31a354,1,2230
+1968,133710,Developed park,Resort/ski area,133,71,Grassland/Herbaceous,#E2E2C1,0,none,#ffffff,1,2230
+1969,133711,Developed park,Resort/ski area,133,71,Grassland/Herbaceous,#E2E2C1,1,low,#e5f5e0,1,2230
+1970,133712,Developed park,Resort/ski area,133,71,Grassland/Herbaceous,#E2E2C1,2,medium,#a1d99b,1,2230
+1971,133713,Developed park,Resort/ski area,133,71,Grassland/Herbaceous,#E2E2C1,3,high,#31a354,1,2230
+1972,133720,Developed park,Resort/ski area,133,72,Sedge/Herbaceuous,#C9C977,0,none,#ffffff,0,
+1973,133721,Developed park,Resort/ski area,133,72,Sedge/Herbaceuous,#C9C977,1,low,#e5f5e0,0,
+1974,133722,Developed park,Resort/ski area,133,72,Sedge/Herbaceuous,#C9C977,2,medium,#a1d99b,0,
+1975,133723,Developed park,Resort/ski area,133,72,Sedge/Herbaceuous,#C9C977,3,high,#31a354,1,
+1976,133730,Developed park,Resort/ski area,133,73,Lichens,#99C147,0,none,#ffffff,0,
+1977,133731,Developed park,Resort/ski area,133,73,Lichens,#99C147,1,low,#e5f5e0,0,
+1978,133732,Developed park,Resort/ski area,133,73,Lichens,#99C147,2,medium,#a1d99b,0,
+1979,133733,Developed park,Resort/ski area,133,73,Lichens,#99C147,3,high,#31a354,1,
+1980,133740,Developed park,Resort/ski area,133,74,Moss,#77AD93,0,none,#ffffff,0,
+1981,133741,Developed park,Resort/ski area,133,74,Moss,#77AD93,1,low,#e5f5e0,0,
+1982,133742,Developed park,Resort/ski area,133,74,Moss,#77AD93,2,medium,#a1d99b,0,
+1983,133743,Developed park,Resort/ski area,133,74,Moss,#77AD93,3,high,#31a354,1,
+1984,133810,Developed park,Resort/ski area,133,81,Pasture/Hay,#DBD83D,0,none,#ffffff,0,2230
+1985,133811,Developed park,Resort/ski area,133,81,Pasture/Hay,#DBD83D,1,low,#e5f5e0,0,2230
+1986,133812,Developed park,Resort/ski area,133,81,Pasture/Hay,#DBD83D,2,medium,#a1d99b,0,2230
+1987,133813,Developed park,Resort/ski area,133,81,Pasture/Hay,#DBD83D,3,high,#31a354,1,2230
+1988,133820,Developed park,Resort/ski area,133,82,Cultivated Crops,#AA7028,0,none,#ffffff,0,2230
+1989,133821,Developed park,Resort/ski area,133,82,Cultivated Crops,#AA7028,1,low,#e5f5e0,0,2230
+1990,133822,Developed park,Resort/ski area,133,82,Cultivated Crops,#AA7028,2,medium,#a1d99b,0,2230
+1991,133823,Developed park,Resort/ski area,133,82,Cultivated Crops,#AA7028,3,high,#31a354,1,2230
+1992,133900,Developed park,Resort/ski area,133,90,Woody Wetlands,#BAD8EA,0,none,#ffffff,1,2230
+1993,133901,Developed park,Resort/ski area,133,90,Woody Wetlands,#BAD8EA,1,low,#e5f5e0,1,2230
+1994,133902,Developed park,Resort/ski area,133,90,Woody Wetlands,#BAD8EA,2,medium,#a1d99b,1,2230
+1995,133903,Developed park,Resort/ski area,133,90,Woody Wetlands,#BAD8EA,3,high,#31a354,1,2230
+1996,133950,Developed park,Resort/ski area,133,95,Emergent Herbaceous Wetlands,#70A3BA,0,none,#ffffff,1,2230
+1997,133951,Developed park,Resort/ski area,133,95,Emergent Herbaceous Wetlands,#70A3BA,1,low,#e5f5e0,1,2230
+1998,133952,Developed park,Resort/ski area,133,95,Emergent Herbaceous Wetlands,#70A3BA,2,medium,#a1d99b,1,2230
+1999,133953,Developed park,Resort/ski area,133,95,Emergent Herbaceous Wetlands,#70A3BA,3,high,#31a354,1,2230
+2000,134110,Developed park,Other,134,11,Open Water,#476BA0,0,none,#ffffff,0,2230
+2001,134111,Developed park,Other,134,11,Open Water,#476BA0,1,low,#e5f5e0,0,2230
+2002,134112,Developed park,Other,134,11,Open Water,#476BA0,2,medium,#a1d99b,0,2230
+2003,134113,Developed park,Other,134,11,Open Water,#476BA0,3,high,#31a354,1,2230
+2004,134120,Developed park,Other,134,12,Perennial Ice/Snow,#D1DDF9,0,none,#ffffff,0,2230
+2005,134121,Developed park,Other,134,12,Perennial Ice/Snow,#D1DDF9,1,low,#e5f5e0,0,2230
+2006,134122,Developed park,Other,134,12,Perennial Ice/Snow,#D1DDF9,2,medium,#a1d99b,0,2230
+2007,134123,Developed park,Other,134,12,Perennial Ice/Snow,#D1DDF9,3,high,#31a354,1,2230
+2008,134210,Developed park,Other,134,21,"Developed, Open Space",#DDC9C9,0,none,#ffffff,0,2230
+2009,134211,Developed park,Other,134,21,"Developed, Open Space",#DDC9C9,1,low,#e5f5e0,0,2230
+2010,134212,Developed park,Other,134,21,"Developed, Open Space",#DDC9C9,2,medium,#a1d99b,0,2230
+2011,134213,Developed park,Other,134,21,"Developed, Open Space",#DDC9C9,3,high,#31a354,1,2230
+2012,134220,Developed park,Other,134,22,"Developed, Low Intensity",#D89382,0,none,#ffffff,0,2230
+2013,134221,Developed park,Other,134,22,"Developed, Low Intensity",#D89382,1,low,#e5f5e0,0,2230
+2014,134222,Developed park,Other,134,22,"Developed, Low Intensity",#D89382,2,medium,#a1d99b,0,2230
+2015,134223,Developed park,Other,134,22,"Developed, Low Intensity",#D89382,3,high,#31a354,1,2230
+2016,134230,Developed park,Other,134,23,"Developed, Medium Intensity",#ED0000,0,none,#ffffff,0,2230
+2017,134231,Developed park,Other,134,23,"Developed, Medium Intensity",#ED0000,1,low,#e5f5e0,0,2230
+2018,134232,Developed park,Other,134,23,"Developed, Medium Intensity",#ED0000,2,medium,#a1d99b,0,2230
+2019,134233,Developed park,Other,134,23,"Developed, Medium Intensity",#ED0000,3,high,#31a354,1,2230
+2020,134240,Developed park,Other,134,24,"Developed, High Intensity",#AA0000,0,none,#ffffff,0,2230
+2021,134241,Developed park,Other,134,24,"Developed, High Intensity",#AA0000,1,low,#e5f5e0,0,2230
+2022,134242,Developed park,Other,134,24,"Developed, High Intensity",#AA0000,2,medium,#a1d99b,0,2230
+2023,134243,Developed park,Other,134,24,"Developed, High Intensity",#AA0000,3,high,#31a354,1,2230
+2024,134310,Developed park,Other,134,31,Barren Land (Rock/Sand/Clay),#B2ADA3,0,none,#ffffff,0,2230
+2025,134311,Developed park,Other,134,31,Barren Land (Rock/Sand/Clay),#B2ADA3,1,low,#e5f5e0,0,2230
+2026,134312,Developed park,Other,134,31,Barren Land (Rock/Sand/Clay),#B2ADA3,2,medium,#a1d99b,0,2230
+2027,134313,Developed park,Other,134,31,Barren Land (Rock/Sand/Clay),#B2ADA3,3,high,#31a354,1,2230
+2028,134410,Developed park,Other,134,41,Deciduous Forest,#68AA63,0,none,#ffffff,1,2230
+2029,134411,Developed park,Other,134,41,Deciduous Forest,#68AA63,1,low,#e5f5e0,1,2230
+2030,134412,Developed park,Other,134,41,Deciduous Forest,#68AA63,2,medium,#a1d99b,1,2230
+2031,134413,Developed park,Other,134,41,Deciduous Forest,#68AA63,3,high,#31a354,1,2230
+2032,134420,Developed park,Other,134,42,Evergreen Forest,#1C6330,0,none,#ffffff,1,2230
+2033,134421,Developed park,Other,134,42,Evergreen Forest,#1C6330,1,low,#e5f5e0,1,2230
+2034,134422,Developed park,Other,134,42,Evergreen Forest,#1C6330,2,medium,#a1d99b,1,2230
+2035,134423,Developed park,Other,134,42,Evergreen Forest,#1C6330,3,high,#31a354,1,2230
+2036,134430,Developed park,Other,134,43,Mixed Forest,#B5C98E,0,none,#ffffff,1,2230
+2037,134431,Developed park,Other,134,43,Mixed Forest,#B5C98E,1,low,#e5f5e0,1,2230
+2038,134432,Developed park,Other,134,43,Mixed Forest,#B5C98E,2,medium,#a1d99b,1,2230
+2039,134433,Developed park,Other,134,43,Mixed Forest,#B5C98E,3,high,#31a354,1,2230
+2040,134510,Developed park,Other,134,51,Dwarf Scrub,#A58C30,0,none,#ffffff,0,
+2041,134511,Developed park,Other,134,51,Dwarf Scrub,#A58C30,1,low,#e5f5e0,0,
+2042,134512,Developed park,Other,134,51,Dwarf Scrub,#A58C30,2,medium,#a1d99b,0,
+2043,134513,Developed park,Other,134,51,Dwarf Scrub,#A58C30,3,high,#31a354,1,
+2044,134520,Developed park,Other,134,52,Scrub/Shrub,#CCBA7C,0,none,#ffffff,1,2230
+2045,134521,Developed park,Other,134,52,Scrub/Shrub,#CCBA7C,1,low,#e5f5e0,1,2230
+2046,134522,Developed park,Other,134,52,Scrub/Shrub,#CCBA7C,2,medium,#a1d99b,1,2230
+2047,134523,Developed park,Other,134,52,Scrub/Shrub,#CCBA7C,3,high,#31a354,1,2230
+2048,134710,Developed park,Other,134,71,Grassland/Herbaceous,#E2E2C1,0,none,#ffffff,1,2230
+2049,134711,Developed park,Other,134,71,Grassland/Herbaceous,#E2E2C1,1,low,#e5f5e0,1,2230
+2050,134712,Developed park,Other,134,71,Grassland/Herbaceous,#E2E2C1,2,medium,#a1d99b,1,2230
+2051,134713,Developed park,Other,134,71,Grassland/Herbaceous,#E2E2C1,3,high,#31a354,1,2230
+2052,134720,Developed park,Other,134,72,Sedge/Herbaceuous,#C9C977,0,none,#ffffff,0,
+2053,134721,Developed park,Other,134,72,Sedge/Herbaceuous,#C9C977,1,low,#e5f5e0,0,
+2054,134722,Developed park,Other,134,72,Sedge/Herbaceuous,#C9C977,2,medium,#a1d99b,0,
+2055,134723,Developed park,Other,134,72,Sedge/Herbaceuous,#C9C977,3,high,#31a354,1,
+2056,134730,Developed park,Other,134,73,Lichens,#99C147,0,none,#ffffff,0,
+2057,134731,Developed park,Other,134,73,Lichens,#99C147,1,low,#e5f5e0,0,
+2058,134732,Developed park,Other,134,73,Lichens,#99C147,2,medium,#a1d99b,0,
+2059,134733,Developed park,Other,134,73,Lichens,#99C147,3,high,#31a354,1,
+2060,134740,Developed park,Other,134,74,Moss,#77AD93,0,none,#ffffff,0,
+2061,134741,Developed park,Other,134,74,Moss,#77AD93,1,low,#e5f5e0,0,
+2062,134742,Developed park,Other,134,74,Moss,#77AD93,2,medium,#a1d99b,0,
+2063,134743,Developed park,Other,134,74,Moss,#77AD93,3,high,#31a354,1,
+2064,134810,Developed park,Other,134,81,Pasture/Hay,#DBD83D,0,none,#ffffff,0,2230
+2065,134811,Developed park,Other,134,81,Pasture/Hay,#DBD83D,1,low,#e5f5e0,0,2230
+2066,134812,Developed park,Other,134,81,Pasture/Hay,#DBD83D,2,medium,#a1d99b,0,2230
+2067,134813,Developed park,Other,134,81,Pasture/Hay,#DBD83D,3,high,#31a354,1,2230
+2068,134820,Developed park,Other,134,82,Cultivated Crops,#AA7028,0,none,#ffffff,0,2230
+2069,134821,Developed park,Other,134,82,Cultivated Crops,#AA7028,1,low,#e5f5e0,0,2230
+2070,134822,Developed park,Other,134,82,Cultivated Crops,#AA7028,2,medium,#a1d99b,0,2230
+2071,134823,Developed park,Other,134,82,Cultivated Crops,#AA7028,3,high,#31a354,1,2230
+2072,134900,Developed park,Other,134,90,Woody Wetlands,#BAD8EA,0,none,#ffffff,1,2230
+2073,134901,Developed park,Other,134,90,Woody Wetlands,#BAD8EA,1,low,#e5f5e0,1,2230
+2074,134902,Developed park,Other,134,90,Woody Wetlands,#BAD8EA,2,medium,#a1d99b,1,2230
+2075,134903,Developed park,Other,134,90,Woody Wetlands,#BAD8EA,3,high,#31a354,1,2230
+2076,134950,Developed park,Other,134,95,Emergent Herbaceous Wetlands,#70A3BA,0,none,#ffffff,1,2230
+2077,134951,Developed park,Other,134,95,Emergent Herbaceous Wetlands,#70A3BA,1,low,#e5f5e0,1,2230
+2078,134952,Developed park,Other,134,95,Emergent Herbaceous Wetlands,#70A3BA,2,medium,#a1d99b,1,2230
+2079,134953,Developed park,Other,134,95,Emergent Herbaceous Wetlands,#70A3BA,3,high,#31a354,1,2230
+2080,140110,Natural park,,140,11,Open Water,#476BA0,0,none,#ffffff,0,2230
+2081,140111,Natural park,,140,11,Open Water,#476BA0,1,low,#e5f5e0,0,2230
+2082,140112,Natural park,,140,11,Open Water,#476BA0,2,medium,#a1d99b,0,2230
+2083,140113,Natural park,,140,11,Open Water,#476BA0,3,high,#31a354,1,2230
+2084,140120,Natural park,,140,12,Perennial Ice/Snow,#D1DDF9,0,none,#ffffff,0,2230
+2085,140121,Natural park,,140,12,Perennial Ice/Snow,#D1DDF9,1,low,#e5f5e0,0,2230
+2086,140122,Natural park,,140,12,Perennial Ice/Snow,#D1DDF9,2,medium,#a1d99b,0,2230
+2087,140123,Natural park,,140,12,Perennial Ice/Snow,#D1DDF9,3,high,#31a354,1,2230
+2088,140210,Natural park,,140,21,"Developed, Open Space",#DDC9C9,0,none,#ffffff,0,2230
+2089,140211,Natural park,,140,21,"Developed, Open Space",#DDC9C9,1,low,#e5f5e0,0,2230
+2090,140212,Natural park,,140,21,"Developed, Open Space",#DDC9C9,2,medium,#a1d99b,0,2230
+2091,140213,Natural park,,140,21,"Developed, Open Space",#DDC9C9,3,high,#31a354,1,2230
+2092,140220,Natural park,,140,22,"Developed, Low Intensity",#D89382,0,none,#ffffff,0,2230
+2093,140221,Natural park,,140,22,"Developed, Low Intensity",#D89382,1,low,#e5f5e0,0,2230
+2094,140222,Natural park,,140,22,"Developed, Low Intensity",#D89382,2,medium,#a1d99b,0,2230
+2095,140223,Natural park,,140,22,"Developed, Low Intensity",#D89382,3,high,#31a354,1,2230
+2096,140230,Natural park,,140,23,"Developed, Medium Intensity",#ED0000,0,none,#ffffff,0,2230
+2097,140231,Natural park,,140,23,"Developed, Medium Intensity",#ED0000,1,low,#e5f5e0,0,2230
+2098,140232,Natural park,,140,23,"Developed, Medium Intensity",#ED0000,2,medium,#a1d99b,0,2230
+2099,140233,Natural park,,140,23,"Developed, Medium Intensity",#ED0000,3,high,#31a354,1,2230
+2100,140240,Natural park,,140,24,"Developed, High Intensity",#AA0000,0,none,#ffffff,0,2230
+2101,140241,Natural park,,140,24,"Developed, High Intensity",#AA0000,1,low,#e5f5e0,0,2230
+2102,140242,Natural park,,140,24,"Developed, High Intensity",#AA0000,2,medium,#a1d99b,0,2230
+2103,140243,Natural park,,140,24,"Developed, High Intensity",#AA0000,3,high,#31a354,1,2230
+2104,140310,Natural park,,140,31,Barren Land (Rock/Sand/Clay),#B2ADA3,0,none,#ffffff,0,2230
+2105,140311,Natural park,,140,31,Barren Land (Rock/Sand/Clay),#B2ADA3,1,low,#e5f5e0,0,2230
+2106,140312,Natural park,,140,31,Barren Land (Rock/Sand/Clay),#B2ADA3,2,medium,#a1d99b,0,2230
+2107,140313,Natural park,,140,31,Barren Land (Rock/Sand/Clay),#B2ADA3,3,high,#31a354,1,2230
+2108,140410,Natural park,,140,41,Deciduous Forest,#68AA63,0,none,#ffffff,1,2230
+2109,140411,Natural park,,140,41,Deciduous Forest,#68AA63,1,low,#e5f5e0,1,2230
+2110,140412,Natural park,,140,41,Deciduous Forest,#68AA63,2,medium,#a1d99b,1,2230
+2111,140413,Natural park,,140,41,Deciduous Forest,#68AA63,3,high,#31a354,1,2230
+2112,140420,Natural park,,140,42,Evergreen Forest,#1C6330,0,none,#ffffff,1,2230
+2113,140421,Natural park,,140,42,Evergreen Forest,#1C6330,1,low,#e5f5e0,1,2230
+2114,140422,Natural park,,140,42,Evergreen Forest,#1C6330,2,medium,#a1d99b,1,2230
+2115,140423,Natural park,,140,42,Evergreen Forest,#1C6330,3,high,#31a354,1,2230
+2116,140430,Natural park,,140,43,Mixed Forest,#B5C98E,0,none,#ffffff,1,2230
+2117,140431,Natural park,,140,43,Mixed Forest,#B5C98E,1,low,#e5f5e0,1,2230
+2118,140432,Natural park,,140,43,Mixed Forest,#B5C98E,2,medium,#a1d99b,1,2230
+2119,140433,Natural park,,140,43,Mixed Forest,#B5C98E,3,high,#31a354,1,2230
+2120,140510,Natural park,,140,51,Dwarf Scrub,#A58C30,0,none,#ffffff,0,
+2121,140511,Natural park,,140,51,Dwarf Scrub,#A58C30,1,low,#e5f5e0,0,
+2122,140512,Natural park,,140,51,Dwarf Scrub,#A58C30,2,medium,#a1d99b,0,
+2123,140513,Natural park,,140,51,Dwarf Scrub,#A58C30,3,high,#31a354,1,
+2124,140520,Natural park,,140,52,Scrub/Shrub,#CCBA7C,0,none,#ffffff,1,2230
+2125,140521,Natural park,,140,52,Scrub/Shrub,#CCBA7C,1,low,#e5f5e0,1,2230
+2126,140522,Natural park,,140,52,Scrub/Shrub,#CCBA7C,2,medium,#a1d99b,1,2230
+2127,140523,Natural park,,140,52,Scrub/Shrub,#CCBA7C,3,high,#31a354,1,2230
+2128,140710,Natural park,,140,71,Grassland/Herbaceous,#E2E2C1,0,none,#ffffff,1,2230
+2129,140711,Natural park,,140,71,Grassland/Herbaceous,#E2E2C1,1,low,#e5f5e0,1,2230
+2130,140712,Natural park,,140,71,Grassland/Herbaceous,#E2E2C1,2,medium,#a1d99b,1,2230
+2131,140713,Natural park,,140,71,Grassland/Herbaceous,#E2E2C1,3,high,#31a354,1,2230
+2132,140720,Natural park,,140,72,Sedge/Herbaceuous,#C9C977,0,none,#ffffff,0,
+2133,140721,Natural park,,140,72,Sedge/Herbaceuous,#C9C977,1,low,#e5f5e0,0,
+2134,140722,Natural park,,140,72,Sedge/Herbaceuous,#C9C977,2,medium,#a1d99b,0,
+2135,140723,Natural park,,140,72,Sedge/Herbaceuous,#C9C977,3,high,#31a354,1,
+2136,140730,Natural park,,140,73,Lichens,#99C147,0,none,#ffffff,0,
+2137,140731,Natural park,,140,73,Lichens,#99C147,1,low,#e5f5e0,0,
+2138,140732,Natural park,,140,73,Lichens,#99C147,2,medium,#a1d99b,0,
+2139,140733,Natural park,,140,73,Lichens,#99C147,3,high,#31a354,1,
+2140,140740,Natural park,,140,74,Moss,#77AD93,0,none,#ffffff,0,
+2141,140741,Natural park,,140,74,Moss,#77AD93,1,low,#e5f5e0,0,
+2142,140742,Natural park,,140,74,Moss,#77AD93,2,medium,#a1d99b,0,
+2143,140743,Natural park,,140,74,Moss,#77AD93,3,high,#31a354,1,
+2144,140810,Natural park,,140,81,Pasture/Hay,#DBD83D,0,none,#ffffff,0,2230
+2145,140811,Natural park,,140,81,Pasture/Hay,#DBD83D,1,low,#e5f5e0,0,2230
+2146,140812,Natural park,,140,81,Pasture/Hay,#DBD83D,2,medium,#a1d99b,0,2230
+2147,140813,Natural park,,140,81,Pasture/Hay,#DBD83D,3,high,#31a354,1,2230
+2148,140820,Natural park,,140,82,Cultivated Crops,#AA7028,0,none,#ffffff,0,2230
+2149,140821,Natural park,,140,82,Cultivated Crops,#AA7028,1,low,#e5f5e0,0,2230
+2150,140822,Natural park,,140,82,Cultivated Crops,#AA7028,2,medium,#a1d99b,0,2230
+2151,140823,Natural park,,140,82,Cultivated Crops,#AA7028,3,high,#31a354,1,2230
+2152,140900,Natural park,,140,90,Woody Wetlands,#BAD8EA,0,none,#ffffff,1,2230
+2153,140901,Natural park,,140,90,Woody Wetlands,#BAD8EA,1,low,#e5f5e0,1,2230
+2154,140902,Natural park,,140,90,Woody Wetlands,#BAD8EA,2,medium,#a1d99b,1,2230
+2155,140903,Natural park,,140,90,Woody Wetlands,#BAD8EA,3,high,#31a354,1,2230
+2156,140950,Natural park,,140,95,Emergent Herbaceous Wetlands,#70A3BA,0,none,#ffffff,1,2230
+2157,140951,Natural park,,140,95,Emergent Herbaceous Wetlands,#70A3BA,1,low,#e5f5e0,1,2230
+2158,140952,Natural park,,140,95,Emergent Herbaceous Wetlands,#70A3BA,2,medium,#a1d99b,1,2230
+2159,140953,Natural park,,140,95,Emergent Herbaceous Wetlands,#70A3BA,3,high,#31a354,1,2230
+2160,151110,Conservation,Public,151,11,Open Water,#476BA0,0,none,#ffffff,0,2230
+2161,151111,Conservation,Public,151,11,Open Water,#476BA0,1,low,#e5f5e0,0,2230
+2162,151112,Conservation,Public,151,11,Open Water,#476BA0,2,medium,#a1d99b,0,2230
+2163,151113,Conservation,Public,151,11,Open Water,#476BA0,3,high,#31a354,1,2230
+2164,151120,Conservation,Public,151,12,Perennial Ice/Snow,#D1DDF9,0,none,#ffffff,0,2230
+2165,151121,Conservation,Public,151,12,Perennial Ice/Snow,#D1DDF9,1,low,#e5f5e0,0,2230
+2166,151122,Conservation,Public,151,12,Perennial Ice/Snow,#D1DDF9,2,medium,#a1d99b,0,2230
+2167,151123,Conservation,Public,151,12,Perennial Ice/Snow,#D1DDF9,3,high,#31a354,1,2230
+2168,151210,Conservation,Public,151,21,"Developed, Open Space",#DDC9C9,0,none,#ffffff,0,2230
+2169,151211,Conservation,Public,151,21,"Developed, Open Space",#DDC9C9,1,low,#e5f5e0,0,2230
+2170,151212,Conservation,Public,151,21,"Developed, Open Space",#DDC9C9,2,medium,#a1d99b,0,2230
+2171,151213,Conservation,Public,151,21,"Developed, Open Space",#DDC9C9,3,high,#31a354,1,2230
+2172,151220,Conservation,Public,151,22,"Developed, Low Intensity",#D89382,0,none,#ffffff,0,2230
+2173,151221,Conservation,Public,151,22,"Developed, Low Intensity",#D89382,1,low,#e5f5e0,0,2230
+2174,151222,Conservation,Public,151,22,"Developed, Low Intensity",#D89382,2,medium,#a1d99b,0,2230
+2175,151223,Conservation,Public,151,22,"Developed, Low Intensity",#D89382,3,high,#31a354,1,2230
+2176,151230,Conservation,Public,151,23,"Developed, Medium Intensity",#ED0000,0,none,#ffffff,0,2230
+2177,151231,Conservation,Public,151,23,"Developed, Medium Intensity",#ED0000,1,low,#e5f5e0,0,2230
+2178,151232,Conservation,Public,151,23,"Developed, Medium Intensity",#ED0000,2,medium,#a1d99b,0,2230
+2179,151233,Conservation,Public,151,23,"Developed, Medium Intensity",#ED0000,3,high,#31a354,1,2230
+2180,151240,Conservation,Public,151,24,"Developed, High Intensity",#AA0000,0,none,#ffffff,0,2230
+2181,151241,Conservation,Public,151,24,"Developed, High Intensity",#AA0000,1,low,#e5f5e0,0,2230
+2182,151242,Conservation,Public,151,24,"Developed, High Intensity",#AA0000,2,medium,#a1d99b,0,2230
+2183,151243,Conservation,Public,151,24,"Developed, High Intensity",#AA0000,3,high,#31a354,1,2230
+2184,151310,Conservation,Public,151,31,Barren Land (Rock/Sand/Clay),#B2ADA3,0,none,#ffffff,0,2230
+2185,151311,Conservation,Public,151,31,Barren Land (Rock/Sand/Clay),#B2ADA3,1,low,#e5f5e0,0,2230
+2186,151312,Conservation,Public,151,31,Barren Land (Rock/Sand/Clay),#B2ADA3,2,medium,#a1d99b,0,2230
+2187,151313,Conservation,Public,151,31,Barren Land (Rock/Sand/Clay),#B2ADA3,3,high,#31a354,1,2230
+2188,151410,Conservation,Public,151,41,Deciduous Forest,#68AA63,0,none,#ffffff,1,2230
+2189,151411,Conservation,Public,151,41,Deciduous Forest,#68AA63,1,low,#e5f5e0,1,2230
+2190,151412,Conservation,Public,151,41,Deciduous Forest,#68AA63,2,medium,#a1d99b,1,2230
+2191,151413,Conservation,Public,151,41,Deciduous Forest,#68AA63,3,high,#31a354,1,2230
+2192,151420,Conservation,Public,151,42,Evergreen Forest,#1C6330,0,none,#ffffff,1,2230
+2193,151421,Conservation,Public,151,42,Evergreen Forest,#1C6330,1,low,#e5f5e0,1,2230
+2194,151422,Conservation,Public,151,42,Evergreen Forest,#1C6330,2,medium,#a1d99b,1,2230
+2195,151423,Conservation,Public,151,42,Evergreen Forest,#1C6330,3,high,#31a354,1,2230
+2196,151430,Conservation,Public,151,43,Mixed Forest,#B5C98E,0,none,#ffffff,1,2230
+2197,151431,Conservation,Public,151,43,Mixed Forest,#B5C98E,1,low,#e5f5e0,1,2230
+2198,151432,Conservation,Public,151,43,Mixed Forest,#B5C98E,2,medium,#a1d99b,1,2230
+2199,151433,Conservation,Public,151,43,Mixed Forest,#B5C98E,3,high,#31a354,1,2230
+2200,151510,Conservation,Public,151,51,Dwarf Scrub,#A58C30,0,none,#ffffff,0,
+2201,151511,Conservation,Public,151,51,Dwarf Scrub,#A58C30,1,low,#e5f5e0,0,
+2202,151512,Conservation,Public,151,51,Dwarf Scrub,#A58C30,2,medium,#a1d99b,0,
+2203,151513,Conservation,Public,151,51,Dwarf Scrub,#A58C30,3,high,#31a354,1,
+2204,151520,Conservation,Public,151,52,Scrub/Shrub,#CCBA7C,0,none,#ffffff,1,2230
+2205,151521,Conservation,Public,151,52,Scrub/Shrub,#CCBA7C,1,low,#e5f5e0,1,2230
+2206,151522,Conservation,Public,151,52,Scrub/Shrub,#CCBA7C,2,medium,#a1d99b,1,2230
+2207,151523,Conservation,Public,151,52,Scrub/Shrub,#CCBA7C,3,high,#31a354,1,2230
+2208,151710,Conservation,Public,151,71,Grassland/Herbaceous,#E2E2C1,0,none,#ffffff,1,2230
+2209,151711,Conservation,Public,151,71,Grassland/Herbaceous,#E2E2C1,1,low,#e5f5e0,1,2230
+2210,151712,Conservation,Public,151,71,Grassland/Herbaceous,#E2E2C1,2,medium,#a1d99b,1,2230
+2211,151713,Conservation,Public,151,71,Grassland/Herbaceous,#E2E2C1,3,high,#31a354,1,2230
+2212,151720,Conservation,Public,151,72,Sedge/Herbaceuous,#C9C977,0,none,#ffffff,0,
+2213,151721,Conservation,Public,151,72,Sedge/Herbaceuous,#C9C977,1,low,#e5f5e0,0,
+2214,151722,Conservation,Public,151,72,Sedge/Herbaceuous,#C9C977,2,medium,#a1d99b,0,
+2215,151723,Conservation,Public,151,72,Sedge/Herbaceuous,#C9C977,3,high,#31a354,1,
+2216,151730,Conservation,Public,151,73,Lichens,#99C147,0,none,#ffffff,0,
+2217,151731,Conservation,Public,151,73,Lichens,#99C147,1,low,#e5f5e0,0,
+2218,151732,Conservation,Public,151,73,Lichens,#99C147,2,medium,#a1d99b,0,
+2219,151733,Conservation,Public,151,73,Lichens,#99C147,3,high,#31a354,1,
+2220,151740,Conservation,Public,151,74,Moss,#77AD93,0,none,#ffffff,0,
+2221,151741,Conservation,Public,151,74,Moss,#77AD93,1,low,#e5f5e0,0,
+2222,151742,Conservation,Public,151,74,Moss,#77AD93,2,medium,#a1d99b,0,
+2223,151743,Conservation,Public,151,74,Moss,#77AD93,3,high,#31a354,1,
+2224,151810,Conservation,Public,151,81,Pasture/Hay,#DBD83D,0,none,#ffffff,0,2230
+2225,151811,Conservation,Public,151,81,Pasture/Hay,#DBD83D,1,low,#e5f5e0,0,2230
+2226,151812,Conservation,Public,151,81,Pasture/Hay,#DBD83D,2,medium,#a1d99b,0,2230
+2227,151813,Conservation,Public,151,81,Pasture/Hay,#DBD83D,3,high,#31a354,1,2230
+2228,151820,Conservation,Public,151,82,Cultivated Crops,#AA7028,0,none,#ffffff,0,2230
+2229,151821,Conservation,Public,151,82,Cultivated Crops,#AA7028,1,low,#e5f5e0,0,2230
+2230,151822,Conservation,Public,151,82,Cultivated Crops,#AA7028,2,medium,#a1d99b,0,2230
+2231,151823,Conservation,Public,151,82,Cultivated Crops,#AA7028,3,high,#31a354,1,2230
+2232,151900,Conservation,Public,151,90,Woody Wetlands,#BAD8EA,0,none,#ffffff,1,2230
+2233,151901,Conservation,Public,151,90,Woody Wetlands,#BAD8EA,1,low,#e5f5e0,1,2230
+2234,151902,Conservation,Public,151,90,Woody Wetlands,#BAD8EA,2,medium,#a1d99b,1,2230
+2235,151903,Conservation,Public,151,90,Woody Wetlands,#BAD8EA,3,high,#31a354,1,2230
+2236,151950,Conservation,Public,151,95,Emergent Herbaceous Wetlands,#70A3BA,0,none,#ffffff,1,2230
+2237,151951,Conservation,Public,151,95,Emergent Herbaceous Wetlands,#70A3BA,1,low,#e5f5e0,1,2230
+2238,151952,Conservation,Public,151,95,Emergent Herbaceous Wetlands,#70A3BA,2,medium,#a1d99b,1,2230
+2239,151953,Conservation,Public,151,95,Emergent Herbaceous Wetlands,#70A3BA,3,high,#31a354,1,2230
+2240,152110,Conservation,Public-limited access,152,11,Open Water,#476BA0,0,none,#ffffff,0,2230
+2241,152111,Conservation,Public-limited access,152,11,Open Water,#476BA0,1,low,#e5f5e0,0,2230
+2242,152112,Conservation,Public-limited access,152,11,Open Water,#476BA0,2,medium,#a1d99b,0,2230
+2243,152113,Conservation,Public-limited access,152,11,Open Water,#476BA0,3,high,#31a354,1,2230
+2244,152120,Conservation,Public-limited access,152,12,Perennial Ice/Snow,#D1DDF9,0,none,#ffffff,0,2230
+2245,152121,Conservation,Public-limited access,152,12,Perennial Ice/Snow,#D1DDF9,1,low,#e5f5e0,0,2230
+2246,152122,Conservation,Public-limited access,152,12,Perennial Ice/Snow,#D1DDF9,2,medium,#a1d99b,0,2230
+2247,152123,Conservation,Public-limited access,152,12,Perennial Ice/Snow,#D1DDF9,3,high,#31a354,1,2230
+2248,152210,Conservation,Public-limited access,152,21,"Developed, Open Space",#DDC9C9,0,none,#ffffff,0,2230
+2249,152211,Conservation,Public-limited access,152,21,"Developed, Open Space",#DDC9C9,1,low,#e5f5e0,0,2230
+2250,152212,Conservation,Public-limited access,152,21,"Developed, Open Space",#DDC9C9,2,medium,#a1d99b,0,2230
+2251,152213,Conservation,Public-limited access,152,21,"Developed, Open Space",#DDC9C9,3,high,#31a354,1,2230
+2252,152220,Conservation,Public-limited access,152,22,"Developed, Low Intensity",#D89382,0,none,#ffffff,0,2230
+2253,152221,Conservation,Public-limited access,152,22,"Developed, Low Intensity",#D89382,1,low,#e5f5e0,0,2230
+2254,152222,Conservation,Public-limited access,152,22,"Developed, Low Intensity",#D89382,2,medium,#a1d99b,0,2230
+2255,152223,Conservation,Public-limited access,152,22,"Developed, Low Intensity",#D89382,3,high,#31a354,1,2230
+2256,152230,Conservation,Public-limited access,152,23,"Developed, Medium Intensity",#ED0000,0,none,#ffffff,0,2230
+2257,152231,Conservation,Public-limited access,152,23,"Developed, Medium Intensity",#ED0000,1,low,#e5f5e0,0,2230
+2258,152232,Conservation,Public-limited access,152,23,"Developed, Medium Intensity",#ED0000,2,medium,#a1d99b,0,2230
+2259,152233,Conservation,Public-limited access,152,23,"Developed, Medium Intensity",#ED0000,3,high,#31a354,1,2230
+2260,152240,Conservation,Public-limited access,152,24,"Developed, High Intensity",#AA0000,0,none,#ffffff,0,2230
+2261,152241,Conservation,Public-limited access,152,24,"Developed, High Intensity",#AA0000,1,low,#e5f5e0,0,2230
+2262,152242,Conservation,Public-limited access,152,24,"Developed, High Intensity",#AA0000,2,medium,#a1d99b,0,2230
+2263,152243,Conservation,Public-limited access,152,24,"Developed, High Intensity",#AA0000,3,high,#31a354,1,2230
+2264,152310,Conservation,Public-limited access,152,31,Barren Land (Rock/Sand/Clay),#B2ADA3,0,none,#ffffff,0,2230
+2265,152311,Conservation,Public-limited access,152,31,Barren Land (Rock/Sand/Clay),#B2ADA3,1,low,#e5f5e0,0,2230
+2266,152312,Conservation,Public-limited access,152,31,Barren Land (Rock/Sand/Clay),#B2ADA3,2,medium,#a1d99b,0,2230
+2267,152313,Conservation,Public-limited access,152,31,Barren Land (Rock/Sand/Clay),#B2ADA3,3,high,#31a354,1,2230
+2268,152410,Conservation,Public-limited access,152,41,Deciduous Forest,#68AA63,0,none,#ffffff,1,2230
+2269,152411,Conservation,Public-limited access,152,41,Deciduous Forest,#68AA63,1,low,#e5f5e0,1,2230
+2270,152412,Conservation,Public-limited access,152,41,Deciduous Forest,#68AA63,2,medium,#a1d99b,1,2230
+2271,152413,Conservation,Public-limited access,152,41,Deciduous Forest,#68AA63,3,high,#31a354,1,2230
+2272,152420,Conservation,Public-limited access,152,42,Evergreen Forest,#1C6330,0,none,#ffffff,1,2230
+2273,152421,Conservation,Public-limited access,152,42,Evergreen Forest,#1C6330,1,low,#e5f5e0,1,2230
+2274,152422,Conservation,Public-limited access,152,42,Evergreen Forest,#1C6330,2,medium,#a1d99b,1,2230
+2275,152423,Conservation,Public-limited access,152,42,Evergreen Forest,#1C6330,3,high,#31a354,1,2230
+2276,152430,Conservation,Public-limited access,152,43,Mixed Forest,#B5C98E,0,none,#ffffff,1,2230
+2277,152431,Conservation,Public-limited access,152,43,Mixed Forest,#B5C98E,1,low,#e5f5e0,1,2230
+2278,152432,Conservation,Public-limited access,152,43,Mixed Forest,#B5C98E,2,medium,#a1d99b,1,2230
+2279,152433,Conservation,Public-limited access,152,43,Mixed Forest,#B5C98E,3,high,#31a354,1,2230
+2280,152510,Conservation,Public-limited access,152,51,Dwarf Scrub,#A58C30,0,none,#ffffff,0,
+2281,152511,Conservation,Public-limited access,152,51,Dwarf Scrub,#A58C30,1,low,#e5f5e0,0,
+2282,152512,Conservation,Public-limited access,152,51,Dwarf Scrub,#A58C30,2,medium,#a1d99b,0,
+2283,152513,Conservation,Public-limited access,152,51,Dwarf Scrub,#A58C30,3,high,#31a354,1,
+2284,152520,Conservation,Public-limited access,152,52,Scrub/Shrub,#CCBA7C,0,none,#ffffff,1,2230
+2285,152521,Conservation,Public-limited access,152,52,Scrub/Shrub,#CCBA7C,1,low,#e5f5e0,1,2230
+2286,152522,Conservation,Public-limited access,152,52,Scrub/Shrub,#CCBA7C,2,medium,#a1d99b,1,2230
+2287,152523,Conservation,Public-limited access,152,52,Scrub/Shrub,#CCBA7C,3,high,#31a354,1,2230
+2288,152710,Conservation,Public-limited access,152,71,Grassland/Herbaceous,#E2E2C1,0,none,#ffffff,1,2230
+2289,152711,Conservation,Public-limited access,152,71,Grassland/Herbaceous,#E2E2C1,1,low,#e5f5e0,1,2230
+2290,152712,Conservation,Public-limited access,152,71,Grassland/Herbaceous,#E2E2C1,2,medium,#a1d99b,1,2230
+2291,152713,Conservation,Public-limited access,152,71,Grassland/Herbaceous,#E2E2C1,3,high,#31a354,1,2230
+2292,152720,Conservation,Public-limited access,152,72,Sedge/Herbaceuous,#C9C977,0,none,#ffffff,0,
+2293,152721,Conservation,Public-limited access,152,72,Sedge/Herbaceuous,#C9C977,1,low,#e5f5e0,0,
+2294,152722,Conservation,Public-limited access,152,72,Sedge/Herbaceuous,#C9C977,2,medium,#a1d99b,0,
+2295,152723,Conservation,Public-limited access,152,72,Sedge/Herbaceuous,#C9C977,3,high,#31a354,1,
+2296,152730,Conservation,Public-limited access,152,73,Lichens,#99C147,0,none,#ffffff,0,
+2297,152731,Conservation,Public-limited access,152,73,Lichens,#99C147,1,low,#e5f5e0,0,
+2298,152732,Conservation,Public-limited access,152,73,Lichens,#99C147,2,medium,#a1d99b,0,
+2299,152733,Conservation,Public-limited access,152,73,Lichens,#99C147,3,high,#31a354,1,
+2300,152740,Conservation,Public-limited access,152,74,Moss,#77AD93,0,none,#ffffff,0,
+2301,152741,Conservation,Public-limited access,152,74,Moss,#77AD93,1,low,#e5f5e0,0,
+2302,152742,Conservation,Public-limited access,152,74,Moss,#77AD93,2,medium,#a1d99b,0,
+2303,152743,Conservation,Public-limited access,152,74,Moss,#77AD93,3,high,#31a354,1,
+2304,152810,Conservation,Public-limited access,152,81,Pasture/Hay,#DBD83D,0,none,#ffffff,0,2230
+2305,152811,Conservation,Public-limited access,152,81,Pasture/Hay,#DBD83D,1,low,#e5f5e0,0,2230
+2306,152812,Conservation,Public-limited access,152,81,Pasture/Hay,#DBD83D,2,medium,#a1d99b,0,2230
+2307,152813,Conservation,Public-limited access,152,81,Pasture/Hay,#DBD83D,3,high,#31a354,1,2230
+2308,152820,Conservation,Public-limited access,152,82,Cultivated Crops,#AA7028,0,none,#ffffff,0,2230
+2309,152821,Conservation,Public-limited access,152,82,Cultivated Crops,#AA7028,1,low,#e5f5e0,0,2230
+2310,152822,Conservation,Public-limited access,152,82,Cultivated Crops,#AA7028,2,medium,#a1d99b,0,2230
+2311,152823,Conservation,Public-limited access,152,82,Cultivated Crops,#AA7028,3,high,#31a354,1,2230
+2312,152900,Conservation,Public-limited access,152,90,Woody Wetlands,#BAD8EA,0,none,#ffffff,1,2230
+2313,152901,Conservation,Public-limited access,152,90,Woody Wetlands,#BAD8EA,1,low,#e5f5e0,1,2230
+2314,152902,Conservation,Public-limited access,152,90,Woody Wetlands,#BAD8EA,2,medium,#a1d99b,1,2230
+2315,152903,Conservation,Public-limited access,152,90,Woody Wetlands,#BAD8EA,3,high,#31a354,1,2230
+2316,152950,Conservation,Public-limited access,152,95,Emergent Herbaceous Wetlands,#70A3BA,0,none,#ffffff,1,2230
+2317,152951,Conservation,Public-limited access,152,95,Emergent Herbaceous Wetlands,#70A3BA,1,low,#e5f5e0,1,2230
+2318,152952,Conservation,Public-limited access,152,95,Emergent Herbaceous Wetlands,#70A3BA,2,medium,#a1d99b,1,2230
+2319,152953,Conservation,Public-limited access,152,95,Emergent Herbaceous Wetlands,#70A3BA,3,high,#31a354,1,2230
+2320,153110,Conservation,Private easement,153,11,Open Water,#476BA0,0,none,#ffffff,0,2230
+2321,153111,Conservation,Private easement,153,11,Open Water,#476BA0,1,low,#e5f5e0,0,2230
+2322,153112,Conservation,Private easement,153,11,Open Water,#476BA0,2,medium,#a1d99b,0,2230
+2323,153113,Conservation,Private easement,153,11,Open Water,#476BA0,3,high,#31a354,1,2230
+2324,153120,Conservation,Private easement,153,12,Perennial Ice/Snow,#D1DDF9,0,none,#ffffff,0,2230
+2325,153121,Conservation,Private easement,153,12,Perennial Ice/Snow,#D1DDF9,1,low,#e5f5e0,0,2230
+2326,153122,Conservation,Private easement,153,12,Perennial Ice/Snow,#D1DDF9,2,medium,#a1d99b,0,2230
+2327,153123,Conservation,Private easement,153,12,Perennial Ice/Snow,#D1DDF9,3,high,#31a354,1,2230
+2328,153210,Conservation,Private easement,153,21,"Developed, Open Space",#DDC9C9,0,none,#ffffff,0,2230
+2329,153211,Conservation,Private easement,153,21,"Developed, Open Space",#DDC9C9,1,low,#e5f5e0,0,2230
+2330,153212,Conservation,Private easement,153,21,"Developed, Open Space",#DDC9C9,2,medium,#a1d99b,0,2230
+2331,153213,Conservation,Private easement,153,21,"Developed, Open Space",#DDC9C9,3,high,#31a354,1,2230
+2332,153220,Conservation,Private easement,153,22,"Developed, Low Intensity",#D89382,0,none,#ffffff,0,2230
+2333,153221,Conservation,Private easement,153,22,"Developed, Low Intensity",#D89382,1,low,#e5f5e0,0,2230
+2334,153222,Conservation,Private easement,153,22,"Developed, Low Intensity",#D89382,2,medium,#a1d99b,0,2230
+2335,153223,Conservation,Private easement,153,22,"Developed, Low Intensity",#D89382,3,high,#31a354,1,2230
+2336,153230,Conservation,Private easement,153,23,"Developed, Medium Intensity",#ED0000,0,none,#ffffff,0,2230
+2337,153231,Conservation,Private easement,153,23,"Developed, Medium Intensity",#ED0000,1,low,#e5f5e0,0,2230
+2338,153232,Conservation,Private easement,153,23,"Developed, Medium Intensity",#ED0000,2,medium,#a1d99b,0,2230
+2339,153233,Conservation,Private easement,153,23,"Developed, Medium Intensity",#ED0000,3,high,#31a354,1,2230
+2340,153240,Conservation,Private easement,153,24,"Developed, High Intensity",#AA0000,0,none,#ffffff,0,2230
+2341,153241,Conservation,Private easement,153,24,"Developed, High Intensity",#AA0000,1,low,#e5f5e0,0,2230
+2342,153242,Conservation,Private easement,153,24,"Developed, High Intensity",#AA0000,2,medium,#a1d99b,0,2230
+2343,153243,Conservation,Private easement,153,24,"Developed, High Intensity",#AA0000,3,high,#31a354,1,2230
+2344,153310,Conservation,Private easement,153,31,Barren Land (Rock/Sand/Clay),#B2ADA3,0,none,#ffffff,0,2230
+2345,153311,Conservation,Private easement,153,31,Barren Land (Rock/Sand/Clay),#B2ADA3,1,low,#e5f5e0,0,2230
+2346,153312,Conservation,Private easement,153,31,Barren Land (Rock/Sand/Clay),#B2ADA3,2,medium,#a1d99b,0,2230
+2347,153313,Conservation,Private easement,153,31,Barren Land (Rock/Sand/Clay),#B2ADA3,3,high,#31a354,1,2230
+2348,153410,Conservation,Private easement,153,41,Deciduous Forest,#68AA63,0,none,#ffffff,1,2230
+2349,153411,Conservation,Private easement,153,41,Deciduous Forest,#68AA63,1,low,#e5f5e0,1,2230
+2350,153412,Conservation,Private easement,153,41,Deciduous Forest,#68AA63,2,medium,#a1d99b,1,2230
+2351,153413,Conservation,Private easement,153,41,Deciduous Forest,#68AA63,3,high,#31a354,1,2230
+2352,153420,Conservation,Private easement,153,42,Evergreen Forest,#1C6330,0,none,#ffffff,1,2230
+2353,153421,Conservation,Private easement,153,42,Evergreen Forest,#1C6330,1,low,#e5f5e0,1,2230
+2354,153422,Conservation,Private easement,153,42,Evergreen Forest,#1C6330,2,medium,#a1d99b,1,2230
+2355,153423,Conservation,Private easement,153,42,Evergreen Forest,#1C6330,3,high,#31a354,1,2230
+2356,153430,Conservation,Private easement,153,43,Mixed Forest,#B5C98E,0,none,#ffffff,1,2230
+2357,153431,Conservation,Private easement,153,43,Mixed Forest,#B5C98E,1,low,#e5f5e0,1,2230
+2358,153432,Conservation,Private easement,153,43,Mixed Forest,#B5C98E,2,medium,#a1d99b,1,2230
+2359,153433,Conservation,Private easement,153,43,Mixed Forest,#B5C98E,3,high,#31a354,1,2230
+2360,153510,Conservation,Private easement,153,51,Dwarf Scrub,#A58C30,0,none,#ffffff,0,
+2361,153511,Conservation,Private easement,153,51,Dwarf Scrub,#A58C30,1,low,#e5f5e0,0,
+2362,153512,Conservation,Private easement,153,51,Dwarf Scrub,#A58C30,2,medium,#a1d99b,0,
+2363,153513,Conservation,Private easement,153,51,Dwarf Scrub,#A58C30,3,high,#31a354,1,
+2364,153520,Conservation,Private easement,153,52,Scrub/Shrub,#CCBA7C,0,none,#ffffff,1,2230
+2365,153521,Conservation,Private easement,153,52,Scrub/Shrub,#CCBA7C,1,low,#e5f5e0,1,2230
+2366,153522,Conservation,Private easement,153,52,Scrub/Shrub,#CCBA7C,2,medium,#a1d99b,1,2230
+2367,153523,Conservation,Private easement,153,52,Scrub/Shrub,#CCBA7C,3,high,#31a354,1,2230
+2368,153710,Conservation,Private easement,153,71,Grassland/Herbaceous,#E2E2C1,0,none,#ffffff,1,2230
+2369,153711,Conservation,Private easement,153,71,Grassland/Herbaceous,#E2E2C1,1,low,#e5f5e0,1,2230
+2370,153712,Conservation,Private easement,153,71,Grassland/Herbaceous,#E2E2C1,2,medium,#a1d99b,1,2230
+2371,153713,Conservation,Private easement,153,71,Grassland/Herbaceous,#E2E2C1,3,high,#31a354,1,2230
+2372,153720,Conservation,Private easement,153,72,Sedge/Herbaceuous,#C9C977,0,none,#ffffff,0,
+2373,153721,Conservation,Private easement,153,72,Sedge/Herbaceuous,#C9C977,1,low,#e5f5e0,0,
+2374,153722,Conservation,Private easement,153,72,Sedge/Herbaceuous,#C9C977,2,medium,#a1d99b,0,
+2375,153723,Conservation,Private easement,153,72,Sedge/Herbaceuous,#C9C977,3,high,#31a354,1,
+2376,153730,Conservation,Private easement,153,73,Lichens,#99C147,0,none,#ffffff,0,
+2377,153731,Conservation,Private easement,153,73,Lichens,#99C147,1,low,#e5f5e0,0,
+2378,153732,Conservation,Private easement,153,73,Lichens,#99C147,2,medium,#a1d99b,0,
+2379,153733,Conservation,Private easement,153,73,Lichens,#99C147,3,high,#31a354,1,
+2380,153740,Conservation,Private easement,153,74,Moss,#77AD93,0,none,#ffffff,0,
+2381,153741,Conservation,Private easement,153,74,Moss,#77AD93,1,low,#e5f5e0,0,
+2382,153742,Conservation,Private easement,153,74,Moss,#77AD93,2,medium,#a1d99b,0,
+2383,153743,Conservation,Private easement,153,74,Moss,#77AD93,3,high,#31a354,1,
+2384,153810,Conservation,Private easement,153,81,Pasture/Hay,#DBD83D,0,none,#ffffff,0,2230
+2385,153811,Conservation,Private easement,153,81,Pasture/Hay,#DBD83D,1,low,#e5f5e0,0,2230
+2386,153812,Conservation,Private easement,153,81,Pasture/Hay,#DBD83D,2,medium,#a1d99b,0,2230
+2387,153813,Conservation,Private easement,153,81,Pasture/Hay,#DBD83D,3,high,#31a354,1,2230
+2388,153820,Conservation,Private easement,153,82,Cultivated Crops,#AA7028,0,none,#ffffff,0,2230
+2389,153821,Conservation,Private easement,153,82,Cultivated Crops,#AA7028,1,low,#e5f5e0,0,2230
+2390,153822,Conservation,Private easement,153,82,Cultivated Crops,#AA7028,2,medium,#a1d99b,0,2230
+2391,153823,Conservation,Private easement,153,82,Cultivated Crops,#AA7028,3,high,#31a354,1,2230
+2392,153900,Conservation,Private easement,153,90,Woody Wetlands,#BAD8EA,0,none,#ffffff,1,2230
+2393,153901,Conservation,Private easement,153,90,Woody Wetlands,#BAD8EA,1,low,#e5f5e0,1,2230
+2394,153902,Conservation,Private easement,153,90,Woody Wetlands,#BAD8EA,2,medium,#a1d99b,1,2230
+2395,153903,Conservation,Private easement,153,90,Woody Wetlands,#BAD8EA,3,high,#31a354,1,2230
+2396,153950,Conservation,Private easement,153,95,Emergent Herbaceous Wetlands,#70A3BA,0,none,#ffffff,1,2230
+2397,153951,Conservation,Private easement,153,95,Emergent Herbaceous Wetlands,#70A3BA,1,low,#e5f5e0,1,2230
+2398,153952,Conservation,Private easement,153,95,Emergent Herbaceous Wetlands,#70A3BA,2,medium,#a1d99b,1,2230
+2399,153953,Conservation,Private easement,153,95,Emergent Herbaceous Wetlands,#70A3BA,3,high,#31a354,1,2230

--- a/backend-worker/invest_args.py
+++ b/backend-worker/invest_args.py
@@ -81,7 +81,7 @@ def urban_cooling(lulc_path, workspace_dir, study_area_wkt):
 
 
 def urban_nature_access(lulc_path, workspace_dir, study_area_wkt):
-    search_radius = 2000
+    search_radius = 800
     aoi_geom = shapely.wkt.loads(study_area_wkt).buffer(search_radius)
     lulc_info = pygeoprocessing.get_raster_info(lulc_path)
     aoi_vector_path = os.path.join(workspace_dir, 'aoi.geojson')

--- a/backend-worker/invest_args.py
+++ b/backend-worker/invest_args.py
@@ -78,3 +78,34 @@ def urban_cooling(lulc_path, workspace_dir, study_area_wkt):
         'ucm_nlcd_simple_nlud_trees.csv')
 
     return args_dict
+
+
+def urban_nature_access(lulc_path, workspace_dir, study_area_wkt):
+    search_radius = 2280
+    aoi_geom = shapely.wkt.loads(study_area_wkt).buffer(search_radius)
+    lulc_info = pygeoprocessing.get_raster_info(lulc_path)
+    aoi_vector_path = os.path.join(workspace_dir, 'aoi.geojson')
+    pygeoprocessing.shapely_geometry_to_vector(
+        [aoi_geom], aoi_vector_path, lulc_info['projection_wkt'], 'GEOJSON')
+
+    lulc_attribute_table_path = os.path.join(
+        INVEST_BASE_PATH,
+        'biophysical_tables',
+        'urban_nature_access_nlcd_simple_nlud_trees.csv')
+    population_raster_path = os.path.join(
+        INVEST_BASE_PATH,
+        'population_san_antonio_final.tif')
+    args_dict = {
+        "workspace_dir": workspace_dir,
+        "admin_boundaries_vector_path": aoi_vector_path,
+        "aggregate_by_pop_group": False,
+        "decay_function": "dichotomy",
+        "lulc_attribute_table": lulc_attribute_table_path,
+        "lulc_raster_path": lulc_path,
+        "population_raster_path": population_raster_path,
+        "search_radius": search_radius,
+        "search_radius_mode": "uniform radius",
+        "urban_nature_demand": "16.7"
+    }
+
+    return args_dict

--- a/backend-worker/invest_args.py
+++ b/backend-worker/invest_args.py
@@ -81,7 +81,7 @@ def urban_cooling(lulc_path, workspace_dir, study_area_wkt):
 
 
 def urban_nature_access(lulc_path, workspace_dir, study_area_wkt):
-    search_radius = 2280
+    search_radius = 2000
     aoi_geom = shapely.wkt.loads(study_area_wkt).buffer(search_radius)
     lulc_info = pygeoprocessing.get_raster_info(lulc_path)
     aoi_vector_path = os.path.join(workspace_dir, 'aoi.geojson')
@@ -94,7 +94,7 @@ def urban_nature_access(lulc_path, workspace_dir, study_area_wkt):
         'urban_nature_access_nlcd_simple_nlud_trees.csv')
     population_raster_path = os.path.join(
         INVEST_BASE_PATH,
-        'population_san_antonio_final.tif')
+        'population_san_antonio_updated_02_27.tif')
     args_dict = {
         "workspace_dir": workspace_dir,
         "admin_boundaries_vector_path": aoi_vector_path,

--- a/backend-worker/invest_results.py
+++ b/backend-worker/invest_results.py
@@ -192,6 +192,7 @@ def urban_nature_access(workspace_dir):
     # Currently only aggregating over one large bounding box, so only one entry
     feat_key = balance_dict.keys()[0]
     nature_access_results['ntr_bal_avg'] = balance_dict[feat_key]
+    LOGGER.info(nature_access_results)
 
     results_json_path = os.path.join(workspace_dir, "derived_results.json")
     with open(results_json_path, "w") as fp:

--- a/backend-worker/invest_results.py
+++ b/backend-worker/invest_results.py
@@ -165,18 +165,18 @@ def urban_nature_access(workspace_dir):
 
     Return:
         nature_access_results (dict) : A python dictionary with values for 
-            nature access balance in total and on average for the aggregated
+            nature supply and balance for the aggregated
             area.
 
             keys:
-                'ntr_bal_tot'
+                'nature_supply_percapita'
                 'ntr_bal_avg'
     """
 
     nature_access_output_dir = os.path.join(workspace_dir, 'output')
     nature_access_outputs = {
-        'ntr_bal_tot': os.path.join(
-            nature_access_output_dir, 'urban_nature_balance_totalpop.tif'),
+        'nature_supply_percapita': os.path.join(
+            nature_access_output_dir, 'urban_nature_supply_percapita.tif'),
     }
 
     nature_access_results = {}

--- a/backend-worker/invest_results.py
+++ b/backend-worker/invest_results.py
@@ -190,7 +190,7 @@ def urban_nature_access(workspace_dir):
     balance_dict = _read_field_from_vector(
         balance_vector_path, 'FID', value_field)
     # Currently only aggregating over one large bounding box, so only one entry
-    feat_key = balance_dict.keys()[0]
+    feat_key = list(balance_dict)[0]
     nature_access_results['ntr_bal_avg'] = balance_dict[feat_key]
     LOGGER.info(nature_access_results)
 

--- a/backend-worker/worker.py
+++ b/backend-worker/worker.py
@@ -107,8 +107,10 @@ INVEST_MODELS = {
         "derive_results": invest_results.urban_nature_access
     }
 }
-# DF: I changed to 2000 to make it a round number, since it is user-facing
-LARGEST_SERVICESHED = 2000  # meters https://github.com/natcap/urban-online-workflow/issues/79
+
+# The largest extent LULC needed by invest models is
+# 2x the 800m search radius used by UNA.
+LARGEST_SERVICESHED = 1600
 
 # Quiet logging
 logging.getLogger(f'pygeoprocessing').setLevel(logging.WARNING)

--- a/backend-worker/worker.py
+++ b/backend-worker/worker.py
@@ -107,7 +107,8 @@ INVEST_MODELS = {
         "derive_results": invest_results.urban_nature_access
     }
 }
-LARGEST_SERVICESHED = 2280  # meters https://github.com/natcap/urban-online-workflow/issues/79
+# DF: I changed to 2000 to make it a round number, since it is user-facing
+LARGEST_SERVICESHED = 2000  # meters https://github.com/natcap/urban-online-workflow/issues/79
 
 # Quiet logging
 logging.getLogger(f'pygeoprocessing').setLevel(logging.WARNING)
@@ -740,10 +741,11 @@ def do_work(host, port, outputs_location):
                     LOGGER.info(f'Post processing {invest_model} model')
                     model_result_path = model_meta['derive_results'](workspace_dir)
 
-                try:
-                    # For now, we only expect this to work for urban-cooling
+                if invest_model == URBAN_COOLING:
                     serviceshed = args_dict['aoi_vector_path']
-                except KeyError:
+                elif invest_model == URBAN_NATURE_ACCESS:
+                    serviceshed = args_dict['admin_boundaries_vector_path']
+                else:
                     serviceshed = ''
                 data = {
                     'result': {

--- a/backend-worker/worker.py
+++ b/backend-worker/worker.py
@@ -21,6 +21,7 @@ from osgeo import osr
 from PIL import Image
 
 from natcap.invest import urban_cooling_model
+from natcap.invest import urban_nature_access
 from natcap.invest import utils
 
 import carbon_urban_pools  # Modified from natcap.invest.carbon w/ carbon pools
@@ -88,6 +89,7 @@ PIXELSIZE_X, PIXELSIZE_Y = _LULC_RASTER_INFO['pixel_size']
 
 CARBON = 'carbon'
 URBAN_COOLING = 'urban_cooling_model'
+URBAN_NATURE_ACCESS = 'urban_nature_access'
 INVEST_MODELS = {
     URBAN_COOLING: {
         "api": urban_cooling_model,
@@ -98,9 +100,14 @@ INVEST_MODELS = {
         "api": carbon_urban_pools,
         "build_args": invest_args.carbon,
         "derive_results": invest_results.carbon,
+    },
+    URBAN_NATURE_ACCESS: {
+        "api": urban_nature_access,
+        "build_args": invest_args.urban_nature_access,
+        "derive_results": invest_results.urban_nature_access
     }
 }
-LARGEST_SERVICESHED = 2230  # meters https://github.com/natcap/urban-online-workflow/issues/79
+LARGEST_SERVICESHED = 2280  # meters https://github.com/natcap/urban-online-workflow/issues/79
 
 # Quiet logging
 logging.getLogger(f'pygeoprocessing').setLevel(logging.WARNING)

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -34,6 +34,9 @@ export default function App() {
       area = await createStudyArea(sessionID, 'Untitled');
       setSavedStudyAreas([...savedStudyAreas, area]);
     }
+    // Clear scenarios from the previous study area to avoid child
+    // components rendering with them before receiving updated props
+    setScenarios([]);
     setStudyArea(area);
   };
 
@@ -120,6 +123,7 @@ export default function App() {
               serviceshedPath={serviceshedPath}
             />
             <EditMenu
+              key={studyArea.id}
               sessionID={sessionID}
               studyArea={studyArea}
               setHoveredParcel={setHoveredParcel}

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -24,7 +24,7 @@ export default function App() {
   const [patternSamplingMode, setPatternSamplingMode] = useState(false);
   const [patternSampleWKT, setPatternSampleWKT] = useState(null);
   const [selectedScenario, setSelectedScenario] = useState(null);
-  const [serviceshedPath, setServiceshedPath] = useState(null);
+  const [servicesheds, setServicesheds] = useState({});
 
   const switchStudyArea = async (id) => {
     let area;
@@ -102,7 +102,7 @@ export default function App() {
 
   useEffect(() => {
     refreshScenarios();
-    setServiceshedPath('');
+    setServicesheds({});
   }, [studyArea.id]);
 
   return (
@@ -120,7 +120,7 @@ export default function App() {
               setPatternSampleWKT={setPatternSampleWKT}
               scenarios={scenarios}
               selectedScenario={selectedScenario}
-              serviceshedPath={serviceshedPath}
+              servicesheds={servicesheds}
             />
             <EditMenu
               key={studyArea.id}
@@ -137,7 +137,7 @@ export default function App() {
               togglePatternSamplingMode={togglePatternSamplingMode}
               patternSampleWKT={patternSampleWKT}
               setSelectedScenario={setSelectedScenario}
-              setServiceshedPath={setServiceshedPath}
+              setServicesheds={setServicesheds}
             />
           </div>
         </div>

--- a/frontend/src/constants.js
+++ b/frontend/src/constants.js
@@ -1,0 +1,4 @@
+// These correspond to invest model args defined in backend-worker/invest_args.py
+export const COOLING_DISTANCE_STR = '450 meters';
+export const NATURE_ACCESS_DISTANCE_STR = '800 meters';
+export const NAT_REQ_PERCAP = 16.7;

--- a/frontend/src/edit/edit.jsx
+++ b/frontend/src/edit/edit.jsx
@@ -58,12 +58,14 @@ export default function EditMenu(props) {
       scenarios.map(scenario => getInvestResults(scenario.scenario_id))
     );
     const data = {};
+    let servicesheds = {};
     scenarios.forEach((scenario, idx) => {
       if (Object.values(modelResults[idx])[0] !== 'InVEST result not found') {
         data[scenario.name] = modelResults[idx]['results'];
-        setServicesheds(modelResults[idx]['servicesheds']);
+        servicesheds = { ...servicesheds, ...modelResults[idx]['servicesheds'] };
       }
     });
+    setServicesheds(servicesheds);
     setResults(data);
   };
 

--- a/frontend/src/edit/edit.jsx
+++ b/frontend/src/edit/edit.jsx
@@ -50,6 +50,7 @@ export default function EditMenu(props) {
   const [scenarioDescriptions, setScenarioDescriptions] = useState(null);
 
   const setInvestResults = async () => {
+    console.log(scenarios)
     // Do results exist for these scenarios? We check after the investRunner
     // determines that all jobs completed. We also check anytime the
     // list of scenarios are updated, such as when the study area changes

--- a/frontend/src/edit/edit.jsx
+++ b/frontend/src/edit/edit.jsx
@@ -42,7 +42,7 @@ export default function EditMenu(props) {
     switchStudyArea,
     savedStudyAreas,
     setSelectedScenario,
-    setServiceshedPath,
+    setServicesheds,
   } = props;
 
   const [activeTab, setActiveTab] = useState('scenarios');
@@ -61,9 +61,7 @@ export default function EditMenu(props) {
     scenarios.forEach((scenario, idx) => {
       if (Object.values(modelResults[idx])[0] !== 'InVEST result not found') {
         data[scenario.name] = modelResults[idx]['results'];
-        if (modelResults[idx]['serviceshed']) {
-          setServiceshedPath(modelResults[idx]['serviceshed']);
-        }
+        setServicesheds(modelResults[idx]['servicesheds']);
       }
     });
     setResults(data);

--- a/frontend/src/edit/edit.jsx
+++ b/frontend/src/edit/edit.jsx
@@ -82,7 +82,7 @@ export default function EditMenu(props) {
           nlcd: [],
           nlud: [],
         };
-        ['nlcd', 'nlud'].forEach((lulcType) => {
+        ['nlcd', 'nlud', 'tree'].forEach((lulcType) => {
           const sorted = Object.entries(stats[lulcType])
             .sort(([, a], [, b]) => b - a);
           const sortedClasses = sorted.map((x) => x[0]);

--- a/frontend/src/edit/edit.jsx
+++ b/frontend/src/edit/edit.jsx
@@ -50,7 +50,6 @@ export default function EditMenu(props) {
   const [scenarioDescriptions, setScenarioDescriptions] = useState(null);
 
   const setInvestResults = async () => {
-    console.log(scenarios)
     // Do results exist for these scenarios? We check after the investRunner
     // determines that all jobs completed. We also check anytime the
     // list of scenarios are updated, such as when the study area changes
@@ -81,6 +80,7 @@ export default function EditMenu(props) {
         descriptions[scenario.name] = {
           nlcd: [],
           nlud: [],
+          tree: [],
         };
         ['nlcd', 'nlud', 'tree'].forEach((lulcType) => {
           const sorted = Object.entries(stats[lulcType])
@@ -100,9 +100,9 @@ export default function EditMenu(props) {
           );
         });
       });
-      setScenarioDescriptions(descriptions);
       (async () => {
         await setInvestResults();
+        setScenarioDescriptions(descriptions);
       })();
     }
   }, [scenarios]);
@@ -201,8 +201,8 @@ export default function EditMenu(props) {
                 title="results"
                 panel={(
                   <Results
+                    // key={studyArea.id}
                     results={results}
-                    studyAreaName={studyArea.name}
                     scenarioDescriptions={scenarioDescriptions}
                     setSelectedScenario={setSelectedScenario}
                   />

--- a/frontend/src/edit/edit.jsx
+++ b/frontend/src/edit/edit.jsx
@@ -201,7 +201,6 @@ export default function EditMenu(props) {
                 title="results"
                 panel={(
                   <Results
-                    // key={studyArea.id}
                     results={results}
                     scenarioDescriptions={scenarioDescriptions}
                     setSelectedScenario={setSelectedScenario}

--- a/frontend/src/edit/investRunner.jsx
+++ b/frontend/src/edit/investRunner.jsx
@@ -45,7 +45,7 @@ export default function InvestRunner(props) {
 
   const handleClick = async () => {
     setProgressState('success');
-    setProgress(0.02); // start at > 0 to indicate things are happening
+    setProgress(0);
     const jobs = await Promise.all(
       scenarios.map((scenario) => runInvest(scenario.scenario_id))
     );

--- a/frontend/src/edit/investRunner.jsx
+++ b/frontend/src/edit/investRunner.jsx
@@ -25,16 +25,17 @@ export default function InvestRunner(props) {
 
   useInterval(async () => {
     const statuses = await Promise.all(jobIDs.map((id) => getJobStatus(id)));
-    const pendingJobs = [...jobIDs];
+    const pendingJobs = [];
     statuses.forEach((status, idx) => {
       if (['success', 'failed'].includes(status)) {
-        pendingJobs.splice(idx, 1);
-        setProgress((nJobs - pendingJobs.length) / nJobs);
         if (status === 'failed') {
           setProgressState('warning');
         }
+      } else {
+        pendingJobs.push(jobIDs[idx]);
       }
     });
+    setProgress((nJobs - pendingJobs.length) / nJobs);
     setJobIDs(pendingJobs);
     if (!pendingJobs.length) {
       setInvestResults();

--- a/frontend/src/edit/results.jsx
+++ b/frontend/src/edit/results.jsx
@@ -54,26 +54,28 @@ function LandcoverDescription(props) {
 
   return (
     <HTMLTable id="landcover-description">
-      <tr>
-        <th className="col-header">from mostly:</th>
-        <th className="col-header">to:</th>
-        <td />
-      </tr>
-      <tr>
-        <td>{scenarioDescriptions['baseline']['nlcd'].join('\n')}</td>
-        <td>{scenarioDescriptions[scenarioName]['nlcd'].join('\n')}</td>
-        <td className="row-header">(landcover)</td>
-      </tr>
-      <tr>
-        <td>{scenarioDescriptions['baseline']['nlud'].join('\n')}</td>
-        <td>{scenarioDescriptions[scenarioName]['nlud'].join('\n')}</td>
-        <td className="row-header">(landuse)</td>
-      </tr>
-      <tr>
-        <td>{scenarioDescriptions['baseline']['tree']}</td>
-        <td>{scenarioDescriptions[scenarioName]['tree']}</td>
-        <td className="row-header">(tree cover)</td>
-      </tr>
+      <tbody>
+        <tr>
+          <th className="col-header">from mostly:</th>
+          <th className="col-header">to:</th>
+          <td />
+        </tr>
+        <tr>
+          <td>{scenarioDescriptions['baseline']['nlcd'].join('\n')}</td>
+          <td>{scenarioDescriptions[scenarioName]['nlcd'].join('\n')}</td>
+          <td className="row-header">(landcover)</td>
+        </tr>
+        <tr>
+          <td>{scenarioDescriptions['baseline']['nlud'].join('\n')}</td>
+          <td>{scenarioDescriptions[scenarioName]['nlud'].join('\n')}</td>
+          <td className="row-header">(landuse)</td>
+        </tr>
+        <tr>
+          <td>{scenarioDescriptions['baseline']['tree']}</td>
+          <td>{scenarioDescriptions[scenarioName]['tree']}</td>
+          <td className="row-header">(tree cover)</td>
+        </tr>
+      </tbody>
     </HTMLTable>
   );
 }

--- a/frontend/src/edit/results.jsx
+++ b/frontend/src/edit/results.jsx
@@ -125,7 +125,7 @@ function ResultsDescription(props) {
         <span>
           Nature accessibility is expected to
           <b> {natureDirection} by {Math.abs(natureSupplyPercentChange).toFixed(METRICS.nature_supply_percapita.precision)}%. </b>
-          within 2 kilometers of the selected parcels.
+          within {NATURE_ACCESS_DISTANCE} of the selected parcels.
           In this study area the average person previously had access to {natureBalanceDemandMet.toFixed(METRICS.nature_supply_percapita.precision)}% of
           the natural area that would meet the typical need. Now they have access to {natureBalanceDemandMetScenario.toFixed(METRICS.nature_supply_percapita.precision)}%.
         </span>
@@ -140,6 +140,7 @@ export default function Results(props) {
     scenarioDescriptions,
     setSelectedScenario,
   } = props;
+  console.log(results)
 
   const [scenarioName, setScenarioName] = useState(null);
   const [deltaTable, setDeltaTable] = useState(null);

--- a/frontend/src/edit/results.jsx
+++ b/frontend/src/edit/results.jsx
@@ -39,31 +39,29 @@ function LandcoverDescription(props) {
     scenarioName,
   } = props;
 
-  const from = (scenarioDescriptions['baseline']['nlcd'].length)
-    ? `
-        ${scenarioDescriptions['baseline']['nlcd'].join(', ')}
-        ( ${scenarioDescriptions['baseline']['nlud'].join(', ')} )
-      `
-    : '';
-
-  const to = (scenarioDescriptions[scenarioName]['nlcd'].length)
-    ? `
-        ${scenarioDescriptions[scenarioName]['nlcd'].join(', ')}
-        ( ${scenarioDescriptions[scenarioName]['nlud'].join(', ')} )
-      `
-    : '';
-
   return (
-    <>
-      <p className="hanging-indent">
-        <b>from: </b>
-        mostly <em>{from}</em>
-      </p>
-      <p className="hanging-indent">
-        <b>to: </b>
-        mostly <em>{to}</em>
-      </p>
-    </>
+    <HTMLTable id="landcover-description">
+      <tr>
+        <th className="col-header">from mostly:</th>
+        <th className="col-header">to:</th>
+        <td />
+      </tr>
+      <tr>
+        <td>{scenarioDescriptions['baseline']['nlcd'].join('\n')}</td>
+        <td>{scenarioDescriptions[scenarioName]['nlcd'].join('\n')}</td>
+        <td className="row-header">(landcover)</td>
+      </tr>
+      <tr>
+        <td>{scenarioDescriptions['baseline']['nlud'].join('\n')}</td>
+        <td>{scenarioDescriptions[scenarioName]['nlud'].join('\n')}</td>
+        <td className="row-header">(landuse)</td>
+      </tr>
+      <tr>
+        <td>{scenarioDescriptions['baseline']['tree']}</td>
+        <td>{scenarioDescriptions[scenarioName]['tree']}</td>
+        <td className="row-header">(tree cover)</td>
+      </tr>
+    </HTMLTable>
   );
 }
 
@@ -183,7 +181,9 @@ export default function Results(props) {
             {scenarioNames
               .map((name) => <option key={name} value={name}>{name}</option>)}
           </HTMLSelect>
-          <span style={{ 'paddingLeft': '2rem' }}>landcover (landuse) changed,</span>
+          <span style={{ 'paddingLeft': '2rem' }}>
+            the landscape changed:
+          </span>
         </h4>
         {
           (scenarioName && deltaTable)
@@ -211,7 +211,7 @@ export default function Results(props) {
               <p>
                 Each scenario's impact relative to baseline conditions:
               </p>
-              <HTMLTable>
+              <HTMLTable id="results-matrix">
                 <tbody>
                   <tr key="header">
                     <th key="blank" />

--- a/frontend/src/edit/results.jsx
+++ b/frontend/src/edit/results.jsx
@@ -31,6 +31,7 @@ const METRICS = {
   },
 };
 const COOLING_DISTANCE = '450 meters';
+const NATURE_ACCESS_DISTANCE = '2 km';
 const NAT_REQ_PERCAP = 16.7; // this is an UNA model paramamter
 
 function LandcoverDescription(props) {
@@ -98,14 +99,14 @@ function ResultsDescription(props) {
           <span>
             The average daytime high <b>temperature</b> during August is expected to
             <b> {tempDirection} by {Math.abs(temperature).toFixed(METRICS.avg_tmp_v.precision)} &deg;F </b>
-            for areas within the dashed white line.
+            for areas within {COOLING_DISTANCE} of the selected parcels.
           </span>
         </p>
         <p>
           <span>
             This represents an <b>{tempDirection} </b>
             in total cooling costs by
-            <b> ${Math.abs(coolingCost).toFixed(METRICS.cdd_cost.precision)}</b>
+            <b> ${Math.abs(coolingCost).toFixed(METRICS.cdd_cost.precision)}</b>.
           </span>
         </p>
       </li>
@@ -115,7 +116,7 @@ function ResultsDescription(props) {
         <span>
           Carbon storage is expected to
           <b> {carbonDirection} by {Math.abs(carbon).toFixed(METRICS.tot_c_cur.precision)} </b>
-          metric tons
+          metric tons.
         </span>
       </li>
       <br />
@@ -124,6 +125,7 @@ function ResultsDescription(props) {
         <span>
           Nature accessibility is expected to
           <b> {natureDirection} by {Math.abs(natureSupplyPercentChange).toFixed(METRICS.nature_supply_percapita.precision)}%. </b>
+          within 2 kilometers of the selected parcels.
           In this study area the average person previously had access to {natureBalanceDemandMet.toFixed(METRICS.nature_supply_percapita.precision)}% of
           the natural area that would meet the typical need. Now they have access to {natureBalanceDemandMetScenario.toFixed(METRICS.nature_supply_percapita.precision)}%.
         </span>

--- a/frontend/src/edit/results.jsx
+++ b/frontend/src/edit/results.jsx
@@ -7,6 +7,11 @@ import {
 } from '@blueprintjs/core';
 
 import ResultsDemographics from './resultsDemographics';
+import {
+  COOLING_DISTANCE_STR,
+  NATURE_ACCESS_DISTANCE_STR,
+  NAT_REQ_PERCAP,
+} from '../constants';
 
 const METRICS = {
   avg_tmp_v: {
@@ -30,9 +35,6 @@ const METRICS = {
     precision: 1,
   },
 };
-const COOLING_DISTANCE = '450 meters';
-const NATURE_ACCESS_DISTANCE = '2 km';
-const NAT_REQ_PERCAP = 16.7; // this is an UNA model paramamter
 
 function LandcoverDescription(props) {
   const {
@@ -99,7 +101,7 @@ function ResultsDescription(props) {
           <span>
             The average daytime high <b>temperature</b> during August is expected to
             <b> {tempDirection} by {Math.abs(temperature).toFixed(METRICS.avg_tmp_v.precision)} &deg;F </b>
-            for areas within {COOLING_DISTANCE} of the selected parcels.
+            for areas within {COOLING_DISTANCE_STR} of the selected parcels.
           </span>
         </p>
         <p>
@@ -125,7 +127,7 @@ function ResultsDescription(props) {
         <span>
           Nature accessibility is expected to
           <b> {natureDirection} by {Math.abs(natureSupplyPercentChange).toFixed(METRICS.nature_supply_percapita.precision)}%. </b>
-          within {NATURE_ACCESS_DISTANCE} of the selected parcels.
+          within {NATURE_ACCESS_DISTANCE_STR} of the selected parcels.
           In this study area the average person previously had access to {natureBalanceDemandMet.toFixed(METRICS.nature_supply_percapita.precision)}% of
           the natural area that would meet the typical need. Now they have access to {natureBalanceDemandMetScenario.toFixed(METRICS.nature_supply_percapita.precision)}%.
         </span>

--- a/frontend/src/edit/results.jsx
+++ b/frontend/src/edit/results.jsx
@@ -39,6 +39,7 @@ const METRICS = {
     label: 'change in supply of nature per person',
     units: {
       'square meters': (x) => x,
+      'hectares': (x) => x * 1e-4,
       'square feet': (x) => x * 10.764,
       'acres': (x) => x / 4016.856,
     },

--- a/frontend/src/edit/results.jsx
+++ b/frontend/src/edit/results.jsx
@@ -16,22 +16,32 @@ import {
 const METRICS = {
   avg_tmp_v: {
     label: 'change in temperature',
-    units: `${'\u00b0'}F`,
+    units: {
+      [`${'\u00b0'}F`]: (x) => x,
+    },
     precision: 2,
   },
   cdd_cost: {
     label: 'change in cooling cost',
-    units: 'USD',
+    units: {
+      USD: (x) => x,
+    },
     precision: 0,
   },
   tot_c_cur: {
     label: 'change in carbon stored',
-    units: 'metric tons',
+    units: {
+      'metric tons': (x) => x,
+    },
     precision: 0,
   },
   nature_supply_percapita: {
-    label: 'change in supply of nature',
-    units: 'square meters per person',
+    label: 'change in supply of nature per person',
+    units: {
+      'square meters': (x) => x,
+      'square feet': (x) => x * 10.764,
+      'acres': (x) => x / 4016.856,
+    },
     precision: 1,
   },
 };
@@ -75,15 +85,15 @@ function ResultsDescription(props) {
     scenarioName,
   } = props;
 
-  const temperature = deltaTable[scenarioName]['avg_tmp_v'].value;
-  const coolingCost = deltaTable[scenarioName]['cdd_cost'].value;
+  const temperature = deltaTable[scenarioName]['avg_tmp_v'];
+  const coolingCost = deltaTable[scenarioName]['cdd_cost'];
   const tempDirection = (temperature >= 0) ? 'increase' : 'decrease';
 
-  const carbon = deltaTable[scenarioName]['tot_c_cur'].value;
+  const carbon = deltaTable[scenarioName]['tot_c_cur'];
   const carbonDirection = (carbon >= 0) ? 'increase' : 'decrease';
 
   const natureSupplyBase = results['baseline']['nature_supply_percapita'];
-  const natureSupplyDelta = deltaTable[scenarioName]['nature_supply_percapita'].value;
+  const natureSupplyDelta = deltaTable[scenarioName]['nature_supply_percapita'];
   const natureSupplyPercentChange = (natureSupplyDelta / natureSupplyBase) * 100;
   const natureDirection = (natureSupplyDelta >= 0) ? 'increase' : 'decrease';
   const natureBalance = results['baseline']['ntr_bal_avg'];
@@ -136,13 +146,84 @@ function ResultsDescription(props) {
   );
 }
 
+function ResultsTable(props) {
+  const {
+    deltaTable,
+    scenarioNames,
+  } = props;
+
+  const [metricLookup, setMetricLookup] = useState(null);
+
+  useEffect(() => {
+    const data = {};
+    Object.keys(METRICS).forEach((metric) => {
+      data[metric] = {
+        unit: Object.keys(METRICS[metric].units)[0],
+        func: Object.values(METRICS[metric].units)[0],
+      };
+    });
+    setMetricLookup(data);
+  }, []);
+
+  const setUnit = (unit, metric) => {
+    const lookup = { ...metricLookup };
+    lookup[metric].unit = unit;
+    lookup[metric].func = METRICS[metric].units[unit];
+    setMetricLookup(lookup);
+  };
+
+  if (metricLookup) {
+    return (
+      <HTMLTable>
+        <tbody>
+          <tr key="header">
+            <th key="blank" />
+            {Object.entries(METRICS).map(([metric, obj]) => (
+              <th key={obj.label}>
+                {obj.label}
+                <br />
+                {(Object.keys(obj.units).length > 1)
+                  ? (
+                    <HTMLSelect
+                      value={metricLookup[metric].unit}
+                      onChange={(e) => setUnit(e.target.value, metric)}
+                    >
+                      {Object.keys(obj.units).map(
+                        (unit) => <option key={unit} value={unit}>{unit}</option>
+                      )}
+                    </HTMLSelect>
+                  )
+                  : <span className="units">({Object.keys(obj.units)[0]})</span>}
+              </th>
+            ))}
+          </tr>
+          {scenarioNames.map((name) => (
+            <tr key={name}>
+              <th>{name}</th>
+              {Object.keys(metricLookup).map((metric) => {
+                const value = metricLookup[metric]['func'](
+                  deltaTable[name][metric],
+                ).toFixed(METRICS[metric].precision);
+                return (
+                  <td className="table-value" key={metric}>
+                    {(value > 0) ? `+${value}` : value}
+                  </td>
+                );
+              })}
+            </tr>
+          ))}
+        </tbody>
+      </HTMLTable>
+    );
+  }
+}
+
 export default function Results(props) {
   const {
     results,
     scenarioDescriptions,
     setSelectedScenario,
   } = props;
-  console.log(results)
 
   const [scenarioName, setScenarioName] = useState(null);
   const [deltaTable, setDeltaTable] = useState(null);
@@ -158,13 +239,8 @@ export default function Results(props) {
     const names = Object.keys(results).filter((key) => key !== 'baseline');
     names.forEach((name) => {
       data[name] = {};
-      Object.entries(METRICS).forEach(([metric, obj]) => {
-        data[name][metric] = {
-          value: results[name][metric] - results['baseline'][metric],
-          units: obj.units,
-          precision: obj.precision,
-          label: obj.label,
-        };
+      Object.keys(METRICS).forEach((metric) => {
+        data[name][metric] = results[name][metric] - results['baseline'][metric];
       });
     });
     setDeltaTable(data);
@@ -215,27 +291,11 @@ export default function Results(props) {
               <p>
                 Each scenario's impact relative to baseline conditions:
               </p>
-              <HTMLTable id="results-matrix">
-                <tbody>
-                  <tr key="header">
-                    <th key="blank" />
-                    {Object.values(METRICS).map((obj) => (
-                      <th key={obj.label}>{obj.label}</th>
-                    ))}
-                  </tr>
-                  {scenarioNames.map((name) => (
-                    <tr key={name}>
-                      <th>{name}</th>
-                      {Object.values(deltaTable[name]).map((obj) => (
-                        <td className="table-value" key={obj.units}>
-                          {(obj.value > 0) ? `+${obj.value.toFixed(obj.precision)}` : obj.value.toFixed(obj.precision)}
-                          <span className="units">{obj.units}</span>
-                        </td>
-                      ))}
-                    </tr>
-                  ))}
-                </tbody>
-              </HTMLTable>
+              <ResultsTable
+                id="results-matrix"
+                deltaTable={deltaTable}
+                scenarioNames={scenarioNames}
+              />
             </div>
           ) : <div />
       }

--- a/frontend/src/edit/results.jsx
+++ b/frontend/src/edit/results.jsx
@@ -94,14 +94,26 @@ function ResultsDescription(props) {
 
   const natureSupplyBase = results['baseline']['nature_supply_percapita'];
   const natureSupplyDelta = deltaTable[scenarioName]['nature_supply_percapita'];
-  const natureSupplyPercentChange = (natureSupplyDelta / natureSupplyBase) * 100;
+  let natureSupplyChange;
+  if (natureSupplyBase === 0) {
+    natureSupplyChange = `${Math.abs(natureSupplyDelta).toFixed(
+      METRICS.nature_supply_percapita.precision
+    )} square meters`;
+  } else {
+    natureSupplyChange = `${Math.abs((
+      natureSupplyDelta / natureSupplyBase) * 100).toFixed(
+      METRICS.nature_supply_percapita.precision
+    )}%`;
+  }
   const natureDirection = (natureSupplyDelta >= 0) ? 'increase' : 'decrease';
   const natureBalance = results['baseline']['ntr_bal_avg'];
   const natureBalanceScen = results[scenarioName]['ntr_bal_avg'];
   const natureBalanceDemandMet = (
-    (natureBalance + NAT_REQ_PERCAP) / NAT_REQ_PERCAP) * 100;
+    ((natureBalance + NAT_REQ_PERCAP) / NAT_REQ_PERCAP) * 100
+  ).toFixed(METRICS.nature_supply_percapita.precision) + 0;
   const natureBalanceDemandMetScenario = (
-    (natureBalanceScen + NAT_REQ_PERCAP) / NAT_REQ_PERCAP) * 100;
+    ((natureBalanceScen + NAT_REQ_PERCAP) / NAT_REQ_PERCAP) * 100
+  ).toFixed(METRICS.nature_supply_percapita.precision);
 
   return (
     <ul>
@@ -136,10 +148,10 @@ function ResultsDescription(props) {
         <Icon icon="walk" />
         <span>
           Nature accessibility is expected to
-          <b> {natureDirection} by {Math.abs(natureSupplyPercentChange).toFixed(METRICS.nature_supply_percapita.precision)}%. </b>
+          <b> {natureDirection} by {natureSupplyChange}. </b>
           within {NATURE_ACCESS_DISTANCE_STR} of the selected parcels.
-          In this study area the average person previously had access to {natureBalanceDemandMet.toFixed(METRICS.nature_supply_percapita.precision)}% of
-          the natural area that would meet the typical need. Now they have access to {natureBalanceDemandMetScenario.toFixed(METRICS.nature_supply_percapita.precision)}%.
+          In this area the average person previously had access to {natureBalanceDemandMet}% of
+          the natural area that would meet the typical need. Now they have access to {natureBalanceDemandMetScenario}%.
         </span>
       </li>
     </ul>

--- a/frontend/src/edit/results.jsx
+++ b/frontend/src/edit/results.jsx
@@ -135,7 +135,6 @@ function ResultsDescription(props) {
 export default function Results(props) {
   const {
     results,
-    studyAreaName,
     scenarioDescriptions,
     setSelectedScenario,
   } = props;

--- a/frontend/src/edit/resultsDemographics.jsx
+++ b/frontend/src/edit/resultsDemographics.jsx
@@ -1,0 +1,76 @@
+import React from 'react';
+
+import {
+  HTMLTable,
+  Icon,
+} from '@blueprintjs/core';
+
+const HOUSE_SNAP = 'Household received Food Stamps or SNAP in the past 12 months';
+const HOUSE_NO_SNAP = 'Household did not receive Food Stamps or SNAP in the past 12 months';
+const INCOME_BELOW = 'Income in the past 12 months below poverty level';
+const INCOME_ABOVE = 'Income in the past 12 months at or above poverty level';
+
+export default function ResultsDemographics(props) {
+  const { census } = props;
+  let populationTable;
+  let povertyPar;
+  if (census && census.race) {
+    const populations = Object.entries(census.race)
+      .sort(([, a], [, b]) => b - a);
+
+    populationTable = (
+      <div>
+        <h3>Population by race</h3>
+        <HTMLTable className="bp4-html-table-condensed">
+          <tbody>
+            {populations.map(([group, count]) => (
+              <tr key={group}>
+                <td key="group">{group}</td>
+                <td key="count">{count}</td>
+              </tr>
+            ))}
+          </tbody>
+        </HTMLTable>
+      </div>
+    );
+  }
+
+  if (census && census.poverty) {
+    povertyPar = (
+      <ul>
+        <li>
+          <b>{census.poverty[HOUSE_SNAP]} households received</b> Food Stamps or SNAP.
+        </li>
+        <p className="hanging-indent">
+          Of those households, <b>{census.poverty[`${HOUSE_SNAP} | ${INCOME_BELOW}`]} were below poverty level </b>
+          and <b>{census.poverty[`${HOUSE_SNAP} | ${INCOME_ABOVE}`]} were above</b>.
+        </p>
+        <li>
+          <b>{census.poverty[HOUSE_NO_SNAP]} households did not receive</b> Food Stamps or SNAP.
+        </li>
+        <p className="hanging-indent">
+          Of those households, <b>{census.poverty[`${HOUSE_NO_SNAP} | ${INCOME_BELOW}`]} were below poverty level </b>
+          and <b>{census.poverty[`${HOUSE_NO_SNAP} | ${INCOME_ABOVE}`]} were above</b>.
+        </p>
+      </ul>
+    );
+  }
+
+  return (
+    <div>
+      <h2 id="demographics-header">
+        <Icon icon="people" size="30"/>
+        Demographics of the impacted area:
+      </h2>
+      <div id="demographics-body">
+        {populationTable}
+        <div id="acs-container">
+          {povertyPar}
+        </div>
+      </div>
+      <div id="demographics-footer">
+        <p>Data from the American Community Survey, 2020</p>
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -326,21 +326,42 @@ html, body, #root, .App {
   align-items: center;
 }
 
-#results th, td {
-  vertical-align: bottom;
-  padding-right: 3rem;
-}
-
-#results table {
+#landcover-description {
+  width: 100%;
   border-collapse: collapse;
 }
 
-#results tr {
+#landcover-description tr {
+  border-bottom: 1px solid lightgray;
+}
+
+#landcover-description tr:last-child {
+  border-bottom: none;
+}
+
+#landcover-description th, td {
+  vertical-align: bottom;
+  white-space: pre-line;
+}
+
+#landcover-description .row-header {
+  font-style: italic;
+}
+
+#landcover-description .col-header {
+  padding-top: 0.2rem;
+  padding-bottom: 0.2rem;
+}
+
+#results-matrix {
+  border-collapse: collapse;
+}
+
+#results-matrix tr {
   border-bottom: 1px solid lightgray;
 }
 
 .units {
-/*  font-size: 0.8em;*/
   color: gray;
   padding-left: 0.5em;
 }

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -363,7 +363,6 @@ html, body, #root, .App {
 
 .units {
   color: gray;
-/*  padding-left: 0.5em;*/
 }
 
 #demographics-header {

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -363,7 +363,7 @@ html, body, #root, .App {
 
 .units {
   color: gray;
-  padding-left: 0.5em;
+/*  padding-left: 0.5em;*/
 }
 
 #demographics-header {

--- a/frontend/src/map/map.jsx
+++ b/frontend/src/map/map.jsx
@@ -52,6 +52,10 @@ import {
 } from './styles';
 
 import { publicUrl } from '../utils';
+import {
+  COOLING_DISTANCE_STR,
+  NATURE_ACCESS_DISTANCE_STR,
+} from '../constants';
 
 const GCS_BUCKET = 'https://storage.googleapis.com/natcap-urban-online-datasets-public';
 const BASE_LULC_URL = `${GCS_BUCKET}/lulc_overlay_3857.tif`
@@ -143,14 +147,12 @@ scenarioLayerGroup.set('title', SCENARIO_LAYER_GROUP_NAME);
 scenarioLayerGroup.setZIndex(1);
 
 // Urban Cooling & Urban Nature models each have a serviceshed
-const UCMLabel = '450 meters';
 const serviceshedLayerUCM = new VectorLayer({
-  style: (feature) => styleServiceshed(feature, UCMLabel),
+  style: (feature) => styleServiceshed(feature, COOLING_DISTANCE_STR),
 });
 serviceshedLayerUCM.setZIndex(3);
-const UNALabel = '2 km';
 const serviceshedLayerUNA = new VectorLayer({
-  style: (feature) => styleServiceshed(feature, UNALabel),
+  style: (feature) => styleServiceshed(feature, NATURE_ACCESS_DISTANCE_STR),
 });
 serviceshedLayerUNA.setZIndex(3);
 

--- a/frontend/src/map/map.jsx
+++ b/frontend/src/map/map.jsx
@@ -466,6 +466,7 @@ export default function MapComponent(props) {
     map.removeLayer(serviceshedLayerUCM);
     map.removeLayer(serviceshedLayerUNA);
     const sources = {};
+    console.log(servicesheds)
     if (Object.keys(servicesheds).length) {
       Object.entries(servicesheds).forEach(([model, path]) => {
         const source = new VectorSource({

--- a/frontend/src/map/styles.js
+++ b/frontend/src/map/styles.js
@@ -1,4 +1,4 @@
-import { Fill, Stroke, Style } from 'ol/style';
+import { Fill, Stroke, Style, Text } from 'ol/style';
 
 const highlightedStrokeColor = 'rgba(3, 186, 252, 0.8)'
 
@@ -46,13 +46,25 @@ export const patternSamplerBoxStyle = new Style({
   }),
 });
 
-export const serviceshedStyle = new Style({
-  stroke: new Stroke({
-    color: 'rgba(255, 255, 255, 0.8)',
-    width: 3,
-    lineDash: [5, 5],
-  })
-});
+export function styleServiceshed(feature, label) {
+  const style = new Style({
+    stroke: new Stroke({
+      color: 'rgba(255, 255, 255, 0.8)',
+      width: 3,
+      lineDash: [5, 5],
+    }),
+    text: new Text({
+      text: label,
+      font: 'bold 20px "Open Sans", "Arial Unicode MS", "sans-serif"',
+      placement: 'line',
+      fill: new Fill({ color: 'white' }),
+      textBaseline: 'bottom',
+      maxAngle: 1,
+      textAlign: 'center'
+    }),
+  });
+  return style;
+}
 
 // dynamic style function for parcels
 export function styleParcel(zoom) {

--- a/frontend/src/map/styles.js
+++ b/frontend/src/map/styles.js
@@ -55,7 +55,7 @@ export function styleServiceshed(feature, label) {
     }),
     text: new Text({
       text: label,
-      font: 'bold 20px "Open Sans", "Arial Unicode MS", "sans-serif"',
+      font: 'bold 18px "Open Sans", "Arial Unicode MS", "sans-serif"',
       placement: 'line',
       fill: new Fill({ color: 'white' }),
       textBaseline: 'bottom',

--- a/frontend/tests/edit.test.jsx
+++ b/frontend/tests/edit.test.jsx
@@ -22,6 +22,7 @@ vi.mock('../src/requests', () => {
 function renderEdit(studyArea, scenarios, patternSamplingMode = false) {
   const screen = render(
     <Edit
+      key="A"
       sessionID="A"
       studyArea={studyArea}
       setHoveredParcel={() => {}}
@@ -35,7 +36,7 @@ function renderEdit(studyArea, scenarios, patternSamplingMode = false) {
       togglePatternSamplingMode={() => {}}
       patternSampleWKT={null}
       setSelectedScenario={() => {}}
-      setServiceshedPath={() => {}}
+      setServicesheds={() => {}}
     />
   );
   return screen;

--- a/frontend/tests/fixtures/investResult.json
+++ b/frontend/tests/fixtures/investResult.json
@@ -1,6 +1,7 @@
 {
     "results": {
         "avg_tmp_v": 44.73067062207524,
+        "cdd_cost": 1000,
         "census": {
             "race": {
                 "White (Not Hispanic or Latino)": 857,
@@ -21,7 +22,9 @@
                 "Household did not receive Food Stamps or SNAP in the past 12 months | Income in the past 12 months at or above poverty level": 2128
             }
         },
-        "tot_c_cur": 513148.3125
+        "tot_c_cur": 513148.3125,
+        "nature_supply_percapita": 1000,
+        "nat_bal_avg": 0.0
     },
     "serviceshed": "/opt/appdata/model_outputs/urban_cooling_model-14/aoi.geojson"
 }

--- a/server/sql_app/main.py
+++ b/server/sql_app/main.py
@@ -46,14 +46,11 @@ LOW_PRIORITY = 3
 MEDIUM_PRIORITY = 2
 HIGH_PRIORITY = 1
 
-# InVEST model list
+# The list of models that run
 INVEST_MODELS = [
-    # "pollination",
-    # "stormwater",
     "urban_cooling_model",
-    "carbon"
-    # "urban_flood_risk_mitigation",
-    # "urban_nature_access"
+    "carbon",
+    "urban_nature_access"
 ]
 
 JOB_TYPES = {

--- a/server/sql_app/main.py
+++ b/server/sql_app/main.py
@@ -780,7 +780,7 @@ def get_invest_results(scenario_id: int, db: Session = Depends(get_db)):
         raise HTTPException(
             status_code=404, detail="InVEST result not found")
     invest_results = {}
-    serviceshed = ''  # For now, only one model has a serviceshed
+    servicesheds = {}
     for row in invest_db_list:
         invest_results_path = row.result
         LOGGER.debug(invest_results_path)
@@ -788,10 +788,10 @@ def get_invest_results(scenario_id: int, db: Session = Depends(get_db)):
             with open(invest_results_path, 'r') as jfp:
                 invest_results.update(json.loads(jfp.read()))
         if row.serviceshed:
-            serviceshed = row.serviceshed
+            servicesheds[row.model_name] = row.serviceshed
     return {
         'results': invest_results,
-        'serviceshed': serviceshed
+        'servicesheds': servicesheds
     }
 
 


### PR DESCRIPTION
This PR runs the Nature Access model and displays it's results.

Two servicesheds (UNA and Urban Cooling) now appear on the map.

An unrelated bug in the invest job progress-tracking was fixed here as well.