### PR TITLE
Bugfix for carbon table

### DIFF
--- a/.github/workflows/frontend-test.yml
+++ b/.github/workflows/frontend-test.yml
@@ -13,16 +13,16 @@ jobs:
 
     steps:
       - name: Check out repo
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Set up node
-        uses: actions/setup-node@v2
+        uses: actions/setup-node@v4
         with:
           node-version: 18
 
       - name: Restore node_modules cache
         id: nodemodules-cache
-        uses: actions/cache@v2
+        uses: actions/cache@v4
         with:
           path: frontend/node_modules
           key: ${{ runner.os }}-${{ hashFiles('frontend/yarn.lock') }}

--- a/appdata/invest-data/biophysical_tables/carbon__nlcd_nlud_tree.csv
+++ b/appdata/invest-data/biophysical_tables/carbon__nlcd_nlud_tree.csv
@@ -1,2109 +1,1985 @@
-lucode,code,nlcd,LULC_name,notes,nlud_simple,nlud_simple_class,nlud_simple_subclass,fertilizer,pesticide,irrigation,planting_diversity,mowing,public_access,green_space,building_type,tree,tree_canopy_percentage,tree_canopy_cover,tree_canopy_colors,c_above,c_below,c_soil,c_dead,c_embedded_storage,c_embedded_emissions,c_annual_emissions
-0,1000,0,Background,,1,Waterbody,Natural,-1,-1,-1,-1,-1,-1,-1,-1,0,0,none,#ffffff,0,0,0,0,0,0,0
-1,1001,0,Background,,1,Waterbody,Natural,-1,-1,-1,-1,-1,-1,-1,-1,1,0.15,low,#e5f5e0,14.16699743,0,15.56798855,1.6,0,0,0
-2,1002,0,Background,,1,Waterbody,Natural,-1,-1,-1,-1,-1,-1,-1,-1,2,0.4,medium,#a1d99b,37.7786598,0,41.51463613,4.266666667,0,0,0
-3,1003,0,Background,,1,Waterbody,Natural,-1,-1,-1,-1,-1,-1,-1,-1,3,0.66,high,#31a354,62.33478868,0,68.49914961,7.04,0,0,0
-4,1110,11,Open Water,,1,Waterbody,Natural,-1,-1,-1,-1,-1,-1,-1,-1,0,0,none,#ffffff,0,0,0,0,0,0,0
-5,1111,11,Open Water,,1,Waterbody,Natural,-1,-1,-1,-1,-1,-1,-1,-1,1,0.15,low,#e5f5e0,14.16699743,0,15.56798855,1.6,0,0,0
-6,1112,11,Open Water,,1,Waterbody,Natural,-1,-1,-1,-1,-1,-1,-1,-1,2,0.4,medium,#a1d99b,37.7786598,0,41.51463613,4.266666667,0,0,0
-7,1113,11,Open Water,,1,Waterbody,Natural,-1,-1,-1,-1,-1,-1,-1,-1,3,0.66,high,#31a354,62.33478868,0,68.49914961,7.04,0,0,0
-8,1120,12,Perennial Ice/Snow,,1,Waterbody,Natural,-1,-1,-1,-1,-1,-1,-1,-1,0,0,none,#ffffff,0,0,0,0,0,0,0
-9,1121,12,Perennial Ice/Snow,,1,Waterbody,Natural,-1,-1,-1,-1,-1,-1,-1,-1,1,0.15,low,#e5f5e0,14.16699743,0,15.56798855,1.6,0,0,0
-10,1122,12,Perennial Ice/Snow,,1,Waterbody,Natural,-1,-1,-1,-1,-1,-1,-1,-1,2,0.4,medium,#a1d99b,37.7786598,0,41.51463613,4.266666667,0,0,0
-11,1123,12,Perennial Ice/Snow,,1,Waterbody,Natural,-1,-1,-1,-1,-1,-1,-1,-1,3,0.66,high,#31a354,62.33478868,0,68.49914961,7.04,0,0,0
-12,1210,21,"Developed, Open Space","20% trees, 60% grass, and 10% buildings and 10% bare soil",1,Waterbody,Natural,-1,-1,-1,-1,-1,-1,-1,-1,0,0,none,#ffffff,25.49986095,4.08,79.01411479,1.76,51.81402439,212.31,37.03522039
-13,1211,21,"Developed, Open Space","20% trees, 60% grass, and 10% buildings and 10% bare soil",1,Waterbody,Natural,-1,-1,-1,-1,-1,-1,-1,-1,1,0.15,low,#e5f5e0,35.84187923,3.468,82.72998612,3.096,51.81402439,212.31,37.03522039
-14,1212,21,"Developed, Open Space","20% trees, 60% grass, and 10% buildings and 10% bare soil",1,Waterbody,Natural,-1,-1,-1,-1,-1,-1,-1,-1,2,0.4,medium,#a1d99b,53.07857637,2.448,88.923105,5.322666667,51.81402439,212.31,37.03522039
-15,1213,21,"Developed, Open Space","20% trees, 60% grass, and 10% buildings and 10% bare soil",1,Waterbody,Natural,-1,-1,-1,-1,-1,-1,-1,-1,3,0.66,high,#31a354,71.0047414,1.3872,95.36394864,7.6384,51.81402439,212.31,37.03522039
-16,1220,22,"Developed, Low Intensity","20% trees, 40% grass, and 40% buildings",1,Waterbody,Natural,-1,-1,-1,-1,-1,-1,-1,-1,0,0,none,#ffffff,20.90844667,3.52,72.06732319,0.61,207.2560976,849.24,147.1338816
-17,1221,22,"Developed, Low Intensity","20% trees, 40% grass, and 40% buildings",1,Waterbody,Natural,-1,-1,-1,-1,-1,-1,-1,-1,1,0.15,low,#e5f5e0,31.9391771,2.992,76.82521326,2.1185,207.2560976,849.24,147.1338816
-18,1222,22,"Developed, Low Intensity","20% trees, 40% grass, and 40% buildings",1,Waterbody,Natural,-1,-1,-1,-1,-1,-1,-1,-1,2,0.4,medium,#a1d99b,50.32372781,2.112,84.75503004,4.632666667,207.2560976,849.24,147.1338816
-19,1223,22,"Developed, Low Intensity","20% trees, 40% grass, and 40% buildings",1,Waterbody,Natural,-1,-1,-1,-1,-1,-1,-1,-1,3,0.66,high,#31a354,69.44366054,1.1968,93.0020395,7.2474,207.2560976,849.24,147.1338816
-20,1230,23,"Developed, Medium Intensity","15% trees, 35% grass, and 50% buildings",1,Waterbody,Natural,-1,-1,-1,-1,-1,-1,-1,-1,0,0,none,#ffffff,17.69813636,3.08,61.93838294,0.36,234.070122,954.85,720.4716833
-21,1231,23,"Developed, Medium Intensity","15% trees, 35% grass, and 50% buildings",1,Waterbody,Natural,-1,-1,-1,-1,-1,-1,-1,-1,1,0.15,low,#e5f5e0,29.21041333,2.618,68.21561405,1.906,234.070122,954.85,720.4716833
-22,1232,23,"Developed, Medium Intensity","15% trees, 35% grass, and 50% buildings",1,Waterbody,Natural,-1,-1,-1,-1,-1,-1,-1,-1,2,0.4,medium,#a1d99b,48.39754162,1.848,78.67766589,4.482666667,234.070122,954.85,720.4716833
-23,1233,23,"Developed, Medium Intensity","15% trees, 35% grass, and 50% buildings",1,Waterbody,Natural,-1,-1,-1,-1,-1,-1,-1,-1,3,0.66,high,#31a354,68.35215504,1.0472,89.55819981,7.1624,234.070122,954.85,720.4716833
-24,1240,24,"Developed, High Intensity","10% trees, 20% grass, and 70% buildings",1,Waterbody,Natural,-1,-1,-1,-1,-1,-1,-1,-1,0,0,none,#ffffff,10.98142029,1.76,44.78642515,0.245,267.9065041,3418.485,1805.616283
-25,1241,24,"Developed, High Intensity","10% trees, 20% grass, and 70% buildings",1,Waterbody,Natural,-1,-1,-1,-1,-1,-1,-1,-1,1,0.15,low,#e5f5e0,23.50120467,1.496,53.63644993,1.80825,267.9065041,3418.485,1805.616283
-26,1242,24,"Developed, High Intensity","10% trees, 20% grass, and 70% buildings",1,Waterbody,Natural,-1,-1,-1,-1,-1,-1,-1,-1,2,0.4,medium,#a1d99b,44.36751198,1.056,68.38649122,4.413666667,267.9065041,3418.485,1805.616283
-27,1243,24,"Developed, High Intensity","10% trees, 20% grass, and 70% buildings",1,Waterbody,Natural,-1,-1,-1,-1,-1,-1,-1,-1,3,0.66,high,#31a354,66.06847158,0.5984,83.72653416,7.1233,267.9065041,3418.485,1805.616283
-28,1310,31,Barren Land,,1,Waterbody,Natural,-1,-1,-1,-1,-1,-1,-1,-1,0,0,none,#ffffff,6.8,0,25.5,0,0,0,0
-29,1311,31,Barren Land,,1,Waterbody,Natural,-1,-1,-1,-1,-1,-1,-1,-1,1,0.15,low,#e5f5e0,19.94699743,0,37.24298855,1.6,0,0,0
-30,1312,31,Barren Land,,1,Waterbody,Natural,-1,-1,-1,-1,-1,-1,-1,-1,2,0.4,medium,#a1d99b,41.8586598,0,56.81463613,4.266666667,0,0,0
-31,1313,31,Barren Land,,1,Waterbody,Natural,-1,-1,-1,-1,-1,-1,-1,-1,3,0.66,high,#31a354,64.64678868,0,77.16914961,7.04,0,0,0
-32,1410,41,Deciduous Forest,,1,Waterbody,Natural,-1,-1,-1,-1,-1,-1,-1,-1,0,0,none,#ffffff,85.88498714,0,96.08994273,8.8,0,0,0
-33,1411,41,Deciduous Forest,,1,Waterbody,Natural,-1,-1,-1,-1,-1,-1,-1,-1,1,0.15,low,#e5f5e0,85.88498714,0,96.08994273,8.8,0,0,0
-34,1412,41,Deciduous Forest,,1,Waterbody,Natural,-1,-1,-1,-1,-1,-1,-1,-1,2,0.4,medium,#a1d99b,85.88498714,0,96.08994273,8.8,0,0,0
-35,1413,41,Deciduous Forest,,1,Waterbody,Natural,-1,-1,-1,-1,-1,-1,-1,-1,3,0.66,high,#31a354,85.88498714,0,96.08994273,8.8,0,0,0
-36,1420,42,Evergreen Forest,,1,Waterbody,Natural,-1,-1,-1,-1,-1,-1,-1,-1,0,0,none,#ffffff,105.6849871,0,96.08994273,14.4,0,0,0
-37,1421,42,Evergreen Forest,,1,Waterbody,Natural,-1,-1,-1,-1,-1,-1,-1,-1,1,0.15,low,#e5f5e0,105.6849871,0,96.08994273,14.4,0,0,0
-38,1422,42,Evergreen Forest,,1,Waterbody,Natural,-1,-1,-1,-1,-1,-1,-1,-1,2,0.4,medium,#a1d99b,105.6849871,0,96.08994273,14.4,0,0,0
-39,1423,42,Evergreen Forest,,1,Waterbody,Natural,-1,-1,-1,-1,-1,-1,-1,-1,3,0.66,high,#31a354,105.6849871,0,96.08994273,14.4,0,0,0
-40,1430,43,Mixed Forest,,1,Waterbody,Natural,-1,-1,-1,-1,-1,-1,-1,-1,0,0,none,#ffffff,91.76997429,0,119.1798855,8.8,0,0,0
-41,1431,43,Mixed Forest,,1,Waterbody,Natural,-1,-1,-1,-1,-1,-1,-1,-1,1,0.15,low,#e5f5e0,91.76997429,0,119.1798855,8.8,0,0,0
-42,1432,43,Mixed Forest,,1,Waterbody,Natural,-1,-1,-1,-1,-1,-1,-1,-1,2,0.4,medium,#a1d99b,91.76997429,0,119.1798855,8.8,0,0,0
-43,1433,43,Mixed Forest,,1,Waterbody,Natural,-1,-1,-1,-1,-1,-1,-1,-1,3,0.66,high,#31a354,91.76997429,0,119.1798855,8.8,0,0,0
-44,1520,52,Shrub/Scrub,,1,Waterbody,Natural,-1,-1,-1,-1,-1,-1,-1,-1,0,0,none,#ffffff,47.875,0,68.15477645,0,0,0,0
-45,1521,52,Shrub/Scrub,,1,Waterbody,Natural,-1,-1,-1,-1,-1,-1,-1,-1,1,0.15,low,#e5f5e0,54.86074743,0,73.49954853,1.6,0,0,0
-46,1522,52,Shrub/Scrub,,1,Waterbody,Natural,-1,-1,-1,-1,-1,-1,-1,-1,2,0.4,medium,#a1d99b,66.5036598,0,82.407502,4.266666667,0,0,0
-47,1523,52,Shrub/Scrub,,1,Waterbody,Natural,-1,-1,-1,-1,-1,-1,-1,-1,3,0.66,high,#31a354,78.61228868,0,91.6717736,7.04,0,0,0
-48,1710,71,Herbaceuous,,1,Waterbody,Natural,-1,-1,-1,-1,-1,-1,-1,-1,0,0,none,#ffffff,10.10660117,8,98.79264417,0,0,0,0
-49,1711,71,Herbaceuous,,1,Waterbody,Natural,-1,-1,-1,-1,-1,-1,-1,-1,1,0.15,low,#e5f5e0,22.75760842,6.8,99.54173609,1.6,0,0,0
-50,1712,71,Herbaceuous,,1,Waterbody,Natural,-1,-1,-1,-1,-1,-1,-1,-1,2,0.4,medium,#a1d99b,43.84262051,4.8,100.7902226,4.266666667,0,0,0
-51,1713,71,Herbaceuous,,1,Waterbody,Natural,-1,-1,-1,-1,-1,-1,-1,-1,3,0.66,high,#31a354,65.77103307,2.72,102.0886486,7.04,0,0,0
-52,1810,81,Hay/Pasture,,1,Waterbody,Natural,-1,-1,-1,-1,-1,-1,-1,-1,0,0,none,#ffffff,10.10660117,8,98.79264417,0,0,0,0
-53,1811,81,Hay/Pasture,,1,Waterbody,Natural,-1,-1,-1,-1,-1,-1,-1,-1,1,0.15,low,#e5f5e0,22.75760842,6.8,99.54173609,1.6,0,0,0
-54,1812,81,Hay/Pasture,,1,Waterbody,Natural,-1,-1,-1,-1,-1,-1,-1,-1,2,0.4,medium,#a1d99b,43.84262051,4.8,100.7902226,4.266666667,0,0,0
-55,1813,81,Hay/Pasture,,1,Waterbody,Natural,-1,-1,-1,-1,-1,-1,-1,-1,3,0.66,high,#31a354,65.77103307,2.72,102.0886486,7.04,0,0,0
-56,1820,82,Cultivated Crops,,1,Waterbody,Natural,-1,-1,-1,-1,-1,-1,-1,-1,0,0,none,#ffffff,4.793840162,0,65.75263422,0,0,0,0
-57,1821,82,Cultivated Crops,,1,Waterbody,Natural,-1,-1,-1,-1,-1,-1,-1,-1,1,0.15,low,#e5f5e0,18.24176156,0,71.45772764,1.6,0,0,0
-58,1822,82,Cultivated Crops,,1,Waterbody,Natural,-1,-1,-1,-1,-1,-1,-1,-1,2,0.4,medium,#a1d99b,40.6549639,0,80.96621666,4.266666667,0,0,0
-59,1823,82,Cultivated Crops,,1,Waterbody,Natural,-1,-1,-1,-1,-1,-1,-1,-1,3,0.66,high,#31a354,63.96469433,0,90.85504525,7.04,0,0,0
-60,1900,90,Woody Wetlands,,1,Waterbody,Natural,-1,-1,-1,-1,-1,-1,-1,-1,0,0,none,#ffffff,33.5,0,259,0,0,0,0
-61,1901,90,Woody Wetlands,,1,Waterbody,Natural,-1,-1,-1,-1,-1,-1,-1,-1,1,0.15,low,#e5f5e0,42.64199743,0,235.7179885,1.6,0,0,0
-62,1902,90,Woody Wetlands,,1,Waterbody,Natural,-1,-1,-1,-1,-1,-1,-1,-1,2,0.4,medium,#a1d99b,57.8786598,0,196.9146361,4.266666667,0,0,0
-63,1903,90,Woody Wetlands,,1,Waterbody,Natural,-1,-1,-1,-1,-1,-1,-1,-1,3,0.66,high,#31a354,73.72478868,0,156.5591496,7.04,0,0,0
-64,1950,95,Emergent Herbaceuous Wetlands,,1,Waterbody,Natural,-1,-1,-1,-1,-1,-1,-1,-1,0,0,none,#ffffff,33.5,0,259,0,0,0,0
-65,1951,95,Emergent Herbaceuous Wetlands,,1,Waterbody,Natural,-1,-1,-1,-1,-1,-1,-1,-1,1,0.15,low,#e5f5e0,42.64199743,0,235.7179885,1.6,0,0,0
-66,1952,95,Emergent Herbaceuous Wetlands,,1,Waterbody,Natural,-1,-1,-1,-1,-1,-1,-1,-1,2,0.4,medium,#a1d99b,57.8786598,0,196.9146361,4.266666667,0,0,0
-67,1953,95,Emergent Herbaceuous Wetlands,,1,Waterbody,Natural,-1,-1,-1,-1,-1,-1,-1,-1,3,0.66,high,#31a354,73.72478868,0,156.5591496,7.04,0,0,0
-68,2000,0,Background,,2,Waterbody,Wetland,-1,-1,-1,-1,-1,-1,-1,-1,0,0,none,#ffffff,0,0,0,0,0,0,0
-69,2001,0,Background,,2,Waterbody,Wetland,-1,-1,-1,-1,-1,-1,-1,-1,1,0.15,low,#e5f5e0,14.16699743,0,15.56798855,1.6,0,0,0
-70,2002,0,Background,,2,Waterbody,Wetland,-1,-1,-1,-1,-1,-1,-1,-1,2,0.4,medium,#a1d99b,37.7786598,0,41.51463613,4.266666667,0,0,0
-71,2003,0,Background,,2,Waterbody,Wetland,-1,-1,-1,-1,-1,-1,-1,-1,3,0.66,high,#31a354,62.33478868,0,68.49914961,7.04,0,0,0
-72,2110,11,Open Water,,2,Waterbody,Wetland,-1,-1,-1,-1,-1,-1,-1,-1,0,0,none,#ffffff,0,0,0,0,0,0,0
-73,2111,11,Open Water,,2,Waterbody,Wetland,-1,-1,-1,-1,-1,-1,-1,-1,1,0.15,low,#e5f5e0,14.16699743,0,15.56798855,1.6,0,0,0
-74,2112,11,Open Water,,2,Waterbody,Wetland,-1,-1,-1,-1,-1,-1,-1,-1,2,0.4,medium,#a1d99b,37.7786598,0,41.51463613,4.266666667,0,0,0
-75,2113,11,Open Water,,2,Waterbody,Wetland,-1,-1,-1,-1,-1,-1,-1,-1,3,0.66,high,#31a354,62.33478868,0,68.49914961,7.04,0,0,0
-76,2120,12,Perennial Ice/Snow,,2,Waterbody,Wetland,-1,-1,-1,-1,-1,-1,-1,-1,0,0,none,#ffffff,0,0,0,0,0,0,0
-77,2121,12,Perennial Ice/Snow,,2,Waterbody,Wetland,-1,-1,-1,-1,-1,-1,-1,-1,1,0.15,low,#e5f5e0,14.16699743,0,15.56798855,1.6,0,0,0
-78,2122,12,Perennial Ice/Snow,,2,Waterbody,Wetland,-1,-1,-1,-1,-1,-1,-1,-1,2,0.4,medium,#a1d99b,37.7786598,0,41.51463613,4.266666667,0,0,0
-79,2123,12,Perennial Ice/Snow,,2,Waterbody,Wetland,-1,-1,-1,-1,-1,-1,-1,-1,3,0.66,high,#31a354,62.33478868,0,68.49914961,7.04,0,0,0
-80,2210,21,"Developed, Open Space","20% trees, 60% grass, and 10% buildings and 10% bare soil",2,Waterbody,Wetland,-1,-1,-1,-1,-1,-1,-1,-1,0,0,none,#ffffff,25.49986095,4.08,79.01411479,1.76,51.81402439,212.31,37.03522039
-81,2211,21,"Developed, Open Space","20% trees, 60% grass, and 10% buildings and 10% bare soil",2,Waterbody,Wetland,-1,-1,-1,-1,-1,-1,-1,-1,1,0.15,low,#e5f5e0,35.84187923,3.468,82.72998612,3.096,51.81402439,212.31,37.03522039
-82,2212,21,"Developed, Open Space","20% trees, 60% grass, and 10% buildings and 10% bare soil",2,Waterbody,Wetland,-1,-1,-1,-1,-1,-1,-1,-1,2,0.4,medium,#a1d99b,53.07857637,2.448,88.923105,5.322666667,51.81402439,212.31,37.03522039
-83,2213,21,"Developed, Open Space","20% trees, 60% grass, and 10% buildings and 10% bare soil",2,Waterbody,Wetland,-1,-1,-1,-1,-1,-1,-1,-1,3,0.66,high,#31a354,71.0047414,1.3872,95.36394864,7.6384,51.81402439,212.31,37.03522039
-84,2220,22,"Developed, Low Intensity","20% trees, 40% grass, and 40% buildings",2,Waterbody,Wetland,-1,-1,-1,-1,-1,-1,-1,-1,0,0,none,#ffffff,20.90844667,3.52,72.06732319,0.61,207.2560976,849.24,147.1338816
-85,2221,22,"Developed, Low Intensity","20% trees, 40% grass, and 40% buildings",2,Waterbody,Wetland,-1,-1,-1,-1,-1,-1,-1,-1,1,0.15,low,#e5f5e0,31.9391771,2.992,76.82521326,2.1185,207.2560976,849.24,147.1338816
-86,2222,22,"Developed, Low Intensity","20% trees, 40% grass, and 40% buildings",2,Waterbody,Wetland,-1,-1,-1,-1,-1,-1,-1,-1,2,0.4,medium,#a1d99b,50.32372781,2.112,84.75503004,4.632666667,207.2560976,849.24,147.1338816
-87,2223,22,"Developed, Low Intensity","20% trees, 40% grass, and 40% buildings",2,Waterbody,Wetland,-1,-1,-1,-1,-1,-1,-1,-1,3,0.66,high,#31a354,69.44366054,1.1968,93.0020395,7.2474,207.2560976,849.24,147.1338816
-88,2230,23,"Developed, Medium Intensity","15% trees, 35% grass, and 50% buildings",2,Waterbody,Wetland,-1,-1,-1,-1,-1,-1,-1,-1,0,0,none,#ffffff,17.69813636,3.08,61.93838294,0.36,234.070122,954.85,720.4716833
-89,2231,23,"Developed, Medium Intensity","15% trees, 35% grass, and 50% buildings",2,Waterbody,Wetland,-1,-1,-1,-1,-1,-1,-1,-1,1,0.15,low,#e5f5e0,29.21041333,2.618,68.21561405,1.906,234.070122,954.85,720.4716833
-90,2232,23,"Developed, Medium Intensity","15% trees, 35% grass, and 50% buildings",2,Waterbody,Wetland,-1,-1,-1,-1,-1,-1,-1,-1,2,0.4,medium,#a1d99b,48.39754162,1.848,78.67766589,4.482666667,234.070122,954.85,720.4716833
-91,2233,23,"Developed, Medium Intensity","15% trees, 35% grass, and 50% buildings",2,Waterbody,Wetland,-1,-1,-1,-1,-1,-1,-1,-1,3,0.66,high,#31a354,68.35215504,1.0472,89.55819981,7.1624,234.070122,954.85,720.4716833
-92,2240,24,"Developed, High Intensity","10% trees, 20% grass, and 70% buildings",2,Waterbody,Wetland,-1,-1,-1,-1,-1,-1,-1,-1,0,0,none,#ffffff,10.98142029,1.76,44.78642515,0.245,267.9065041,3418.485,1805.616283
-93,2241,24,"Developed, High Intensity","10% trees, 20% grass, and 70% buildings",2,Waterbody,Wetland,-1,-1,-1,-1,-1,-1,-1,-1,1,0.15,low,#e5f5e0,23.50120467,1.496,53.63644993,1.80825,267.9065041,3418.485,1805.616283
-94,2242,24,"Developed, High Intensity","10% trees, 20% grass, and 70% buildings",2,Waterbody,Wetland,-1,-1,-1,-1,-1,-1,-1,-1,2,0.4,medium,#a1d99b,44.36751198,1.056,68.38649122,4.413666667,267.9065041,3418.485,1805.616283
-95,2243,24,"Developed, High Intensity","10% trees, 20% grass, and 70% buildings",2,Waterbody,Wetland,-1,-1,-1,-1,-1,-1,-1,-1,3,0.66,high,#31a354,66.06847158,0.5984,83.72653416,7.1233,267.9065041,3418.485,1805.616283
-96,2310,31,Barren Land,,2,Waterbody,Wetland,-1,-1,-1,-1,-1,-1,-1,-1,0,0,none,#ffffff,6.8,0,25.5,0,0,0,0
-97,2311,31,Barren Land,,2,Waterbody,Wetland,-1,-1,-1,-1,-1,-1,-1,-1,1,0.15,low,#e5f5e0,19.94699743,0,37.24298855,1.6,0,0,0
-98,2312,31,Barren Land,,2,Waterbody,Wetland,-1,-1,-1,-1,-1,-1,-1,-1,2,0.4,medium,#a1d99b,41.8586598,0,56.81463613,4.266666667,0,0,0
-99,2313,31,Barren Land,,2,Waterbody,Wetland,-1,-1,-1,-1,-1,-1,-1,-1,3,0.66,high,#31a354,64.64678868,0,77.16914961,7.04,0,0,0
-100,2410,41,Deciduous Forest,,2,Waterbody,Wetland,-1,-1,-1,-1,-1,-1,-1,-1,0,0,none,#ffffff,85.88498714,0,96.08994273,8.8,0,0,0
-101,2411,41,Deciduous Forest,,2,Waterbody,Wetland,-1,-1,-1,-1,-1,-1,-1,-1,1,0.15,low,#e5f5e0,85.88498714,0,96.08994273,8.8,0,0,0
-102,2412,41,Deciduous Forest,,2,Waterbody,Wetland,-1,-1,-1,-1,-1,-1,-1,-1,2,0.4,medium,#a1d99b,85.88498714,0,96.08994273,8.8,0,0,0
-103,2413,41,Deciduous Forest,,2,Waterbody,Wetland,-1,-1,-1,-1,-1,-1,-1,-1,3,0.66,high,#31a354,85.88498714,0,96.08994273,8.8,0,0,0
-104,2420,42,Evergreen Forest,,2,Waterbody,Wetland,-1,-1,-1,-1,-1,-1,-1,-1,0,0,none,#ffffff,105.6849871,0,96.08994273,14.4,0,0,0
-105,2421,42,Evergreen Forest,,2,Waterbody,Wetland,-1,-1,-1,-1,-1,-1,-1,-1,1,0.15,low,#e5f5e0,105.6849871,0,96.08994273,14.4,0,0,0
-106,2422,42,Evergreen Forest,,2,Waterbody,Wetland,-1,-1,-1,-1,-1,-1,-1,-1,2,0.4,medium,#a1d99b,105.6849871,0,96.08994273,14.4,0,0,0
-107,2423,42,Evergreen Forest,,2,Waterbody,Wetland,-1,-1,-1,-1,-1,-1,-1,-1,3,0.66,high,#31a354,105.6849871,0,96.08994273,14.4,0,0,0
-108,2430,43,Mixed Forest,,2,Waterbody,Wetland,-1,-1,-1,-1,-1,-1,-1,-1,0,0,none,#ffffff,91.76997429,0,119.1798855,8.8,0,0,0
-109,2431,43,Mixed Forest,,2,Waterbody,Wetland,-1,-1,-1,-1,-1,-1,-1,-1,1,0.15,low,#e5f5e0,91.76997429,0,119.1798855,8.8,0,0,0
-110,2432,43,Mixed Forest,,2,Waterbody,Wetland,-1,-1,-1,-1,-1,-1,-1,-1,2,0.4,medium,#a1d99b,91.76997429,0,119.1798855,8.8,0,0,0
-111,2433,43,Mixed Forest,,2,Waterbody,Wetland,-1,-1,-1,-1,-1,-1,-1,-1,3,0.66,high,#31a354,91.76997429,0,119.1798855,8.8,0,0,0
-112,2520,52,Shrub/Scrub,,2,Waterbody,Wetland,-1,-1,-1,-1,-1,-1,-1,-1,0,0,none,#ffffff,47.875,0,68.15477645,0,0,0,0
-113,2521,52,Shrub/Scrub,,2,Waterbody,Wetland,-1,-1,-1,-1,-1,-1,-1,-1,1,0.15,low,#e5f5e0,54.86074743,0,73.49954853,1.6,0,0,0
-114,2522,52,Shrub/Scrub,,2,Waterbody,Wetland,-1,-1,-1,-1,-1,-1,-1,-1,2,0.4,medium,#a1d99b,66.5036598,0,82.407502,4.266666667,0,0,0
-115,2523,52,Shrub/Scrub,,2,Waterbody,Wetland,-1,-1,-1,-1,-1,-1,-1,-1,3,0.66,high,#31a354,78.61228868,0,91.6717736,7.04,0,0,0
-116,2710,71,Herbaceuous,,2,Waterbody,Wetland,-1,-1,-1,-1,-1,-1,-1,-1,0,0,none,#ffffff,10.10660117,8,98.79264417,0,0,0,0
-117,2711,71,Herbaceuous,,2,Waterbody,Wetland,-1,-1,-1,-1,-1,-1,-1,-1,1,0.15,low,#e5f5e0,22.75760842,6.8,99.54173609,1.6,0,0,0
-118,2712,71,Herbaceuous,,2,Waterbody,Wetland,-1,-1,-1,-1,-1,-1,-1,-1,2,0.4,medium,#a1d99b,43.84262051,4.8,100.7902226,4.266666667,0,0,0
-119,2713,71,Herbaceuous,,2,Waterbody,Wetland,-1,-1,-1,-1,-1,-1,-1,-1,3,0.66,high,#31a354,65.77103307,2.72,102.0886486,7.04,0,0,0
-120,2810,81,Hay/Pasture,,2,Waterbody,Wetland,-1,-1,-1,-1,-1,-1,-1,-1,0,0,none,#ffffff,10.10660117,8,98.79264417,0,0,0,0
-121,2811,81,Hay/Pasture,,2,Waterbody,Wetland,-1,-1,-1,-1,-1,-1,-1,-1,1,0.15,low,#e5f5e0,22.75760842,6.8,99.54173609,1.6,0,0,0
-122,2812,81,Hay/Pasture,,2,Waterbody,Wetland,-1,-1,-1,-1,-1,-1,-1,-1,2,0.4,medium,#a1d99b,43.84262051,4.8,100.7902226,4.266666667,0,0,0
-123,2813,81,Hay/Pasture,,2,Waterbody,Wetland,-1,-1,-1,-1,-1,-1,-1,-1,3,0.66,high,#31a354,65.77103307,2.72,102.0886486,7.04,0,0,0
-124,2820,82,Cultivated Crops,,2,Waterbody,Wetland,-1,-1,-1,-1,-1,-1,-1,-1,0,0,none,#ffffff,4.793840162,0,65.75263422,0,0,0,0
-125,2821,82,Cultivated Crops,,2,Waterbody,Wetland,-1,-1,-1,-1,-1,-1,-1,-1,1,0.15,low,#e5f5e0,18.24176156,0,71.45772764,1.6,0,0,0
-126,2822,82,Cultivated Crops,,2,Waterbody,Wetland,-1,-1,-1,-1,-1,-1,-1,-1,2,0.4,medium,#a1d99b,40.6549639,0,80.96621666,4.266666667,0,0,0
-127,2823,82,Cultivated Crops,,2,Waterbody,Wetland,-1,-1,-1,-1,-1,-1,-1,-1,3,0.66,high,#31a354,63.96469433,0,90.85504525,7.04,0,0,0
-128,2900,90,Woody Wetlands,,2,Waterbody,Wetland,-1,-1,-1,-1,-1,-1,-1,-1,0,0,none,#ffffff,33.5,0,259,0,0,0,0
-129,2901,90,Woody Wetlands,,2,Waterbody,Wetland,-1,-1,-1,-1,-1,-1,-1,-1,1,0.15,low,#e5f5e0,42.64199743,0,235.7179885,1.6,0,0,0
-130,2902,90,Woody Wetlands,,2,Waterbody,Wetland,-1,-1,-1,-1,-1,-1,-1,-1,2,0.4,medium,#a1d99b,57.8786598,0,196.9146361,4.266666667,0,0,0
-131,2903,90,Woody Wetlands,,2,Waterbody,Wetland,-1,-1,-1,-1,-1,-1,-1,-1,3,0.66,high,#31a354,73.72478868,0,156.5591496,7.04,0,0,0
-132,2950,95,Emergent Herbaceuous Wetlands,,2,Waterbody,Wetland,-1,-1,-1,-1,-1,-1,-1,-1,0,0,none,#ffffff,33.5,0,259,0,0,0,0
-133,2951,95,Emergent Herbaceuous Wetlands,,2,Waterbody,Wetland,-1,-1,-1,-1,-1,-1,-1,-1,1,0.15,low,#e5f5e0,42.64199743,0,235.7179885,1.6,0,0,0
-134,2952,95,Emergent Herbaceuous Wetlands,,2,Waterbody,Wetland,-1,-1,-1,-1,-1,-1,-1,-1,2,0.4,medium,#a1d99b,57.8786598,0,196.9146361,4.266666667,0,0,0
-135,2953,95,Emergent Herbaceuous Wetlands,,2,Waterbody,Wetland,-1,-1,-1,-1,-1,-1,-1,-1,3,0.66,high,#31a354,73.72478868,0,156.5591496,7.04,0,0,0
-136,3000,0,Background,,3,Waterbody,Artificial,-1,-1,-1,-1,-1,-1,-1,-1,0,0,none,#ffffff,0,0,0,0,0,0,0
-137,3001,0,Background,,3,Waterbody,Artificial,-1,-1,-1,-1,-1,-1,-1,-1,1,0.15,low,#e5f5e0,14.16699743,0,15.56798855,1.6,0,0,0
-138,3002,0,Background,,3,Waterbody,Artificial,-1,-1,-1,-1,-1,-1,-1,-1,2,0.4,medium,#a1d99b,37.7786598,0,41.51463613,4.266666667,0,0,0
-139,3003,0,Background,,3,Waterbody,Artificial,-1,-1,-1,-1,-1,-1,-1,-1,3,0.66,high,#31a354,62.33478868,0,68.49914961,7.04,0,0,0
-140,3110,11,Open Water,,3,Waterbody,Artificial,-1,-1,-1,-1,-1,-1,-1,-1,0,0,none,#ffffff,0,0,0,0,0,0,0
-141,3111,11,Open Water,,3,Waterbody,Artificial,-1,-1,-1,-1,-1,-1,-1,-1,1,0.15,low,#e5f5e0,14.16699743,0,15.56798855,1.6,0,0,0
-142,3112,11,Open Water,,3,Waterbody,Artificial,-1,-1,-1,-1,-1,-1,-1,-1,2,0.4,medium,#a1d99b,37.7786598,0,41.51463613,4.266666667,0,0,0
-143,3113,11,Open Water,,3,Waterbody,Artificial,-1,-1,-1,-1,-1,-1,-1,-1,3,0.66,high,#31a354,62.33478868,0,68.49914961,7.04,0,0,0
-144,3120,12,Perennial Ice/Snow,,3,Waterbody,Artificial,-1,-1,-1,-1,-1,-1,-1,-1,0,0,none,#ffffff,0,0,0,0,0,0,0
-145,3121,12,Perennial Ice/Snow,,3,Waterbody,Artificial,-1,-1,-1,-1,-1,-1,-1,-1,1,0.15,low,#e5f5e0,14.16699743,0,15.56798855,1.6,0,0,0
-146,3122,12,Perennial Ice/Snow,,3,Waterbody,Artificial,-1,-1,-1,-1,-1,-1,-1,-1,2,0.4,medium,#a1d99b,37.7786598,0,41.51463613,4.266666667,0,0,0
-147,3123,12,Perennial Ice/Snow,,3,Waterbody,Artificial,-1,-1,-1,-1,-1,-1,-1,-1,3,0.66,high,#31a354,62.33478868,0,68.49914961,7.04,0,0,0
-148,3210,21,"Developed, Open Space","20% trees, 60% grass, and 10% buildings and 10% bare soil",3,Waterbody,Artificial,-1,-1,-1,-1,-1,-1,-1,-1,0,0,none,#ffffff,25.49986095,4.08,79.01411479,1.76,51.81402439,212.31,37.03522039
-149,3211,21,"Developed, Open Space","20% trees, 60% grass, and 10% buildings and 10% bare soil",3,Waterbody,Artificial,-1,-1,-1,-1,-1,-1,-1,-1,1,0.15,low,#e5f5e0,35.84187923,3.468,82.72998612,3.096,51.81402439,212.31,37.03522039
-150,3212,21,"Developed, Open Space","20% trees, 60% grass, and 10% buildings and 10% bare soil",3,Waterbody,Artificial,-1,-1,-1,-1,-1,-1,-1,-1,2,0.4,medium,#a1d99b,53.07857637,2.448,88.923105,5.322666667,51.81402439,212.31,37.03522039
-151,3213,21,"Developed, Open Space","20% trees, 60% grass, and 10% buildings and 10% bare soil",3,Waterbody,Artificial,-1,-1,-1,-1,-1,-1,-1,-1,3,0.66,high,#31a354,71.0047414,1.3872,95.36394864,7.6384,51.81402439,212.31,37.03522039
-152,3220,22,"Developed, Low Intensity","20% trees, 40% grass, and 40% buildings",3,Waterbody,Artificial,-1,-1,-1,-1,-1,-1,-1,-1,0,0,none,#ffffff,20.90844667,3.52,72.06732319,0.61,207.2560976,849.24,147.1338816
-153,3221,22,"Developed, Low Intensity","20% trees, 40% grass, and 40% buildings",3,Waterbody,Artificial,-1,-1,-1,-1,-1,-1,-1,-1,1,0.15,low,#e5f5e0,31.9391771,2.992,76.82521326,2.1185,207.2560976,849.24,147.1338816
-154,3222,22,"Developed, Low Intensity","20% trees, 40% grass, and 40% buildings",3,Waterbody,Artificial,-1,-1,-1,-1,-1,-1,-1,-1,2,0.4,medium,#a1d99b,50.32372781,2.112,84.75503004,4.632666667,207.2560976,849.24,147.1338816
-155,3223,22,"Developed, Low Intensity","20% trees, 40% grass, and 40% buildings",3,Waterbody,Artificial,-1,-1,-1,-1,-1,-1,-1,-1,3,0.66,high,#31a354,69.44366054,1.1968,93.0020395,7.2474,207.2560976,849.24,147.1338816
-156,3230,23,"Developed, Medium Intensity","15% trees, 35% grass, and 50% buildings",3,Waterbody,Artificial,-1,-1,-1,-1,-1,-1,-1,-1,0,0,none,#ffffff,17.69813636,3.08,61.93838294,0.36,234.070122,954.85,720.4716833
-157,3231,23,"Developed, Medium Intensity","15% trees, 35% grass, and 50% buildings",3,Waterbody,Artificial,-1,-1,-1,-1,-1,-1,-1,-1,1,0.15,low,#e5f5e0,29.21041333,2.618,68.21561405,1.906,234.070122,954.85,720.4716833
-158,3232,23,"Developed, Medium Intensity","15% trees, 35% grass, and 50% buildings",3,Waterbody,Artificial,-1,-1,-1,-1,-1,-1,-1,-1,2,0.4,medium,#a1d99b,48.39754162,1.848,78.67766589,4.482666667,234.070122,954.85,720.4716833
-159,3233,23,"Developed, Medium Intensity","15% trees, 35% grass, and 50% buildings",3,Waterbody,Artificial,-1,-1,-1,-1,-1,-1,-1,-1,3,0.66,high,#31a354,68.35215504,1.0472,89.55819981,7.1624,234.070122,954.85,720.4716833
-160,3240,24,"Developed, High Intensity","10% trees, 20% grass, and 70% buildings",3,Waterbody,Artificial,-1,-1,-1,-1,-1,-1,-1,-1,0,0,none,#ffffff,10.98142029,1.76,44.78642515,0.245,267.9065041,3418.485,1805.616283
-161,3241,24,"Developed, High Intensity","10% trees, 20% grass, and 70% buildings",3,Waterbody,Artificial,-1,-1,-1,-1,-1,-1,-1,-1,1,0.15,low,#e5f5e0,23.50120467,1.496,53.63644993,1.80825,267.9065041,3418.485,1805.616283
-162,3242,24,"Developed, High Intensity","10% trees, 20% grass, and 70% buildings",3,Waterbody,Artificial,-1,-1,-1,-1,-1,-1,-1,-1,2,0.4,medium,#a1d99b,44.36751198,1.056,68.38649122,4.413666667,267.9065041,3418.485,1805.616283
-163,3243,24,"Developed, High Intensity","10% trees, 20% grass, and 70% buildings",3,Waterbody,Artificial,-1,-1,-1,-1,-1,-1,-1,-1,3,0.66,high,#31a354,66.06847158,0.5984,83.72653416,7.1233,267.9065041,3418.485,1805.616283
-164,3310,31,Barren Land,,3,Waterbody,Artificial,-1,-1,-1,-1,-1,-1,-1,-1,0,0,none,#ffffff,6.8,0,25.5,0,0,0,0
-165,3311,31,Barren Land,,3,Waterbody,Artificial,-1,-1,-1,-1,-1,-1,-1,-1,1,0.15,low,#e5f5e0,19.94699743,0,37.24298855,1.6,0,0,0
-166,3312,31,Barren Land,,3,Waterbody,Artificial,-1,-1,-1,-1,-1,-1,-1,-1,2,0.4,medium,#a1d99b,41.8586598,0,56.81463613,4.266666667,0,0,0
-167,3313,31,Barren Land,,3,Waterbody,Artificial,-1,-1,-1,-1,-1,-1,-1,-1,3,0.66,high,#31a354,64.64678868,0,77.16914961,7.04,0,0,0
-168,3410,41,Deciduous Forest,,3,Waterbody,Artificial,-1,-1,-1,-1,-1,-1,-1,-1,0,0,none,#ffffff,85.88498714,0,96.08994273,8.8,0,0,0
-169,3411,41,Deciduous Forest,,3,Waterbody,Artificial,-1,-1,-1,-1,-1,-1,-1,-1,1,0.15,low,#e5f5e0,85.88498714,0,96.08994273,8.8,0,0,0
-170,3412,41,Deciduous Forest,,3,Waterbody,Artificial,-1,-1,-1,-1,-1,-1,-1,-1,2,0.4,medium,#a1d99b,85.88498714,0,96.08994273,8.8,0,0,0
-171,3413,41,Deciduous Forest,,3,Waterbody,Artificial,-1,-1,-1,-1,-1,-1,-1,-1,3,0.66,high,#31a354,85.88498714,0,96.08994273,8.8,0,0,0
-172,3420,42,Evergreen Forest,,3,Waterbody,Artificial,-1,-1,-1,-1,-1,-1,-1,-1,0,0,none,#ffffff,105.6849871,0,96.08994273,14.4,0,0,0
-173,3421,42,Evergreen Forest,,3,Waterbody,Artificial,-1,-1,-1,-1,-1,-1,-1,-1,1,0.15,low,#e5f5e0,105.6849871,0,96.08994273,14.4,0,0,0
-174,3422,42,Evergreen Forest,,3,Waterbody,Artificial,-1,-1,-1,-1,-1,-1,-1,-1,2,0.4,medium,#a1d99b,105.6849871,0,96.08994273,14.4,0,0,0
-175,3423,42,Evergreen Forest,,3,Waterbody,Artificial,-1,-1,-1,-1,-1,-1,-1,-1,3,0.66,high,#31a354,105.6849871,0,96.08994273,14.4,0,0,0
-176,3430,43,Mixed Forest,,3,Waterbody,Artificial,-1,-1,-1,-1,-1,-1,-1,-1,0,0,none,#ffffff,91.76997429,0,119.1798855,8.8,0,0,0
-177,3431,43,Mixed Forest,,3,Waterbody,Artificial,-1,-1,-1,-1,-1,-1,-1,-1,1,0.15,low,#e5f5e0,91.76997429,0,119.1798855,8.8,0,0,0
-178,3432,43,Mixed Forest,,3,Waterbody,Artificial,-1,-1,-1,-1,-1,-1,-1,-1,2,0.4,medium,#a1d99b,91.76997429,0,119.1798855,8.8,0,0,0
-179,3433,43,Mixed Forest,,3,Waterbody,Artificial,-1,-1,-1,-1,-1,-1,-1,-1,3,0.66,high,#31a354,91.76997429,0,119.1798855,8.8,0,0,0
-180,3520,52,Shrub/Scrub,,3,Waterbody,Artificial,-1,-1,-1,-1,-1,-1,-1,-1,0,0,none,#ffffff,47.875,0,68.15477645,0,0,0,0
-181,3521,52,Shrub/Scrub,,3,Waterbody,Artificial,-1,-1,-1,-1,-1,-1,-1,-1,1,0.15,low,#e5f5e0,54.86074743,0,73.49954853,1.6,0,0,0
-182,3522,52,Shrub/Scrub,,3,Waterbody,Artificial,-1,-1,-1,-1,-1,-1,-1,-1,2,0.4,medium,#a1d99b,66.5036598,0,82.407502,4.266666667,0,0,0
-183,3523,52,Shrub/Scrub,,3,Waterbody,Artificial,-1,-1,-1,-1,-1,-1,-1,-1,3,0.66,high,#31a354,78.61228868,0,91.6717736,7.04,0,0,0
-184,3710,71,Herbaceuous,,3,Waterbody,Artificial,-1,-1,-1,-1,-1,-1,-1,-1,0,0,none,#ffffff,10.10660117,8,98.79264417,0,0,0,0
-185,3711,71,Herbaceuous,,3,Waterbody,Artificial,-1,-1,-1,-1,-1,-1,-1,-1,1,0.15,low,#e5f5e0,22.75760842,6.8,99.54173609,1.6,0,0,0
-186,3712,71,Herbaceuous,,3,Waterbody,Artificial,-1,-1,-1,-1,-1,-1,-1,-1,2,0.4,medium,#a1d99b,43.84262051,4.8,100.7902226,4.266666667,0,0,0
-187,3713,71,Herbaceuous,,3,Waterbody,Artificial,-1,-1,-1,-1,-1,-1,-1,-1,3,0.66,high,#31a354,65.77103307,2.72,102.0886486,7.04,0,0,0
-188,3810,81,Hay/Pasture,,3,Waterbody,Artificial,-1,-1,-1,-1,-1,-1,-1,-1,0,0,none,#ffffff,10.10660117,8,98.79264417,0,0,0,0
-189,3811,81,Hay/Pasture,,3,Waterbody,Artificial,-1,-1,-1,-1,-1,-1,-1,-1,1,0.15,low,#e5f5e0,22.75760842,6.8,99.54173609,1.6,0,0,0
-190,3812,81,Hay/Pasture,,3,Waterbody,Artificial,-1,-1,-1,-1,-1,-1,-1,-1,2,0.4,medium,#a1d99b,43.84262051,4.8,100.7902226,4.266666667,0,0,0
-191,3813,81,Hay/Pasture,,3,Waterbody,Artificial,-1,-1,-1,-1,-1,-1,-1,-1,3,0.66,high,#31a354,65.77103307,2.72,102.0886486,7.04,0,0,0
-192,3820,82,Cultivated Crops,,3,Waterbody,Artificial,-1,-1,-1,-1,-1,-1,-1,-1,0,0,none,#ffffff,4.793840162,0,65.75263422,0,0,0,0
-193,3821,82,Cultivated Crops,,3,Waterbody,Artificial,-1,-1,-1,-1,-1,-1,-1,-1,1,0.15,low,#e5f5e0,18.24176156,0,71.45772764,1.6,0,0,0
-194,3822,82,Cultivated Crops,,3,Waterbody,Artificial,-1,-1,-1,-1,-1,-1,-1,-1,2,0.4,medium,#a1d99b,40.6549639,0,80.96621666,4.266666667,0,0,0
-195,3823,82,Cultivated Crops,,3,Waterbody,Artificial,-1,-1,-1,-1,-1,-1,-1,-1,3,0.66,high,#31a354,63.96469433,0,90.85504525,7.04,0,0,0
-196,3900,90,Woody Wetlands,,3,Waterbody,Artificial,-1,-1,-1,-1,-1,-1,-1,-1,0,0,none,#ffffff,33.5,0,259,0,0,0,0
-197,3901,90,Woody Wetlands,,3,Waterbody,Artificial,-1,-1,-1,-1,-1,-1,-1,-1,1,0.15,low,#e5f5e0,42.64199743,0,235.7179885,1.6,0,0,0
-198,3902,90,Woody Wetlands,,3,Waterbody,Artificial,-1,-1,-1,-1,-1,-1,-1,-1,2,0.4,medium,#a1d99b,57.8786598,0,196.9146361,4.266666667,0,0,0
-199,3903,90,Woody Wetlands,,3,Waterbody,Artificial,-1,-1,-1,-1,-1,-1,-1,-1,3,0.66,high,#31a354,73.72478868,0,156.5591496,7.04,0,0,0
-200,3950,95,Emergent Herbaceuous Wetlands,,3,Waterbody,Artificial,-1,-1,-1,-1,-1,-1,-1,-1,0,0,none,#ffffff,33.5,0,259,0,0,0,0
-201,3951,95,Emergent Herbaceuous Wetlands,,3,Waterbody,Artificial,-1,-1,-1,-1,-1,-1,-1,-1,1,0.15,low,#e5f5e0,42.64199743,0,235.7179885,1.6,0,0,0
-202,3952,95,Emergent Herbaceuous Wetlands,,3,Waterbody,Artificial,-1,-1,-1,-1,-1,-1,-1,-1,2,0.4,medium,#a1d99b,57.8786598,0,196.9146361,4.266666667,0,0,0
-203,3953,95,Emergent Herbaceuous Wetlands,,3,Waterbody,Artificial,-1,-1,-1,-1,-1,-1,-1,-1,3,0.66,high,#31a354,73.72478868,0,156.5591496,7.04,0,0,0
-204,4000,0,Background,,4,Waterbody,Perennial Ice/Snow,-1,-1,-1,-1,-1,-1,-1,-1,0,0,none,#ffffff,0,0,0,0,0,0,0
-205,4001,0,Background,,4,Waterbody,Perennial Ice/Snow,-1,-1,-1,-1,-1,-1,-1,-1,1,0.15,low,#e5f5e0,14.16699743,0,15.56798855,1.6,0,0,0
-206,4002,0,Background,,4,Waterbody,Perennial Ice/Snow,-1,-1,-1,-1,-1,-1,-1,-1,2,0.4,medium,#a1d99b,37.7786598,0,41.51463613,4.266666667,0,0,0
-207,4003,0,Background,,4,Waterbody,Perennial Ice/Snow,-1,-1,-1,-1,-1,-1,-1,-1,3,0.66,high,#31a354,62.33478868,0,68.49914961,7.04,0,0,0
-208,4110,11,Open Water,,4,Waterbody,Perennial Ice/Snow,-1,-1,-1,-1,-1,-1,-1,-1,0,0,none,#ffffff,0,0,0,0,0,0,0
-209,4111,11,Open Water,,4,Waterbody,Perennial Ice/Snow,-1,-1,-1,-1,-1,-1,-1,-1,1,0.15,low,#e5f5e0,14.16699743,0,15.56798855,1.6,0,0,0
-210,4112,11,Open Water,,4,Waterbody,Perennial Ice/Snow,-1,-1,-1,-1,-1,-1,-1,-1,2,0.4,medium,#a1d99b,37.7786598,0,41.51463613,4.266666667,0,0,0
-211,4113,11,Open Water,,4,Waterbody,Perennial Ice/Snow,-1,-1,-1,-1,-1,-1,-1,-1,3,0.66,high,#31a354,62.33478868,0,68.49914961,7.04,0,0,0
-212,4120,12,Perennial Ice/Snow,,4,Waterbody,Perennial Ice/Snow,-1,-1,-1,-1,-1,-1,-1,-1,0,0,none,#ffffff,0,0,0,0,0,0,0
-213,4121,12,Perennial Ice/Snow,,4,Waterbody,Perennial Ice/Snow,-1,-1,-1,-1,-1,-1,-1,-1,1,0.15,low,#e5f5e0,14.16699743,0,15.56798855,1.6,0,0,0
-214,4122,12,Perennial Ice/Snow,,4,Waterbody,Perennial Ice/Snow,-1,-1,-1,-1,-1,-1,-1,-1,2,0.4,medium,#a1d99b,37.7786598,0,41.51463613,4.266666667,0,0,0
-215,4123,12,Perennial Ice/Snow,,4,Waterbody,Perennial Ice/Snow,-1,-1,-1,-1,-1,-1,-1,-1,3,0.66,high,#31a354,62.33478868,0,68.49914961,7.04,0,0,0
-216,4210,21,"Developed, Open Space","20% trees, 60% grass, and 10% buildings and 10% bare soil",4,Waterbody,Perennial Ice/Snow,-1,-1,-1,-1,-1,-1,-1,-1,0,0,none,#ffffff,25.49986095,4.08,79.01411479,1.76,51.81402439,212.31,37.03522039
-217,4211,21,"Developed, Open Space","20% trees, 60% grass, and 10% buildings and 10% bare soil",4,Waterbody,Perennial Ice/Snow,-1,-1,-1,-1,-1,-1,-1,-1,1,0.15,low,#e5f5e0,35.84187923,3.468,82.72998612,3.096,51.81402439,212.31,37.03522039
-218,4212,21,"Developed, Open Space","20% trees, 60% grass, and 10% buildings and 10% bare soil",4,Waterbody,Perennial Ice/Snow,-1,-1,-1,-1,-1,-1,-1,-1,2,0.4,medium,#a1d99b,53.07857637,2.448,88.923105,5.322666667,51.81402439,212.31,37.03522039
-219,4213,21,"Developed, Open Space","20% trees, 60% grass, and 10% buildings and 10% bare soil",4,Waterbody,Perennial Ice/Snow,-1,-1,-1,-1,-1,-1,-1,-1,3,0.66,high,#31a354,71.0047414,1.3872,95.36394864,7.6384,51.81402439,212.31,37.03522039
-220,4220,22,"Developed, Low Intensity","20% trees, 40% grass, and 40% buildings",4,Waterbody,Perennial Ice/Snow,-1,-1,-1,-1,-1,-1,-1,-1,0,0,none,#ffffff,20.90844667,3.52,72.06732319,0.61,207.2560976,849.24,147.1338816
-221,4221,22,"Developed, Low Intensity","20% trees, 40% grass, and 40% buildings",4,Waterbody,Perennial Ice/Snow,-1,-1,-1,-1,-1,-1,-1,-1,1,0.15,low,#e5f5e0,31.9391771,2.992,76.82521326,2.1185,207.2560976,849.24,147.1338816
-222,4222,22,"Developed, Low Intensity","20% trees, 40% grass, and 40% buildings",4,Waterbody,Perennial Ice/Snow,-1,-1,-1,-1,-1,-1,-1,-1,2,0.4,medium,#a1d99b,50.32372781,2.112,84.75503004,4.632666667,207.2560976,849.24,147.1338816
-223,4223,22,"Developed, Low Intensity","20% trees, 40% grass, and 40% buildings",4,Waterbody,Perennial Ice/Snow,-1,-1,-1,-1,-1,-1,-1,-1,3,0.66,high,#31a354,69.44366054,1.1968,93.0020395,7.2474,207.2560976,849.24,147.1338816
-224,4230,23,"Developed, Medium Intensity","15% trees, 35% grass, and 50% buildings",4,Waterbody,Perennial Ice/Snow,-1,-1,-1,-1,-1,-1,-1,-1,0,0,none,#ffffff,17.69813636,3.08,61.93838294,0.36,234.070122,954.85,720.4716833
-225,4231,23,"Developed, Medium Intensity","15% trees, 35% grass, and 50% buildings",4,Waterbody,Perennial Ice/Snow,-1,-1,-1,-1,-1,-1,-1,-1,1,0.15,low,#e5f5e0,29.21041333,2.618,68.21561405,1.906,234.070122,954.85,720.4716833
-226,4232,23,"Developed, Medium Intensity","15% trees, 35% grass, and 50% buildings",4,Waterbody,Perennial Ice/Snow,-1,-1,-1,-1,-1,-1,-1,-1,2,0.4,medium,#a1d99b,48.39754162,1.848,78.67766589,4.482666667,234.070122,954.85,720.4716833
-227,4233,23,"Developed, Medium Intensity","15% trees, 35% grass, and 50% buildings",4,Waterbody,Perennial Ice/Snow,-1,-1,-1,-1,-1,-1,-1,-1,3,0.66,high,#31a354,68.35215504,1.0472,89.55819981,7.1624,234.070122,954.85,720.4716833
-228,4240,24,"Developed, High Intensity","10% trees, 20% grass, and 70% buildings",4,Waterbody,Perennial Ice/Snow,-1,-1,-1,-1,-1,-1,-1,-1,0,0,none,#ffffff,10.98142029,1.76,44.78642515,0.245,267.9065041,3418.485,1805.616283
-229,4241,24,"Developed, High Intensity","10% trees, 20% grass, and 70% buildings",4,Waterbody,Perennial Ice/Snow,-1,-1,-1,-1,-1,-1,-1,-1,1,0.15,low,#e5f5e0,23.50120467,1.496,53.63644993,1.80825,267.9065041,3418.485,1805.616283
-230,4242,24,"Developed, High Intensity","10% trees, 20% grass, and 70% buildings",4,Waterbody,Perennial Ice/Snow,-1,-1,-1,-1,-1,-1,-1,-1,2,0.4,medium,#a1d99b,44.36751198,1.056,68.38649122,4.413666667,267.9065041,3418.485,1805.616283
-231,4243,24,"Developed, High Intensity","10% trees, 20% grass, and 70% buildings",4,Waterbody,Perennial Ice/Snow,-1,-1,-1,-1,-1,-1,-1,-1,3,0.66,high,#31a354,66.06847158,0.5984,83.72653416,7.1233,267.9065041,3418.485,1805.616283
-232,4310,31,Barren Land,,4,Waterbody,Perennial Ice/Snow,-1,-1,-1,-1,-1,-1,-1,-1,0,0,none,#ffffff,6.8,0,25.5,0,0,0,0
-233,4311,31,Barren Land,,4,Waterbody,Perennial Ice/Snow,-1,-1,-1,-1,-1,-1,-1,-1,1,0.15,low,#e5f5e0,19.94699743,0,37.24298855,1.6,0,0,0
-234,4312,31,Barren Land,,4,Waterbody,Perennial Ice/Snow,-1,-1,-1,-1,-1,-1,-1,-1,2,0.4,medium,#a1d99b,41.8586598,0,56.81463613,4.266666667,0,0,0
-235,4313,31,Barren Land,,4,Waterbody,Perennial Ice/Snow,-1,-1,-1,-1,-1,-1,-1,-1,3,0.66,high,#31a354,64.64678868,0,77.16914961,7.04,0,0,0
-236,4410,41,Deciduous Forest,,4,Waterbody,Perennial Ice/Snow,-1,-1,-1,-1,-1,-1,-1,-1,0,0,none,#ffffff,85.88498714,0,96.08994273,8.8,0,0,0
-237,4411,41,Deciduous Forest,,4,Waterbody,Perennial Ice/Snow,-1,-1,-1,-1,-1,-1,-1,-1,1,0.15,low,#e5f5e0,85.88498714,0,96.08994273,8.8,0,0,0
-238,4412,41,Deciduous Forest,,4,Waterbody,Perennial Ice/Snow,-1,-1,-1,-1,-1,-1,-1,-1,2,0.4,medium,#a1d99b,85.88498714,0,96.08994273,8.8,0,0,0
-239,4413,41,Deciduous Forest,,4,Waterbody,Perennial Ice/Snow,-1,-1,-1,-1,-1,-1,-1,-1,3,0.66,high,#31a354,85.88498714,0,96.08994273,8.8,0,0,0
-240,4420,42,Evergreen Forest,,4,Waterbody,Perennial Ice/Snow,-1,-1,-1,-1,-1,-1,-1,-1,0,0,none,#ffffff,105.6849871,0,96.08994273,14.4,0,0,0
-241,4421,42,Evergreen Forest,,4,Waterbody,Perennial Ice/Snow,-1,-1,-1,-1,-1,-1,-1,-1,1,0.15,low,#e5f5e0,105.6849871,0,96.08994273,14.4,0,0,0
-242,4422,42,Evergreen Forest,,4,Waterbody,Perennial Ice/Snow,-1,-1,-1,-1,-1,-1,-1,-1,2,0.4,medium,#a1d99b,105.6849871,0,96.08994273,14.4,0,0,0
-243,4423,42,Evergreen Forest,,4,Waterbody,Perennial Ice/Snow,-1,-1,-1,-1,-1,-1,-1,-1,3,0.66,high,#31a354,105.6849871,0,96.08994273,14.4,0,0,0
-244,4430,43,Mixed Forest,,4,Waterbody,Perennial Ice/Snow,-1,-1,-1,-1,-1,-1,-1,-1,0,0,none,#ffffff,91.76997429,0,119.1798855,8.8,0,0,0
-245,4431,43,Mixed Forest,,4,Waterbody,Perennial Ice/Snow,-1,-1,-1,-1,-1,-1,-1,-1,1,0.15,low,#e5f5e0,91.76997429,0,119.1798855,8.8,0,0,0
-246,4432,43,Mixed Forest,,4,Waterbody,Perennial Ice/Snow,-1,-1,-1,-1,-1,-1,-1,-1,2,0.4,medium,#a1d99b,91.76997429,0,119.1798855,8.8,0,0,0
-247,4433,43,Mixed Forest,,4,Waterbody,Perennial Ice/Snow,-1,-1,-1,-1,-1,-1,-1,-1,3,0.66,high,#31a354,91.76997429,0,119.1798855,8.8,0,0,0
-248,4520,52,Shrub/Scrub,,4,Waterbody,Perennial Ice/Snow,-1,-1,-1,-1,-1,-1,-1,-1,0,0,none,#ffffff,47.875,0,68.15477645,0,0,0,0
-249,4521,52,Shrub/Scrub,,4,Waterbody,Perennial Ice/Snow,-1,-1,-1,-1,-1,-1,-1,-1,1,0.15,low,#e5f5e0,54.86074743,0,73.49954853,1.6,0,0,0
-250,4522,52,Shrub/Scrub,,4,Waterbody,Perennial Ice/Snow,-1,-1,-1,-1,-1,-1,-1,-1,2,0.4,medium,#a1d99b,66.5036598,0,82.407502,4.266666667,0,0,0
-251,4523,52,Shrub/Scrub,,4,Waterbody,Perennial Ice/Snow,-1,-1,-1,-1,-1,-1,-1,-1,3,0.66,high,#31a354,78.61228868,0,91.6717736,7.04,0,0,0
-252,4710,71,Herbaceuous,,4,Waterbody,Perennial Ice/Snow,-1,-1,-1,-1,-1,-1,-1,-1,0,0,none,#ffffff,10.10660117,8,98.79264417,0,0,0,0
-253,4711,71,Herbaceuous,,4,Waterbody,Perennial Ice/Snow,-1,-1,-1,-1,-1,-1,-1,-1,1,0.15,low,#e5f5e0,22.75760842,6.8,99.54173609,1.6,0,0,0
-254,4712,71,Herbaceuous,,4,Waterbody,Perennial Ice/Snow,-1,-1,-1,-1,-1,-1,-1,-1,2,0.4,medium,#a1d99b,43.84262051,4.8,100.7902226,4.266666667,0,0,0
-255,4713,71,Herbaceuous,,4,Waterbody,Perennial Ice/Snow,-1,-1,-1,-1,-1,-1,-1,-1,3,0.66,high,#31a354,65.77103307,2.72,102.0886486,7.04,0,0,0
-256,4810,81,Hay/Pasture,,4,Waterbody,Perennial Ice/Snow,-1,-1,-1,-1,-1,-1,-1,-1,0,0,none,#ffffff,10.10660117,8,98.79264417,0,0,0,0
-257,4811,81,Hay/Pasture,,4,Waterbody,Perennial Ice/Snow,-1,-1,-1,-1,-1,-1,-1,-1,1,0.15,low,#e5f5e0,22.75760842,6.8,99.54173609,1.6,0,0,0
-258,4812,81,Hay/Pasture,,4,Waterbody,Perennial Ice/Snow,-1,-1,-1,-1,-1,-1,-1,-1,2,0.4,medium,#a1d99b,43.84262051,4.8,100.7902226,4.266666667,0,0,0
-259,4813,81,Hay/Pasture,,4,Waterbody,Perennial Ice/Snow,-1,-1,-1,-1,-1,-1,-1,-1,3,0.66,high,#31a354,65.77103307,2.72,102.0886486,7.04,0,0,0
-260,4820,82,Cultivated Crops,,4,Waterbody,Perennial Ice/Snow,-1,-1,-1,-1,-1,-1,-1,-1,0,0,none,#ffffff,4.793840162,0,65.75263422,0,0,0,0
-261,4821,82,Cultivated Crops,,4,Waterbody,Perennial Ice/Snow,-1,-1,-1,-1,-1,-1,-1,-1,1,0.15,low,#e5f5e0,18.24176156,0,71.45772764,1.6,0,0,0
-262,4822,82,Cultivated Crops,,4,Waterbody,Perennial Ice/Snow,-1,-1,-1,-1,-1,-1,-1,-1,2,0.4,medium,#a1d99b,40.6549639,0,80.96621666,4.266666667,0,0,0
-263,4823,82,Cultivated Crops,,4,Waterbody,Perennial Ice/Snow,-1,-1,-1,-1,-1,-1,-1,-1,3,0.66,high,#31a354,63.96469433,0,90.85504525,7.04,0,0,0
-264,4900,90,Woody Wetlands,,4,Waterbody,Perennial Ice/Snow,-1,-1,-1,-1,-1,-1,-1,-1,0,0,none,#ffffff,33.5,0,259,0,0,0,0
-265,4901,90,Woody Wetlands,,4,Waterbody,Perennial Ice/Snow,-1,-1,-1,-1,-1,-1,-1,-1,1,0.15,low,#e5f5e0,42.64199743,0,235.7179885,1.6,0,0,0
-266,4902,90,Woody Wetlands,,4,Waterbody,Perennial Ice/Snow,-1,-1,-1,-1,-1,-1,-1,-1,2,0.4,medium,#a1d99b,57.8786598,0,196.9146361,4.266666667,0,0,0
-267,4903,90,Woody Wetlands,,4,Waterbody,Perennial Ice/Snow,-1,-1,-1,-1,-1,-1,-1,-1,3,0.66,high,#31a354,73.72478868,0,156.5591496,7.04,0,0,0
-268,4950,95,Emergent Herbaceuous Wetlands,,4,Waterbody,Perennial Ice/Snow,-1,-1,-1,-1,-1,-1,-1,-1,0,0,none,#ffffff,33.5,0,259,0,0,0,0
-269,4951,95,Emergent Herbaceuous Wetlands,,4,Waterbody,Perennial Ice/Snow,-1,-1,-1,-1,-1,-1,-1,-1,1,0.15,low,#e5f5e0,42.64199743,0,235.7179885,1.6,0,0,0
-270,4952,95,Emergent Herbaceuous Wetlands,,4,Waterbody,Perennial Ice/Snow,-1,-1,-1,-1,-1,-1,-1,-1,2,0.4,medium,#a1d99b,57.8786598,0,196.9146361,4.266666667,0,0,0
-271,4953,95,Emergent Herbaceuous Wetlands,,4,Waterbody,Perennial Ice/Snow,-1,-1,-1,-1,-1,-1,-1,-1,3,0.66,high,#31a354,73.72478868,0,156.5591496,7.04,0,0,0
-272,11000,0,Background,,11,Residential,Dense urban,-1,-1,-1,-1,-1,-1,-1,-1,0,0,none,#ffffff,0,0,0,0,0,0,0
-273,11001,0,Background,,11,Residential,Dense urban,-1,-1,-1,-1,-1,-1,-1,-1,1,0.15,low,#e5f5e0,14.16699743,0,15.56798855,1.6,0,0,0
-274,11002,0,Background,,11,Residential,Dense urban,-1,-1,-1,-1,-1,-1,-1,-1,2,0.4,medium,#a1d99b,37.7786598,0,41.51463613,4.266666667,0,0,0
-275,11003,0,Background,,11,Residential,Dense urban,-1,-1,-1,-1,-1,-1,-1,-1,3,0.66,high,#31a354,62.33478868,0,68.49914961,7.04,0,0,0
-276,11110,11,Open Water,,11,Residential,Dense urban,-1,-1,-1,-1,-1,-1,-1,-1,0,0,none,#ffffff,0,0,0,0,0,0,0
-277,11111,11,Open Water,,11,Residential,Dense urban,-1,-1,-1,-1,-1,-1,-1,-1,1,0.15,low,#e5f5e0,14.16699743,0,15.56798855,1.6,0,0,0
-278,11112,11,Open Water,,11,Residential,Dense urban,-1,-1,-1,-1,-1,-1,-1,-1,2,0.4,medium,#a1d99b,37.7786598,0,41.51463613,4.266666667,0,0,0
-279,11113,11,Open Water,,11,Residential,Dense urban,-1,-1,-1,-1,-1,-1,-1,-1,3,0.66,high,#31a354,62.33478868,0,68.49914961,7.04,0,0,0
-280,11120,12,Perennial Ice/Snow,,11,Residential,Dense urban,-1,-1,-1,-1,-1,-1,-1,-1,0,0,none,#ffffff,0,0,0,0,0,0,0
-281,11121,12,Perennial Ice/Snow,,11,Residential,Dense urban,-1,-1,-1,-1,-1,-1,-1,-1,1,0.15,low,#e5f5e0,14.16699743,0,15.56798855,1.6,0,0,0
-282,11122,12,Perennial Ice/Snow,,11,Residential,Dense urban,-1,-1,-1,-1,-1,-1,-1,-1,2,0.4,medium,#a1d99b,37.7786598,0,41.51463613,4.266666667,0,0,0
-283,11123,12,Perennial Ice/Snow,,11,Residential,Dense urban,-1,-1,-1,-1,-1,-1,-1,-1,3,0.66,high,#31a354,62.33478868,0,68.49914961,7.04,0,0,0
-284,11210,21,"Developed, Open Space","20% trees, 60% grass, and 10% buildings and 10% bare soil",11,Residential,Dense urban,0.8,0.8,0.8,0.1,1,-1,-1,-1,0,0,none,#ffffff,25.49986095,4.08,79.01411479,1.76,51.81402439,212.31,37.03522039
-285,11211,21,"Developed, Open Space","20% trees, 60% grass, and 10% buildings and 10% bare soil",11,Residential,Dense urban,0.8,0.8,0.8,0.1,1,-1,-1,-1,1,0.15,low,#e5f5e0,35.84187923,3.468,82.72998612,3.096,51.81402439,212.31,37.03522039
-286,11212,21,"Developed, Open Space","20% trees, 60% grass, and 10% buildings and 10% bare soil",11,Residential,Dense urban,0.8,0.8,0.8,0.1,1,-1,-1,-1,2,0.4,medium,#a1d99b,53.07857637,2.448,88.923105,5.322666667,51.81402439,212.31,37.03522039
-287,11213,21,"Developed, Open Space","20% trees, 60% grass, and 10% buildings and 10% bare soil",11,Residential,Dense urban,0.8,0.8,0.8,0.1,1,-1,-1,-1,3,0.66,high,#31a354,71.0047414,1.3872,95.36394864,7.6384,51.81402439,212.31,37.03522039
-288,11220,22,"Developed, Low Intensity","20% trees, 40% grass, and 40% buildings",11,Residential,Dense urban,0.8,0.8,0.8,0.1,1,-1,-1,-1,0,0,none,#ffffff,20.90844667,3.52,72.06732319,0.61,207.2560976,849.24,147.1338816
-289,11221,22,"Developed, Low Intensity","20% trees, 40% grass, and 40% buildings",11,Residential,Dense urban,0.8,0.8,0.8,0.1,1,-1,-1,-1,1,0.15,low,#e5f5e0,31.9391771,2.992,76.82521326,2.1185,207.2560976,849.24,147.1338816
-290,11222,22,"Developed, Low Intensity","20% trees, 40% grass, and 40% buildings",11,Residential,Dense urban,0.8,0.8,0.8,0.1,1,-1,-1,-1,2,0.4,medium,#a1d99b,50.32372781,2.112,84.75503004,4.632666667,207.2560976,849.24,147.1338816
-291,11223,22,"Developed, Low Intensity","20% trees, 40% grass, and 40% buildings",11,Residential,Dense urban,0.8,0.8,0.8,0.1,1,-1,-1,-1,3,0.66,high,#31a354,69.44366054,1.1968,93.0020395,7.2474,207.2560976,849.24,147.1338816
-292,11230,23,"Developed, Medium Intensity","15% trees, 35% grass, and 50% buildings",11,Residential,Dense urban,0.8,0.8,0.8,0.1,1,-1,-1,-1,0,0,none,#ffffff,17.69813636,3.08,61.93838294,0.36,234.070122,954.85,720.4716833
-293,11231,23,"Developed, Medium Intensity","15% trees, 35% grass, and 50% buildings",11,Residential,Dense urban,0.8,0.8,0.8,0.1,1,-1,-1,-1,1,0.15,low,#e5f5e0,29.21041333,2.618,68.21561405,1.906,234.070122,954.85,720.4716833
-294,11232,23,"Developed, Medium Intensity","15% trees, 35% grass, and 50% buildings",11,Residential,Dense urban,0.8,0.8,0.8,0.1,1,-1,-1,-1,2,0.4,medium,#a1d99b,48.39754162,1.848,78.67766589,4.482666667,234.070122,954.85,720.4716833
-295,11233,23,"Developed, Medium Intensity","15% trees, 35% grass, and 50% buildings",11,Residential,Dense urban,0.8,0.8,0.8,0.1,1,-1,-1,-1,3,0.66,high,#31a354,68.35215504,1.0472,89.55819981,7.1624,234.070122,954.85,720.4716833
-296,11240,24,"Developed, High Intensity","10% trees, 20% grass, and 70% buildings",11,Residential,Dense urban,0.8,0.8,0.8,0.1,1,-1,-1,-1,0,0,none,#ffffff,10.98142029,1.76,44.78642515,0.245,267.9065041,3418.485,1805.616283
-297,11241,24,"Developed, High Intensity","10% trees, 20% grass, and 70% buildings",11,Residential,Dense urban,0.8,0.8,0.8,0.1,1,-1,-1,-1,1,0.15,low,#e5f5e0,23.50120467,1.496,53.63644993,1.80825,267.9065041,3418.485,1805.616283
-298,11242,24,"Developed, High Intensity","10% trees, 20% grass, and 70% buildings",11,Residential,Dense urban,0.8,0.8,0.8,0.1,1,-1,-1,-1,2,0.4,medium,#a1d99b,44.36751198,1.056,68.38649122,4.413666667,267.9065041,3418.485,1805.616283
-299,11243,24,"Developed, High Intensity","10% trees, 20% grass, and 70% buildings",11,Residential,Dense urban,0.8,0.8,0.8,0.1,1,-1,-1,-1,3,0.66,high,#31a354,66.06847158,0.5984,83.72653416,7.1233,267.9065041,3418.485,1805.616283
-300,11310,31,Barren Land,,11,Residential,Dense urban,0.8,0.8,0.8,0.1,1,-1,-1,-1,0,0,none,#ffffff,6.8,0,25.5,0,0,0,0
-301,11311,31,Barren Land,,11,Residential,Dense urban,0.8,0.8,0.8,0.1,1,-1,-1,-1,1,0.15,low,#e5f5e0,19.94699743,0,37.24298855,1.6,0,0,0
-302,11312,31,Barren Land,,11,Residential,Dense urban,0.8,0.8,0.8,0.1,1,-1,-1,-1,2,0.4,medium,#a1d99b,41.8586598,0,56.81463613,4.266666667,0,0,0
-303,11313,31,Barren Land,,11,Residential,Dense urban,0.8,0.8,0.8,0.1,1,-1,-1,-1,3,0.66,high,#31a354,64.64678868,0,77.16914961,7.04,0,0,0
-304,11410,41,Deciduous Forest,,11,Residential,Dense urban,-1,0.8,-1,-1,1,-1,-1,-1,0,0,none,#ffffff,85.88498714,0,96.08994273,8.8,0,0,0
-305,11411,41,Deciduous Forest,,11,Residential,Dense urban,-1,0.8,-1,-1,1,-1,-1,-1,1,0.15,low,#e5f5e0,85.88498714,0,96.08994273,8.8,0,0,0
-306,11412,41,Deciduous Forest,,11,Residential,Dense urban,-1,0.8,-1,-1,1,-1,-1,-1,2,0.4,medium,#a1d99b,85.88498714,0,96.08994273,8.8,0,0,0
-307,11413,41,Deciduous Forest,,11,Residential,Dense urban,-1,0.8,-1,-1,1,-1,-1,-1,3,0.66,high,#31a354,85.88498714,0,96.08994273,8.8,0,0,0
-308,11420,42,Evergreen Forest,,11,Residential,Dense urban,-1,0.8,-1,-1,1,-1,-1,-1,0,0,none,#ffffff,105.6849871,0,96.08994273,14.4,0,0,0
-309,11421,42,Evergreen Forest,,11,Residential,Dense urban,-1,0.8,-1,-1,1,-1,-1,-1,1,0.15,low,#e5f5e0,105.6849871,0,96.08994273,14.4,0,0,0
-310,11422,42,Evergreen Forest,,11,Residential,Dense urban,-1,0.8,-1,-1,1,-1,-1,-1,2,0.4,medium,#a1d99b,105.6849871,0,96.08994273,14.4,0,0,0
-311,11423,42,Evergreen Forest,,11,Residential,Dense urban,-1,0.8,-1,-1,1,-1,-1,-1,3,0.66,high,#31a354,105.6849871,0,96.08994273,14.4,0,0,0
-312,11430,43,Mixed Forest,,11,Residential,Dense urban,-1,0.8,-1,-1,1,-1,-1,-1,0,0,none,#ffffff,91.76997429,0,119.1798855,8.8,0,0,0
-313,11431,43,Mixed Forest,,11,Residential,Dense urban,-1,0.8,-1,-1,1,-1,-1,-1,1,0.15,low,#e5f5e0,91.76997429,0,119.1798855,8.8,0,0,0
-314,11432,43,Mixed Forest,,11,Residential,Dense urban,-1,0.8,-1,-1,1,-1,-1,-1,2,0.4,medium,#a1d99b,91.76997429,0,119.1798855,8.8,0,0,0
-315,11433,43,Mixed Forest,,11,Residential,Dense urban,-1,0.8,-1,-1,1,-1,-1,-1,3,0.66,high,#31a354,91.76997429,0,119.1798855,8.8,0,0,0
-316,11520,52,Shrub/Scrub,,11,Residential,Dense urban,0.8,0.8,0.8,0.1,1,-1,-1,-1,0,0,none,#ffffff,47.875,0,68.15477645,0,0,0,0
-317,11521,52,Shrub/Scrub,,11,Residential,Dense urban,0.8,0.8,0.8,0.1,1,-1,-1,-1,1,0.15,low,#e5f5e0,54.86074743,0,73.49954853,1.6,0,0,0
-318,11522,52,Shrub/Scrub,,11,Residential,Dense urban,0.8,0.8,0.8,0.1,1,-1,-1,-1,2,0.4,medium,#a1d99b,66.5036598,0,82.407502,4.266666667,0,0,0
-319,11523,52,Shrub/Scrub,,11,Residential,Dense urban,0.8,0.8,0.8,0.1,1,-1,-1,-1,3,0.66,high,#31a354,78.61228868,0,91.6717736,7.04,0,0,0
-320,11710,71,Herbaceuous,,11,Residential,Dense urban,0.8,0.8,0.8,0.1,1,-1,-1,-1,0,0,none,#ffffff,10.10660117,8,98.79264417,0,0,0,0
-321,11711,71,Herbaceuous,,11,Residential,Dense urban,0.8,0.8,0.8,0.1,1,-1,-1,-1,1,0.15,low,#e5f5e0,22.75760842,6.8,99.54173609,1.6,0,0,0
-322,11712,71,Herbaceuous,,11,Residential,Dense urban,0.8,0.8,0.8,0.1,1,-1,-1,-1,2,0.4,medium,#a1d99b,43.84262051,4.8,100.7902226,4.266666667,0,0,0
-323,11713,71,Herbaceuous,,11,Residential,Dense urban,0.8,0.8,0.8,0.1,1,-1,-1,-1,3,0.66,high,#31a354,65.77103307,2.72,102.0886486,7.04,0,0,0
-324,11810,81,Hay/Pasture,,11,Residential,Dense urban,0.8,0.8,0.8,0.1,1,-1,-1,-1,0,0,none,#ffffff,10.10660117,8,98.79264417,0,0,0,0
-325,11811,81,Hay/Pasture,,11,Residential,Dense urban,0.8,0.8,0.8,0.1,1,-1,-1,-1,1,0.15,low,#e5f5e0,22.75760842,6.8,99.54173609,1.6,0,0,0
-326,11812,81,Hay/Pasture,,11,Residential,Dense urban,0.8,0.8,0.8,0.1,1,-1,-1,-1,2,0.4,medium,#a1d99b,43.84262051,4.8,100.7902226,4.266666667,0,0,0
-327,11813,81,Hay/Pasture,,11,Residential,Dense urban,0.8,0.8,0.8,0.1,1,-1,-1,-1,3,0.66,high,#31a354,65.77103307,2.72,102.0886486,7.04,0,0,0
-328,11820,82,Cultivated Crops,,11,Residential,Dense urban,0.8,0.8,0.8,-1,-1,-1,-1,-1,0,0,none,#ffffff,4.793840162,0,65.75263422,0,0,0,0
-329,11821,82,Cultivated Crops,,11,Residential,Dense urban,0.8,0.8,0.8,-1,-1,-1,-1,-1,1,0.15,low,#e5f5e0,18.24176156,0,71.45772764,1.6,0,0,0
-330,11822,82,Cultivated Crops,,11,Residential,Dense urban,0.8,0.8,0.8,-1,-1,-1,-1,-1,2,0.4,medium,#a1d99b,40.6549639,0,80.96621666,4.266666667,0,0,0
-331,11823,82,Cultivated Crops,,11,Residential,Dense urban,0.8,0.8,0.8,-1,-1,-1,-1,-1,3,0.66,high,#31a354,63.96469433,0,90.85504525,7.04,0,0,0
-332,11900,90,Woody Wetlands,,11,Residential,Dense urban,0.8,0.8,-1,-1,1,-1,-1,-1,0,0,none,#ffffff,33.5,0,259,0,0,0,0
-333,11901,90,Woody Wetlands,,11,Residential,Dense urban,0.8,0.8,-1,-1,1,-1,-1,-1,1,0.15,low,#e5f5e0,42.64199743,0,235.7179885,1.6,0,0,0
-334,11902,90,Woody Wetlands,,11,Residential,Dense urban,0.8,0.8,-1,-1,1,-1,-1,-1,2,0.4,medium,#a1d99b,57.8786598,0,196.9146361,4.266666667,0,0,0
-335,11903,90,Woody Wetlands,,11,Residential,Dense urban,0.8,0.8,-1,-1,1,-1,-1,-1,3,0.66,high,#31a354,73.72478868,0,156.5591496,7.04,0,0,0
-336,11950,95,Emergent Herbaceuous Wetlands,,11,Residential,Dense urban,0.8,0.8,-1,-1,1,-1,-1,-1,0,0,none,#ffffff,33.5,0,259,0,0,0,0
-337,11951,95,Emergent Herbaceuous Wetlands,,11,Residential,Dense urban,0.8,0.8,-1,-1,1,-1,-1,-1,1,0.15,low,#e5f5e0,42.64199743,0,235.7179885,1.6,0,0,0
-338,11952,95,Emergent Herbaceuous Wetlands,,11,Residential,Dense urban,0.8,0.8,-1,-1,1,-1,-1,-1,2,0.4,medium,#a1d99b,57.8786598,0,196.9146361,4.266666667,0,0,0
-339,11953,95,Emergent Herbaceuous Wetlands,,11,Residential,Dense urban,0.8,0.8,-1,-1,1,-1,-1,-1,3,0.66,high,#31a354,73.72478868,0,156.5591496,7.04,0,0,0
-340,12000,0,Background,,12,Residential,Urban,-1,-1,-1,-1,-1,-1,-1,-1,0,0,none,#ffffff,0,0,0,0,0,0,0
-341,12001,0,Background,,12,Residential,Urban,-1,-1,-1,-1,-1,-1,-1,-1,1,0.15,low,#e5f5e0,14.16699743,0,15.56798855,1.6,0,0,0
-342,12002,0,Background,,12,Residential,Urban,-1,-1,-1,-1,-1,-1,-1,-1,2,0.4,medium,#a1d99b,37.7786598,0,41.51463613,4.266666667,0,0,0
-343,12003,0,Background,,12,Residential,Urban,-1,-1,-1,-1,-1,-1,-1,-1,3,0.66,high,#31a354,62.33478868,0,68.49914961,7.04,0,0,0
-344,12110,11,Open Water,,12,Residential,Urban,-1,-1,-1,-1,-1,-1,-1,-1,0,0,none,#ffffff,0,0,0,0,0,0,0
-345,12111,11,Open Water,,12,Residential,Urban,-1,-1,-1,-1,-1,-1,-1,-1,1,0.15,low,#e5f5e0,14.16699743,0,15.56798855,1.6,0,0,0
-346,12112,11,Open Water,,12,Residential,Urban,-1,-1,-1,-1,-1,-1,-1,-1,2,0.4,medium,#a1d99b,37.7786598,0,41.51463613,4.266666667,0,0,0
-347,12113,11,Open Water,,12,Residential,Urban,-1,-1,-1,-1,-1,-1,-1,-1,3,0.66,high,#31a354,62.33478868,0,68.49914961,7.04,0,0,0
-348,12120,12,Perennial Ice/Snow,,12,Residential,Urban,-1,-1,-1,-1,-1,-1,-1,-1,0,0,none,#ffffff,0,0,0,0,0,0,0
-349,12121,12,Perennial Ice/Snow,,12,Residential,Urban,-1,-1,-1,-1,-1,-1,-1,-1,1,0.15,low,#e5f5e0,14.16699743,0,15.56798855,1.6,0,0,0
-350,12122,12,Perennial Ice/Snow,,12,Residential,Urban,-1,-1,-1,-1,-1,-1,-1,-1,2,0.4,medium,#a1d99b,37.7786598,0,41.51463613,4.266666667,0,0,0
-351,12123,12,Perennial Ice/Snow,,12,Residential,Urban,-1,-1,-1,-1,-1,-1,-1,-1,3,0.66,high,#31a354,62.33478868,0,68.49914961,7.04,0,0,0
-352,12210,21,"Developed, Open Space","20% trees, 60% grass, and 10% buildings and 10% bare soil",12,Residential,Urban,0.8,0.8,0.8,0.3,1,-1,-1,-1,0,0,none,#ffffff,25.49986095,4.08,79.01411479,1.76,51.81402439,212.31,37.03522039
-353,12211,21,"Developed, Open Space","20% trees, 60% grass, and 10% buildings and 10% bare soil",12,Residential,Urban,0.8,0.8,0.8,0.3,1,-1,-1,-1,1,0.15,low,#e5f5e0,35.84187923,3.468,82.72998612,3.096,51.81402439,212.31,37.03522039
-354,12212,21,"Developed, Open Space","20% trees, 60% grass, and 10% buildings and 10% bare soil",12,Residential,Urban,0.8,0.8,0.8,0.3,1,-1,-1,-1,2,0.4,medium,#a1d99b,53.07857637,2.448,88.923105,5.322666667,51.81402439,212.31,37.03522039
-355,12213,21,"Developed, Open Space","20% trees, 60% grass, and 10% buildings and 10% bare soil",12,Residential,Urban,0.8,0.8,0.8,0.3,1,-1,-1,-1,3,0.66,high,#31a354,71.0047414,1.3872,95.36394864,7.6384,51.81402439,212.31,37.03522039
-356,12220,22,"Developed, Low Intensity","20% trees, 40% grass, and 40% buildings",12,Residential,Urban,0.8,0.8,0.8,0.3,1,-1,-1,-1,0,0,none,#ffffff,20.90844667,3.52,72.06732319,0.61,207.2560976,849.24,147.1338816
-357,12221,22,"Developed, Low Intensity","20% trees, 40% grass, and 40% buildings",12,Residential,Urban,0.8,0.8,0.8,0.3,1,-1,-1,-1,1,0.15,low,#e5f5e0,31.9391771,2.992,76.82521326,2.1185,207.2560976,849.24,147.1338816
-358,12222,22,"Developed, Low Intensity","20% trees, 40% grass, and 40% buildings",12,Residential,Urban,0.8,0.8,0.8,0.3,1,-1,-1,-1,2,0.4,medium,#a1d99b,50.32372781,2.112,84.75503004,4.632666667,207.2560976,849.24,147.1338816
-359,12223,22,"Developed, Low Intensity","20% trees, 40% grass, and 40% buildings",12,Residential,Urban,0.8,0.8,0.8,0.3,1,-1,-1,-1,3,0.66,high,#31a354,69.44366054,1.1968,93.0020395,7.2474,207.2560976,849.24,147.1338816
-360,12230,23,"Developed, Medium Intensity","15% trees, 35% grass, and 50% buildings",12,Residential,Urban,0.8,0.8,0.8,0.3,1,-1,-1,-1,0,0,none,#ffffff,17.69813636,3.08,61.93838294,0.36,234.070122,954.85,720.4716833
-361,12231,23,"Developed, Medium Intensity","15% trees, 35% grass, and 50% buildings",12,Residential,Urban,0.8,0.8,0.8,0.3,1,-1,-1,-1,1,0.15,low,#e5f5e0,29.21041333,2.618,68.21561405,1.906,234.070122,954.85,720.4716833
-362,12232,23,"Developed, Medium Intensity","15% trees, 35% grass, and 50% buildings",12,Residential,Urban,0.8,0.8,0.8,0.3,1,-1,-1,-1,2,0.4,medium,#a1d99b,48.39754162,1.848,78.67766589,4.482666667,234.070122,954.85,720.4716833
-363,12233,23,"Developed, Medium Intensity","15% trees, 35% grass, and 50% buildings",12,Residential,Urban,0.8,0.8,0.8,0.3,1,-1,-1,-1,3,0.66,high,#31a354,68.35215504,1.0472,89.55819981,7.1624,234.070122,954.85,720.4716833
-364,12240,24,"Developed, High Intensity","10% trees, 20% grass, and 70% buildings",12,Residential,Urban,0.8,0.8,0.8,0.3,1,-1,-1,-1,0,0,none,#ffffff,10.98142029,1.76,44.78642515,0.245,267.9065041,3418.485,1805.616283
-365,12241,24,"Developed, High Intensity","10% trees, 20% grass, and 70% buildings",12,Residential,Urban,0.8,0.8,0.8,0.3,1,-1,-1,-1,1,0.15,low,#e5f5e0,23.50120467,1.496,53.63644993,1.80825,267.9065041,3418.485,1805.616283
-366,12242,24,"Developed, High Intensity","10% trees, 20% grass, and 70% buildings",12,Residential,Urban,0.8,0.8,0.8,0.3,1,-1,-1,-1,2,0.4,medium,#a1d99b,44.36751198,1.056,68.38649122,4.413666667,267.9065041,3418.485,1805.616283
-367,12243,24,"Developed, High Intensity","10% trees, 20% grass, and 70% buildings",12,Residential,Urban,0.8,0.8,0.8,0.3,1,-1,-1,-1,3,0.66,high,#31a354,66.06847158,0.5984,83.72653416,7.1233,267.9065041,3418.485,1805.616283
-368,12310,31,Barren Land,,12,Residential,Urban,0.8,0.8,0.8,0.3,1,-1,-1,-1,0,0,none,#ffffff,6.8,0,25.5,0,0,0,0
-369,12311,31,Barren Land,,12,Residential,Urban,0.8,0.8,0.8,0.3,1,-1,-1,-1,1,0.15,low,#e5f5e0,19.94699743,0,37.24298855,1.6,0,0,0
-370,12312,31,Barren Land,,12,Residential,Urban,0.8,0.8,0.8,0.3,1,-1,-1,-1,2,0.4,medium,#a1d99b,41.8586598,0,56.81463613,4.266666667,0,0,0
-371,12313,31,Barren Land,,12,Residential,Urban,0.8,0.8,0.8,0.3,1,-1,-1,-1,3,0.66,high,#31a354,64.64678868,0,77.16914961,7.04,0,0,0
-372,12410,41,Deciduous Forest,,12,Residential,Urban,-1,0.8,-1,-1,1,-1,-1,-1,0,0,none,#ffffff,85.88498714,0,96.08994273,8.8,0,0,0
-373,12411,41,Deciduous Forest,,12,Residential,Urban,-1,0.8,-1,-1,1,-1,-1,-1,1,0.15,low,#e5f5e0,85.88498714,0,96.08994273,8.8,0,0,0
-374,12412,41,Deciduous Forest,,12,Residential,Urban,-1,0.8,-1,-1,1,-1,-1,-1,2,0.4,medium,#a1d99b,85.88498714,0,96.08994273,8.8,0,0,0
-375,12413,41,Deciduous Forest,,12,Residential,Urban,-1,0.8,-1,-1,1,-1,-1,-1,3,0.66,high,#31a354,85.88498714,0,96.08994273,8.8,0,0,0
-376,12420,42,Evergreen Forest,,12,Residential,Urban,-1,0.8,-1,-1,1,-1,-1,-1,0,0,none,#ffffff,105.6849871,0,96.08994273,14.4,0,0,0
-377,12421,42,Evergreen Forest,,12,Residential,Urban,-1,0.8,-1,-1,1,-1,-1,-1,1,0.15,low,#e5f5e0,105.6849871,0,96.08994273,14.4,0,0,0
-378,12422,42,Evergreen Forest,,12,Residential,Urban,-1,0.8,-1,-1,1,-1,-1,-1,2,0.4,medium,#a1d99b,105.6849871,0,96.08994273,14.4,0,0,0
-379,12423,42,Evergreen Forest,,12,Residential,Urban,-1,0.8,-1,-1,1,-1,-1,-1,3,0.66,high,#31a354,105.6849871,0,96.08994273,14.4,0,0,0
-380,12430,43,Mixed Forest,,12,Residential,Urban,-1,0.8,-1,-1,1,-1,-1,-1,0,0,none,#ffffff,91.76997429,0,119.1798855,8.8,0,0,0
-381,12431,43,Mixed Forest,,12,Residential,Urban,-1,0.8,-1,-1,1,-1,-1,-1,1,0.15,low,#e5f5e0,91.76997429,0,119.1798855,8.8,0,0,0
-382,12432,43,Mixed Forest,,12,Residential,Urban,-1,0.8,-1,-1,1,-1,-1,-1,2,0.4,medium,#a1d99b,91.76997429,0,119.1798855,8.8,0,0,0
-383,12433,43,Mixed Forest,,12,Residential,Urban,-1,0.8,-1,-1,1,-1,-1,-1,3,0.66,high,#31a354,91.76997429,0,119.1798855,8.8,0,0,0
-384,12520,52,Shrub/Scrub,,12,Residential,Urban,0.8,0.8,0.8,0.3,1,-1,-1,-1,0,0,none,#ffffff,47.875,0,68.15477645,0,0,0,0
-385,12521,52,Shrub/Scrub,,12,Residential,Urban,0.8,0.8,0.8,0.3,1,-1,-1,-1,1,0.15,low,#e5f5e0,54.86074743,0,73.49954853,1.6,0,0,0
-386,12522,52,Shrub/Scrub,,12,Residential,Urban,0.8,0.8,0.8,0.3,1,-1,-1,-1,2,0.4,medium,#a1d99b,66.5036598,0,82.407502,4.266666667,0,0,0
-387,12523,52,Shrub/Scrub,,12,Residential,Urban,0.8,0.8,0.8,0.3,1,-1,-1,-1,3,0.66,high,#31a354,78.61228868,0,91.6717736,7.04,0,0,0
-388,12710,71,Herbaceuous,,12,Residential,Urban,0.8,0.8,0.8,0.3,1,-1,-1,-1,0,0,none,#ffffff,10.10660117,8,98.79264417,0,0,0,0
-389,12711,71,Herbaceuous,,12,Residential,Urban,0.8,0.8,0.8,0.3,1,-1,-1,-1,1,0.15,low,#e5f5e0,22.75760842,6.8,99.54173609,1.6,0,0,0
-390,12712,71,Herbaceuous,,12,Residential,Urban,0.8,0.8,0.8,0.3,1,-1,-1,-1,2,0.4,medium,#a1d99b,43.84262051,4.8,100.7902226,4.266666667,0,0,0
-391,12713,71,Herbaceuous,,12,Residential,Urban,0.8,0.8,0.8,0.3,1,-1,-1,-1,3,0.66,high,#31a354,65.77103307,2.72,102.0886486,7.04,0,0,0
-392,12810,81,Hay/Pasture,,12,Residential,Urban,0.8,0.8,0.8,0.3,1,-1,-1,-1,0,0,none,#ffffff,10.10660117,8,98.79264417,0,0,0,0
-393,12811,81,Hay/Pasture,,12,Residential,Urban,0.8,0.8,0.8,0.3,1,-1,-1,-1,1,0.15,low,#e5f5e0,22.75760842,6.8,99.54173609,1.6,0,0,0
-394,12812,81,Hay/Pasture,,12,Residential,Urban,0.8,0.8,0.8,0.3,1,-1,-1,-1,2,0.4,medium,#a1d99b,43.84262051,4.8,100.7902226,4.266666667,0,0,0
-395,12813,81,Hay/Pasture,,12,Residential,Urban,0.8,0.8,0.8,0.3,1,-1,-1,-1,3,0.66,high,#31a354,65.77103307,2.72,102.0886486,7.04,0,0,0
-396,12820,82,Cultivated Crops,,12,Residential,Urban,0.8,0.8,0.8,-1,-1,-1,-1,-1,0,0,none,#ffffff,4.793840162,0,65.75263422,0,0,0,0
-397,12821,82,Cultivated Crops,,12,Residential,Urban,0.8,0.8,0.8,-1,-1,-1,-1,-1,1,0.15,low,#e5f5e0,18.24176156,0,71.45772764,1.6,0,0,0
-398,12822,82,Cultivated Crops,,12,Residential,Urban,0.8,0.8,0.8,-1,-1,-1,-1,-1,2,0.4,medium,#a1d99b,40.6549639,0,80.96621666,4.266666667,0,0,0
-399,12823,82,Cultivated Crops,,12,Residential,Urban,0.8,0.8,0.8,-1,-1,-1,-1,-1,3,0.66,high,#31a354,63.96469433,0,90.85504525,7.04,0,0,0
-400,12900,90,Woody Wetlands,,12,Residential,Urban,0.8,0.8,-1,-1,1,-1,-1,-1,0,0,none,#ffffff,33.5,0,259,0,0,0,0
-401,12901,90,Woody Wetlands,,12,Residential,Urban,0.8,0.8,-1,-1,1,-1,-1,-1,1,0.15,low,#e5f5e0,42.64199743,0,235.7179885,1.6,0,0,0
-402,12902,90,Woody Wetlands,,12,Residential,Urban,0.8,0.8,-1,-1,1,-1,-1,-1,2,0.4,medium,#a1d99b,57.8786598,0,196.9146361,4.266666667,0,0,0
-403,12903,90,Woody Wetlands,,12,Residential,Urban,0.8,0.8,-1,-1,1,-1,-1,-1,3,0.66,high,#31a354,73.72478868,0,156.5591496,7.04,0,0,0
-404,12950,95,Emergent Herbaceuous Wetlands,,12,Residential,Urban,0.8,0.8,-1,-1,1,-1,-1,-1,0,0,none,#ffffff,33.5,0,259,0,0,0,0
-405,12951,95,Emergent Herbaceuous Wetlands,,12,Residential,Urban,0.8,0.8,-1,-1,1,-1,-1,-1,1,0.15,low,#e5f5e0,42.64199743,0,235.7179885,1.6,0,0,0
-406,12952,95,Emergent Herbaceuous Wetlands,,12,Residential,Urban,0.8,0.8,-1,-1,1,-1,-1,-1,2,0.4,medium,#a1d99b,57.8786598,0,196.9146361,4.266666667,0,0,0
-407,12953,95,Emergent Herbaceuous Wetlands,,12,Residential,Urban,0.8,0.8,-1,-1,1,-1,-1,-1,3,0.66,high,#31a354,73.72478868,0,156.5591496,7.04,0,0,0
-408,13000,0,Background,,13,Residential,Suburban,-1,-1,-1,-1,-1,-1,-1,-1,0,0,none,#ffffff,0,0,0,0,0,0,0
-409,13001,0,Background,,13,Residential,Suburban,-1,-1,-1,-1,-1,-1,-1,-1,1,0.15,low,#e5f5e0,14.16699743,0,15.56798855,1.6,0,0,0
-410,13002,0,Background,,13,Residential,Suburban,-1,-1,-1,-1,-1,-1,-1,-1,2,0.4,medium,#a1d99b,37.7786598,0,41.51463613,4.266666667,0,0,0
-411,13003,0,Background,,13,Residential,Suburban,-1,-1,-1,-1,-1,-1,-1,-1,3,0.66,high,#31a354,62.33478868,0,68.49914961,7.04,0,0,0
-412,13110,11,Open Water,,13,Residential,Suburban,-1,-1,-1,-1,-1,-1,-1,-1,0,0,none,#ffffff,0,0,0,0,0,0,0
-413,13111,11,Open Water,,13,Residential,Suburban,-1,-1,-1,-1,-1,-1,-1,-1,1,0.15,low,#e5f5e0,14.16699743,0,15.56798855,1.6,0,0,0
-414,13112,11,Open Water,,13,Residential,Suburban,-1,-1,-1,-1,-1,-1,-1,-1,2,0.4,medium,#a1d99b,37.7786598,0,41.51463613,4.266666667,0,0,0
-415,13113,11,Open Water,,13,Residential,Suburban,-1,-1,-1,-1,-1,-1,-1,-1,3,0.66,high,#31a354,62.33478868,0,68.49914961,7.04,0,0,0
-416,13120,12,Perennial Ice/Snow,,13,Residential,Suburban,-1,-1,-1,-1,-1,-1,-1,-1,0,0,none,#ffffff,0,0,0,0,0,0,0
-417,13121,12,Perennial Ice/Snow,,13,Residential,Suburban,-1,-1,-1,-1,-1,-1,-1,-1,1,0.15,low,#e5f5e0,14.16699743,0,15.56798855,1.6,0,0,0
-418,13122,12,Perennial Ice/Snow,,13,Residential,Suburban,-1,-1,-1,-1,-1,-1,-1,-1,2,0.4,medium,#a1d99b,37.7786598,0,41.51463613,4.266666667,0,0,0
-419,13123,12,Perennial Ice/Snow,,13,Residential,Suburban,-1,-1,-1,-1,-1,-1,-1,-1,3,0.66,high,#31a354,62.33478868,0,68.49914961,7.04,0,0,0
-420,13210,21,"Developed, Open Space","20% trees, 60% grass, and 10% buildings and 10% bare soil",13,Residential,Suburban,0.8,0.8,0.8,0.5,1,-1,-1,-1,0,0,none,#ffffff,25.49986095,4.08,79.01411479,1.76,51.81402439,212.31,37.03522039
-421,13211,21,"Developed, Open Space","20% trees, 60% grass, and 10% buildings and 10% bare soil",13,Residential,Suburban,0.8,0.8,0.8,0.5,1,-1,-1,-1,1,0.15,low,#e5f5e0,35.84187923,3.468,82.72998612,3.096,51.81402439,212.31,37.03522039
-422,13212,21,"Developed, Open Space","20% trees, 60% grass, and 10% buildings and 10% bare soil",13,Residential,Suburban,0.8,0.8,0.8,0.5,1,-1,-1,-1,2,0.4,medium,#a1d99b,53.07857637,2.448,88.923105,5.322666667,51.81402439,212.31,37.03522039
-423,13213,21,"Developed, Open Space","20% trees, 60% grass, and 10% buildings and 10% bare soil",13,Residential,Suburban,0.8,0.8,0.8,0.5,1,-1,-1,-1,3,0.66,high,#31a354,71.0047414,1.3872,95.36394864,7.6384,51.81402439,212.31,37.03522039
-424,13220,22,"Developed, Low Intensity","20% trees, 40% grass, and 40% buildings",13,Residential,Suburban,0.8,0.8,0.8,0.5,1,-1,-1,-1,0,0,none,#ffffff,20.90844667,3.52,72.06732319,0.61,207.2560976,849.24,147.1338816
-425,13221,22,"Developed, Low Intensity","20% trees, 40% grass, and 40% buildings",13,Residential,Suburban,0.8,0.8,0.8,0.5,1,-1,-1,-1,1,0.15,low,#e5f5e0,31.9391771,2.992,76.82521326,2.1185,207.2560976,849.24,147.1338816
-426,13222,22,"Developed, Low Intensity","20% trees, 40% grass, and 40% buildings",13,Residential,Suburban,0.8,0.8,0.8,0.5,1,-1,-1,-1,2,0.4,medium,#a1d99b,50.32372781,2.112,84.75503004,4.632666667,207.2560976,849.24,147.1338816
-427,13223,22,"Developed, Low Intensity","20% trees, 40% grass, and 40% buildings",13,Residential,Suburban,0.8,0.8,0.8,0.5,1,-1,-1,-1,3,0.66,high,#31a354,69.44366054,1.1968,93.0020395,7.2474,207.2560976,849.24,147.1338816
-428,13230,23,"Developed, Medium Intensity","15% trees, 35% grass, and 50% buildings",13,Residential,Suburban,0.8,0.8,0.8,0.5,1,-1,-1,-1,0,0,none,#ffffff,17.69813636,3.08,61.93838294,0.36,234.070122,954.85,720.4716833
-429,13231,23,"Developed, Medium Intensity","15% trees, 35% grass, and 50% buildings",13,Residential,Suburban,0.8,0.8,0.8,0.5,1,-1,-1,-1,1,0.15,low,#e5f5e0,29.21041333,2.618,68.21561405,1.906,234.070122,954.85,720.4716833
-430,13232,23,"Developed, Medium Intensity","15% trees, 35% grass, and 50% buildings",13,Residential,Suburban,0.8,0.8,0.8,0.5,1,-1,-1,-1,2,0.4,medium,#a1d99b,48.39754162,1.848,78.67766589,4.482666667,234.070122,954.85,720.4716833
-431,13233,23,"Developed, Medium Intensity","15% trees, 35% grass, and 50% buildings",13,Residential,Suburban,0.8,0.8,0.8,0.5,1,-1,-1,-1,3,0.66,high,#31a354,68.35215504,1.0472,89.55819981,7.1624,234.070122,954.85,720.4716833
-432,13240,24,"Developed, High Intensity","10% trees, 20% grass, and 70% buildings",13,Residential,Suburban,0.8,0.8,0.8,0.5,1,-1,-1,-1,0,0,none,#ffffff,10.98142029,1.76,44.78642515,0.245,267.9065041,3418.485,1805.616283
-433,13241,24,"Developed, High Intensity","10% trees, 20% grass, and 70% buildings",13,Residential,Suburban,0.8,0.8,0.8,0.5,1,-1,-1,-1,1,0.15,low,#e5f5e0,23.50120467,1.496,53.63644993,1.80825,267.9065041,3418.485,1805.616283
-434,13242,24,"Developed, High Intensity","10% trees, 20% grass, and 70% buildings",13,Residential,Suburban,0.8,0.8,0.8,0.5,1,-1,-1,-1,2,0.4,medium,#a1d99b,44.36751198,1.056,68.38649122,4.413666667,267.9065041,3418.485,1805.616283
-435,13243,24,"Developed, High Intensity","10% trees, 20% grass, and 70% buildings",13,Residential,Suburban,0.8,0.8,0.8,0.5,1,-1,-1,-1,3,0.66,high,#31a354,66.06847158,0.5984,83.72653416,7.1233,267.9065041,3418.485,1805.616283
-436,13310,31,Barren Land,,13,Residential,Suburban,0.8,0.8,0.8,0.5,1,-1,-1,-1,0,0,none,#ffffff,6.8,0,25.5,0,0,0,0
-437,13311,31,Barren Land,,13,Residential,Suburban,0.8,0.8,0.8,0.5,1,-1,-1,-1,1,0.15,low,#e5f5e0,19.94699743,0,37.24298855,1.6,0,0,0
-438,13312,31,Barren Land,,13,Residential,Suburban,0.8,0.8,0.8,0.5,1,-1,-1,-1,2,0.4,medium,#a1d99b,41.8586598,0,56.81463613,4.266666667,0,0,0
-439,13313,31,Barren Land,,13,Residential,Suburban,0.8,0.8,0.8,0.5,1,-1,-1,-1,3,0.66,high,#31a354,64.64678868,0,77.16914961,7.04,0,0,0
-440,13410,41,Deciduous Forest,,13,Residential,Suburban,-1,0.8,-1,-1,1,-1,-1,-1,0,0,none,#ffffff,85.88498714,0,96.08994273,8.8,0,0,0
-441,13411,41,Deciduous Forest,,13,Residential,Suburban,-1,0.8,-1,-1,1,-1,-1,-1,1,0.15,low,#e5f5e0,85.88498714,0,96.08994273,8.8,0,0,0
-442,13412,41,Deciduous Forest,,13,Residential,Suburban,-1,0.8,-1,-1,1,-1,-1,-1,2,0.4,medium,#a1d99b,85.88498714,0,96.08994273,8.8,0,0,0
-443,13413,41,Deciduous Forest,,13,Residential,Suburban,-1,0.8,-1,-1,1,-1,-1,-1,3,0.66,high,#31a354,85.88498714,0,96.08994273,8.8,0,0,0
-444,13420,42,Evergreen Forest,,13,Residential,Suburban,-1,0.8,-1,-1,1,-1,-1,-1,0,0,none,#ffffff,105.6849871,0,96.08994273,14.4,0,0,0
-445,13421,42,Evergreen Forest,,13,Residential,Suburban,-1,0.8,-1,-1,1,-1,-1,-1,1,0.15,low,#e5f5e0,105.6849871,0,96.08994273,14.4,0,0,0
-446,13422,42,Evergreen Forest,,13,Residential,Suburban,-1,0.8,-1,-1,1,-1,-1,-1,2,0.4,medium,#a1d99b,105.6849871,0,96.08994273,14.4,0,0,0
-447,13423,42,Evergreen Forest,,13,Residential,Suburban,-1,0.8,-1,-1,1,-1,-1,-1,3,0.66,high,#31a354,105.6849871,0,96.08994273,14.4,0,0,0
-448,13430,43,Mixed Forest,,13,Residential,Suburban,-1,0.8,-1,-1,1,-1,-1,-1,0,0,none,#ffffff,91.76997429,0,119.1798855,8.8,0,0,0
-449,13431,43,Mixed Forest,,13,Residential,Suburban,-1,0.8,-1,-1,1,-1,-1,-1,1,0.15,low,#e5f5e0,91.76997429,0,119.1798855,8.8,0,0,0
-450,13432,43,Mixed Forest,,13,Residential,Suburban,-1,0.8,-1,-1,1,-1,-1,-1,2,0.4,medium,#a1d99b,91.76997429,0,119.1798855,8.8,0,0,0
-451,13433,43,Mixed Forest,,13,Residential,Suburban,-1,0.8,-1,-1,1,-1,-1,-1,3,0.66,high,#31a354,91.76997429,0,119.1798855,8.8,0,0,0
-452,13520,52,Shrub/Scrub,,13,Residential,Suburban,0.8,0.8,0.8,0.5,1,-1,-1,-1,0,0,none,#ffffff,47.875,0,68.15477645,0,0,0,0
-453,13521,52,Shrub/Scrub,,13,Residential,Suburban,0.8,0.8,0.8,0.5,1,-1,-1,-1,1,0.15,low,#e5f5e0,54.86074743,0,73.49954853,1.6,0,0,0
-454,13522,52,Shrub/Scrub,,13,Residential,Suburban,0.8,0.8,0.8,0.5,1,-1,-1,-1,2,0.4,medium,#a1d99b,66.5036598,0,82.407502,4.266666667,0,0,0
-455,13523,52,Shrub/Scrub,,13,Residential,Suburban,0.8,0.8,0.8,0.5,1,-1,-1,-1,3,0.66,high,#31a354,78.61228868,0,91.6717736,7.04,0,0,0
-456,13710,71,Herbaceuous,,13,Residential,Suburban,0.8,0.8,0.8,0.5,1,-1,-1,-1,0,0,none,#ffffff,10.10660117,8,98.79264417,0,0,0,0
-457,13711,71,Herbaceuous,,13,Residential,Suburban,0.8,0.8,0.8,0.5,1,-1,-1,-1,1,0.15,low,#e5f5e0,22.75760842,6.8,99.54173609,1.6,0,0,0
-458,13712,71,Herbaceuous,,13,Residential,Suburban,0.8,0.8,0.8,0.5,1,-1,-1,-1,2,0.4,medium,#a1d99b,43.84262051,4.8,100.7902226,4.266666667,0,0,0
-459,13713,71,Herbaceuous,,13,Residential,Suburban,0.8,0.8,0.8,0.5,1,-1,-1,-1,3,0.66,high,#31a354,65.77103307,2.72,102.0886486,7.04,0,0,0
-460,13810,81,Hay/Pasture,,13,Residential,Suburban,0.8,0.8,0.8,0.5,1,-1,-1,-1,0,0,none,#ffffff,10.10660117,8,98.79264417,0,0,0,0
-461,13811,81,Hay/Pasture,,13,Residential,Suburban,0.8,0.8,0.8,0.5,1,-1,-1,-1,1,0.15,low,#e5f5e0,22.75760842,6.8,99.54173609,1.6,0,0,0
-462,13812,81,Hay/Pasture,,13,Residential,Suburban,0.8,0.8,0.8,0.5,1,-1,-1,-1,2,0.4,medium,#a1d99b,43.84262051,4.8,100.7902226,4.266666667,0,0,0
-463,13813,81,Hay/Pasture,,13,Residential,Suburban,0.8,0.8,0.8,0.5,1,-1,-1,-1,3,0.66,high,#31a354,65.77103307,2.72,102.0886486,7.04,0,0,0
-464,13820,82,Cultivated Crops,,13,Residential,Suburban,0.8,0.8,0.8,-1,-1,-1,-1,-1,0,0,none,#ffffff,4.793840162,0,65.75263422,0,0,0,0
-465,13821,82,Cultivated Crops,,13,Residential,Suburban,0.8,0.8,0.8,-1,-1,-1,-1,-1,1,0.15,low,#e5f5e0,18.24176156,0,71.45772764,1.6,0,0,0
-466,13822,82,Cultivated Crops,,13,Residential,Suburban,0.8,0.8,0.8,-1,-1,-1,-1,-1,2,0.4,medium,#a1d99b,40.6549639,0,80.96621666,4.266666667,0,0,0
-467,13823,82,Cultivated Crops,,13,Residential,Suburban,0.8,0.8,0.8,-1,-1,-1,-1,-1,3,0.66,high,#31a354,63.96469433,0,90.85504525,7.04,0,0,0
-468,13900,90,Woody Wetlands,,13,Residential,Suburban,0.8,0.8,-1,-1,1,-1,-1,-1,0,0,none,#ffffff,33.5,0,259,0,0,0,0
-469,13901,90,Woody Wetlands,,13,Residential,Suburban,0.8,0.8,-1,-1,1,-1,-1,-1,1,0.15,low,#e5f5e0,42.64199743,0,235.7179885,1.6,0,0,0
-470,13902,90,Woody Wetlands,,13,Residential,Suburban,0.8,0.8,-1,-1,1,-1,-1,-1,2,0.4,medium,#a1d99b,57.8786598,0,196.9146361,4.266666667,0,0,0
-471,13903,90,Woody Wetlands,,13,Residential,Suburban,0.8,0.8,-1,-1,1,-1,-1,-1,3,0.66,high,#31a354,73.72478868,0,156.5591496,7.04,0,0,0
-472,13950,95,Emergent Herbaceuous Wetlands,,13,Residential,Suburban,0.8,0.8,-1,-1,1,-1,-1,-1,0,0,none,#ffffff,33.5,0,259,0,0,0,0
-473,13951,95,Emergent Herbaceuous Wetlands,,13,Residential,Suburban,0.8,0.8,-1,-1,1,-1,-1,-1,1,0.15,low,#e5f5e0,42.64199743,0,235.7179885,1.6,0,0,0
-474,13952,95,Emergent Herbaceuous Wetlands,,13,Residential,Suburban,0.8,0.8,-1,-1,1,-1,-1,-1,2,0.4,medium,#a1d99b,57.8786598,0,196.9146361,4.266666667,0,0,0
-475,13953,95,Emergent Herbaceuous Wetlands,,13,Residential,Suburban,0.8,0.8,-1,-1,1,-1,-1,-1,3,0.66,high,#31a354,73.72478868,0,156.5591496,7.04,0,0,0
-476,14000,0,Background,,14,Residential,Exurban,-1,-1,-1,-1,-1,-1,-1,-1,0,0,none,#ffffff,0,0,0,0,0,0,0
-477,14001,0,Background,,14,Residential,Exurban,-1,-1,-1,-1,-1,-1,-1,-1,1,0.15,low,#e5f5e0,14.16699743,0,15.56798855,1.6,0,0,0
-478,14002,0,Background,,14,Residential,Exurban,-1,-1,-1,-1,-1,-1,-1,-1,2,0.4,medium,#a1d99b,37.7786598,0,41.51463613,4.266666667,0,0,0
-479,14003,0,Background,,14,Residential,Exurban,-1,-1,-1,-1,-1,-1,-1,-1,3,0.66,high,#31a354,62.33478868,0,68.49914961,7.04,0,0,0
-480,14110,11,Open Water,,14,Residential,Exurban,-1,-1,-1,-1,-1,-1,-1,-1,0,0,none,#ffffff,0,0,0,0,0,0,0
-481,14111,11,Open Water,,14,Residential,Exurban,-1,-1,-1,-1,-1,-1,-1,-1,1,0.15,low,#e5f5e0,14.16699743,0,15.56798855,1.6,0,0,0
-482,14112,11,Open Water,,14,Residential,Exurban,-1,-1,-1,-1,-1,-1,-1,-1,2,0.4,medium,#a1d99b,37.7786598,0,41.51463613,4.266666667,0,0,0
-483,14113,11,Open Water,,14,Residential,Exurban,-1,-1,-1,-1,-1,-1,-1,-1,3,0.66,high,#31a354,62.33478868,0,68.49914961,7.04,0,0,0
-484,14120,12,Perennial Ice/Snow,,14,Residential,Exurban,-1,-1,-1,-1,-1,-1,-1,-1,0,0,none,#ffffff,0,0,0,0,0,0,0
-485,14121,12,Perennial Ice/Snow,,14,Residential,Exurban,-1,-1,-1,-1,-1,-1,-1,-1,1,0.15,low,#e5f5e0,14.16699743,0,15.56798855,1.6,0,0,0
-486,14122,12,Perennial Ice/Snow,,14,Residential,Exurban,-1,-1,-1,-1,-1,-1,-1,-1,2,0.4,medium,#a1d99b,37.7786598,0,41.51463613,4.266666667,0,0,0
-487,14123,12,Perennial Ice/Snow,,14,Residential,Exurban,-1,-1,-1,-1,-1,-1,-1,-1,3,0.66,high,#31a354,62.33478868,0,68.49914961,7.04,0,0,0
-488,14210,21,"Developed, Open Space","20% trees, 60% grass, and 10% buildings and 10% bare soil",14,Residential,Exurban,0.6,0.6,0.6,0.7,0.8,-1,-1,-1,0,0,none,#ffffff,25.49986095,4.08,79.01411479,1.76,51.81402439,212.31,37.03522039
-489,14211,21,"Developed, Open Space","20% trees, 60% grass, and 10% buildings and 10% bare soil",14,Residential,Exurban,0.6,0.6,0.6,0.7,0.8,-1,-1,-1,1,0.15,low,#e5f5e0,35.84187923,3.468,82.72998612,3.096,51.81402439,212.31,37.03522039
-490,14212,21,"Developed, Open Space","20% trees, 60% grass, and 10% buildings and 10% bare soil",14,Residential,Exurban,0.6,0.6,0.6,0.7,0.8,-1,-1,-1,2,0.4,medium,#a1d99b,53.07857637,2.448,88.923105,5.322666667,51.81402439,212.31,37.03522039
-491,14213,21,"Developed, Open Space","20% trees, 60% grass, and 10% buildings and 10% bare soil",14,Residential,Exurban,0.6,0.6,0.6,0.7,0.8,-1,-1,-1,3,0.66,high,#31a354,71.0047414,1.3872,95.36394864,7.6384,51.81402439,212.31,37.03522039
-492,14220,22,"Developed, Low Intensity","20% trees, 40% grass, and 40% buildings",14,Residential,Exurban,0.6,0.6,0.6,0.7,0.8,-1,-1,-1,0,0,none,#ffffff,20.90844667,3.52,72.06732319,0.61,207.2560976,849.24,147.1338816
-493,14221,22,"Developed, Low Intensity","20% trees, 40% grass, and 40% buildings",14,Residential,Exurban,0.6,0.6,0.6,0.7,0.8,-1,-1,-1,1,0.15,low,#e5f5e0,31.9391771,2.992,76.82521326,2.1185,207.2560976,849.24,147.1338816
-494,14222,22,"Developed, Low Intensity","20% trees, 40% grass, and 40% buildings",14,Residential,Exurban,0.6,0.6,0.6,0.7,0.8,-1,-1,-1,2,0.4,medium,#a1d99b,50.32372781,2.112,84.75503004,4.632666667,207.2560976,849.24,147.1338816
-495,14223,22,"Developed, Low Intensity","20% trees, 40% grass, and 40% buildings",14,Residential,Exurban,0.6,0.6,0.6,0.7,0.8,-1,-1,-1,3,0.66,high,#31a354,69.44366054,1.1968,93.0020395,7.2474,207.2560976,849.24,147.1338816
-496,14230,23,"Developed, Medium Intensity","15% trees, 35% grass, and 50% buildings",14,Residential,Exurban,0.6,0.6,0.6,0.7,0.8,-1,-1,-1,0,0,none,#ffffff,17.69813636,3.08,61.93838294,0.36,234.070122,954.85,720.4716833
-497,14231,23,"Developed, Medium Intensity","15% trees, 35% grass, and 50% buildings",14,Residential,Exurban,0.6,0.6,0.6,0.7,0.8,-1,-1,-1,1,0.15,low,#e5f5e0,29.21041333,2.618,68.21561405,1.906,234.070122,954.85,720.4716833
-498,14232,23,"Developed, Medium Intensity","15% trees, 35% grass, and 50% buildings",14,Residential,Exurban,0.6,0.6,0.6,0.7,0.8,-1,-1,-1,2,0.4,medium,#a1d99b,48.39754162,1.848,78.67766589,4.482666667,234.070122,954.85,720.4716833
-499,14233,23,"Developed, Medium Intensity","15% trees, 35% grass, and 50% buildings",14,Residential,Exurban,0.6,0.6,0.6,0.7,0.8,-1,-1,-1,3,0.66,high,#31a354,68.35215504,1.0472,89.55819981,7.1624,234.070122,954.85,720.4716833
-500,14240,24,"Developed, High Intensity","10% trees, 20% grass, and 70% buildings",14,Residential,Exurban,0.6,0.6,0.6,0.7,0.8,-1,-1,-1,0,0,none,#ffffff,10.98142029,1.76,44.78642515,0.245,267.9065041,3418.485,1805.616283
-501,14241,24,"Developed, High Intensity","10% trees, 20% grass, and 70% buildings",14,Residential,Exurban,0.6,0.6,0.6,0.7,0.8,-1,-1,-1,1,0.15,low,#e5f5e0,23.50120467,1.496,53.63644993,1.80825,267.9065041,3418.485,1805.616283
-502,14242,24,"Developed, High Intensity","10% trees, 20% grass, and 70% buildings",14,Residential,Exurban,0.6,0.6,0.6,0.7,0.8,-1,-1,-1,2,0.4,medium,#a1d99b,44.36751198,1.056,68.38649122,4.413666667,267.9065041,3418.485,1805.616283
-503,14243,24,"Developed, High Intensity","10% trees, 20% grass, and 70% buildings",14,Residential,Exurban,0.6,0.6,0.6,0.7,0.8,-1,-1,-1,3,0.66,high,#31a354,66.06847158,0.5984,83.72653416,7.1233,267.9065041,3418.485,1805.616283
-504,14310,31,Barren Land,,14,Residential,Exurban,0.6,0.6,0.6,0.7,0.8,-1,-1,-1,0,0,none,#ffffff,6.8,0,25.5,0,0,0,0
-505,14311,31,Barren Land,,14,Residential,Exurban,0.6,0.6,0.6,0.7,0.8,-1,-1,-1,1,0.15,low,#e5f5e0,19.94699743,0,37.24298855,1.6,0,0,0
-506,14312,31,Barren Land,,14,Residential,Exurban,0.6,0.6,0.6,0.7,0.8,-1,-1,-1,2,0.4,medium,#a1d99b,41.8586598,0,56.81463613,4.266666667,0,0,0
-507,14313,31,Barren Land,,14,Residential,Exurban,0.6,0.6,0.6,0.7,0.8,-1,-1,-1,3,0.66,high,#31a354,64.64678868,0,77.16914961,7.04,0,0,0
-508,14410,41,Deciduous Forest,,14,Residential,Exurban,-1,0.6,-1,-1,0.8,-1,-1,-1,0,0,none,#ffffff,85.88498714,0,96.08994273,8.8,0,0,0
-509,14411,41,Deciduous Forest,,14,Residential,Exurban,-1,0.6,-1,-1,0.8,-1,-1,-1,1,0.15,low,#e5f5e0,85.88498714,0,96.08994273,8.8,0,0,0
-510,14412,41,Deciduous Forest,,14,Residential,Exurban,-1,0.6,-1,-1,0.8,-1,-1,-1,2,0.4,medium,#a1d99b,85.88498714,0,96.08994273,8.8,0,0,0
-511,14413,41,Deciduous Forest,,14,Residential,Exurban,-1,0.6,-1,-1,0.8,-1,-1,-1,3,0.66,high,#31a354,85.88498714,0,96.08994273,8.8,0,0,0
-512,14420,42,Evergreen Forest,,14,Residential,Exurban,-1,0.6,-1,-1,0.8,-1,-1,-1,0,0,none,#ffffff,105.6849871,0,96.08994273,14.4,0,0,0
-513,14421,42,Evergreen Forest,,14,Residential,Exurban,-1,0.6,-1,-1,0.8,-1,-1,-1,1,0.15,low,#e5f5e0,105.6849871,0,96.08994273,14.4,0,0,0
-514,14422,42,Evergreen Forest,,14,Residential,Exurban,-1,0.6,-1,-1,0.8,-1,-1,-1,2,0.4,medium,#a1d99b,105.6849871,0,96.08994273,14.4,0,0,0
-515,14423,42,Evergreen Forest,,14,Residential,Exurban,-1,0.6,-1,-1,0.8,-1,-1,-1,3,0.66,high,#31a354,105.6849871,0,96.08994273,14.4,0,0,0
-516,14430,43,Mixed Forest,,14,Residential,Exurban,-1,0.6,-1,-1,0.8,-1,-1,-1,0,0,none,#ffffff,91.76997429,0,119.1798855,8.8,0,0,0
-517,14431,43,Mixed Forest,,14,Residential,Exurban,-1,0.6,-1,-1,0.8,-1,-1,-1,1,0.15,low,#e5f5e0,91.76997429,0,119.1798855,8.8,0,0,0
-518,14432,43,Mixed Forest,,14,Residential,Exurban,-1,0.6,-1,-1,0.8,-1,-1,-1,2,0.4,medium,#a1d99b,91.76997429,0,119.1798855,8.8,0,0,0
-519,14433,43,Mixed Forest,,14,Residential,Exurban,-1,0.6,-1,-1,0.8,-1,-1,-1,3,0.66,high,#31a354,91.76997429,0,119.1798855,8.8,0,0,0
-520,14520,52,Shrub/Scrub,,14,Residential,Exurban,0.6,0.6,0.6,0.7,0.8,-1,-1,-1,0,0,none,#ffffff,47.875,0,68.15477645,0,0,0,0
-521,14521,52,Shrub/Scrub,,14,Residential,Exurban,0.6,0.6,0.6,0.7,0.8,-1,-1,-1,1,0.15,low,#e5f5e0,54.86074743,0,73.49954853,1.6,0,0,0
-522,14522,52,Shrub/Scrub,,14,Residential,Exurban,0.6,0.6,0.6,0.7,0.8,-1,-1,-1,2,0.4,medium,#a1d99b,66.5036598,0,82.407502,4.266666667,0,0,0
-523,14523,52,Shrub/Scrub,,14,Residential,Exurban,0.6,0.6,0.6,0.7,0.8,-1,-1,-1,3,0.66,high,#31a354,78.61228868,0,91.6717736,7.04,0,0,0
-524,14710,71,Herbaceuous,,14,Residential,Exurban,0.6,0.6,0.6,0.7,0.8,-1,-1,-1,0,0,none,#ffffff,10.10660117,8,98.79264417,0,0,0,0
-525,14711,71,Herbaceuous,,14,Residential,Exurban,0.6,0.6,0.6,0.7,0.8,-1,-1,-1,1,0.15,low,#e5f5e0,22.75760842,6.8,99.54173609,1.6,0,0,0
-526,14712,71,Herbaceuous,,14,Residential,Exurban,0.6,0.6,0.6,0.7,0.8,-1,-1,-1,2,0.4,medium,#a1d99b,43.84262051,4.8,100.7902226,4.266666667,0,0,0
-527,14713,71,Herbaceuous,,14,Residential,Exurban,0.6,0.6,0.6,0.7,0.8,-1,-1,-1,3,0.66,high,#31a354,65.77103307,2.72,102.0886486,7.04,0,0,0
-528,14810,81,Hay/Pasture,,14,Residential,Exurban,0.6,0.6,0.6,0.7,0.8,-1,-1,-1,0,0,none,#ffffff,10.10660117,8,98.79264417,0,0,0,0
-529,14811,81,Hay/Pasture,,14,Residential,Exurban,0.6,0.6,0.6,0.7,0.8,-1,-1,-1,1,0.15,low,#e5f5e0,22.75760842,6.8,99.54173609,1.6,0,0,0
-530,14812,81,Hay/Pasture,,14,Residential,Exurban,0.6,0.6,0.6,0.7,0.8,-1,-1,-1,2,0.4,medium,#a1d99b,43.84262051,4.8,100.7902226,4.266666667,0,0,0
-531,14813,81,Hay/Pasture,,14,Residential,Exurban,0.6,0.6,0.6,0.7,0.8,-1,-1,-1,3,0.66,high,#31a354,65.77103307,2.72,102.0886486,7.04,0,0,0
-532,14820,82,Cultivated Crops,,14,Residential,Exurban,0.6,0.6,0.6,-1,-1,-1,-1,-1,0,0,none,#ffffff,4.793840162,0,65.75263422,0,0,0,0
-533,14821,82,Cultivated Crops,,14,Residential,Exurban,0.6,0.6,0.6,-1,-1,-1,-1,-1,1,0.15,low,#e5f5e0,18.24176156,0,71.45772764,1.6,0,0,0
-534,14822,82,Cultivated Crops,,14,Residential,Exurban,0.6,0.6,0.6,-1,-1,-1,-1,-1,2,0.4,medium,#a1d99b,40.6549639,0,80.96621666,4.266666667,0,0,0
-535,14823,82,Cultivated Crops,,14,Residential,Exurban,0.6,0.6,0.6,-1,-1,-1,-1,-1,3,0.66,high,#31a354,63.96469433,0,90.85504525,7.04,0,0,0
-536,14900,90,Woody Wetlands,,14,Residential,Exurban,0.6,0.6,-1,-1,0.8,-1,-1,-1,0,0,none,#ffffff,33.5,0,259,0,0,0,0
-537,14901,90,Woody Wetlands,,14,Residential,Exurban,0.6,0.6,-1,-1,0.8,-1,-1,-1,1,0.15,low,#e5f5e0,42.64199743,0,235.7179885,1.6,0,0,0
-538,14902,90,Woody Wetlands,,14,Residential,Exurban,0.6,0.6,-1,-1,0.8,-1,-1,-1,2,0.4,medium,#a1d99b,57.8786598,0,196.9146361,4.266666667,0,0,0
-539,14903,90,Woody Wetlands,,14,Residential,Exurban,0.6,0.6,-1,-1,0.8,-1,-1,-1,3,0.66,high,#31a354,73.72478868,0,156.5591496,7.04,0,0,0
-540,14950,95,Emergent Herbaceuous Wetlands,,14,Residential,Exurban,0.6,0.6,-1,-1,0.8,-1,-1,-1,0,0,none,#ffffff,33.5,0,259,0,0,0,0
-541,14951,95,Emergent Herbaceuous Wetlands,,14,Residential,Exurban,0.6,0.6,-1,-1,0.8,-1,-1,-1,1,0.15,low,#e5f5e0,42.64199743,0,235.7179885,1.6,0,0,0
-542,14952,95,Emergent Herbaceuous Wetlands,,14,Residential,Exurban,0.6,0.6,-1,-1,0.8,-1,-1,-1,2,0.4,medium,#a1d99b,57.8786598,0,196.9146361,4.266666667,0,0,0
-543,14953,95,Emergent Herbaceuous Wetlands,,14,Residential,Exurban,0.6,0.6,-1,-1,0.8,-1,-1,-1,3,0.66,high,#31a354,73.72478868,0,156.5591496,7.04,0,0,0
-544,15000,0,Background,,15,Residential,Rural,-1,-1,-1,-1,-1,-1,-1,-1,0,0,none,#ffffff,0,0,0,0,0,0,0
-545,15001,0,Background,,15,Residential,Rural,-1,-1,-1,-1,-1,-1,-1,-1,1,0.15,low,#e5f5e0,14.16699743,0,15.56798855,1.6,0,0,0
-546,15002,0,Background,,15,Residential,Rural,-1,-1,-1,-1,-1,-1,-1,-1,2,0.4,medium,#a1d99b,37.7786598,0,41.51463613,4.266666667,0,0,0
-547,15003,0,Background,,15,Residential,Rural,-1,-1,-1,-1,-1,-1,-1,-1,3,0.66,high,#31a354,62.33478868,0,68.49914961,7.04,0,0,0
-548,15110,11,Open Water,,15,Residential,Rural,-1,-1,-1,-1,-1,-1,-1,-1,0,0,none,#ffffff,0,0,0,0,0,0,0
-549,15111,11,Open Water,,15,Residential,Rural,-1,-1,-1,-1,-1,-1,-1,-1,1,0.15,low,#e5f5e0,14.16699743,0,15.56798855,1.6,0,0,0
-550,15112,11,Open Water,,15,Residential,Rural,-1,-1,-1,-1,-1,-1,-1,-1,2,0.4,medium,#a1d99b,37.7786598,0,41.51463613,4.266666667,0,0,0
-551,15113,11,Open Water,,15,Residential,Rural,-1,-1,-1,-1,-1,-1,-1,-1,3,0.66,high,#31a354,62.33478868,0,68.49914961,7.04,0,0,0
-552,15120,12,Perennial Ice/Snow,,15,Residential,Rural,-1,-1,-1,-1,-1,-1,-1,-1,0,0,none,#ffffff,0,0,0,0,0,0,0
-553,15121,12,Perennial Ice/Snow,,15,Residential,Rural,-1,-1,-1,-1,-1,-1,-1,-1,1,0.15,low,#e5f5e0,14.16699743,0,15.56798855,1.6,0,0,0
-554,15122,12,Perennial Ice/Snow,,15,Residential,Rural,-1,-1,-1,-1,-1,-1,-1,-1,2,0.4,medium,#a1d99b,37.7786598,0,41.51463613,4.266666667,0,0,0
-555,15123,12,Perennial Ice/Snow,,15,Residential,Rural,-1,-1,-1,-1,-1,-1,-1,-1,3,0.66,high,#31a354,62.33478868,0,68.49914961,7.04,0,0,0
-556,15210,21,"Developed, Open Space","20% trees, 60% grass, and 10% buildings and 10% bare soil",15,Residential,Rural,0.4,0.4,0.4,0.9,0.6,-1,-1,-1,0,0,none,#ffffff,25.49986095,4.08,79.01411479,1.76,51.81402439,212.31,37.03522039
-557,15211,21,"Developed, Open Space","20% trees, 60% grass, and 10% buildings and 10% bare soil",15,Residential,Rural,0.4,0.4,0.4,0.9,0.6,-1,-1,-1,1,0.15,low,#e5f5e0,35.84187923,3.468,82.72998612,3.096,51.81402439,212.31,37.03522039
-558,15212,21,"Developed, Open Space","20% trees, 60% grass, and 10% buildings and 10% bare soil",15,Residential,Rural,0.4,0.4,0.4,0.9,0.6,-1,-1,-1,2,0.4,medium,#a1d99b,53.07857637,2.448,88.923105,5.322666667,51.81402439,212.31,37.03522039
-559,15213,21,"Developed, Open Space","20% trees, 60% grass, and 10% buildings and 10% bare soil",15,Residential,Rural,0.4,0.4,0.4,0.9,0.6,-1,-1,-1,3,0.66,high,#31a354,71.0047414,1.3872,95.36394864,7.6384,51.81402439,212.31,37.03522039
-560,15220,22,"Developed, Low Intensity","20% trees, 40% grass, and 40% buildings",15,Residential,Rural,0.4,0.4,0.4,0.9,0.6,-1,-1,-1,0,0,none,#ffffff,20.90844667,3.52,72.06732319,0.61,207.2560976,849.24,147.1338816
-561,15221,22,"Developed, Low Intensity","20% trees, 40% grass, and 40% buildings",15,Residential,Rural,0.4,0.4,0.4,0.9,0.6,-1,-1,-1,1,0.15,low,#e5f5e0,31.9391771,2.992,76.82521326,2.1185,207.2560976,849.24,147.1338816
-562,15222,22,"Developed, Low Intensity","20% trees, 40% grass, and 40% buildings",15,Residential,Rural,0.4,0.4,0.4,0.9,0.6,-1,-1,-1,2,0.4,medium,#a1d99b,50.32372781,2.112,84.75503004,4.632666667,207.2560976,849.24,147.1338816
-563,15223,22,"Developed, Low Intensity","20% trees, 40% grass, and 40% buildings",15,Residential,Rural,0.4,0.4,0.4,0.9,0.6,-1,-1,-1,3,0.66,high,#31a354,69.44366054,1.1968,93.0020395,7.2474,207.2560976,849.24,147.1338816
-564,15230,23,"Developed, Medium Intensity","15% trees, 35% grass, and 50% buildings",15,Residential,Rural,0.4,0.4,0.4,0.9,0.6,-1,-1,-1,0,0,none,#ffffff,17.69813636,3.08,61.93838294,0.36,234.070122,954.85,720.4716833
-565,15231,23,"Developed, Medium Intensity","15% trees, 35% grass, and 50% buildings",15,Residential,Rural,0.4,0.4,0.4,0.9,0.6,-1,-1,-1,1,0.15,low,#e5f5e0,29.21041333,2.618,68.21561405,1.906,234.070122,954.85,720.4716833
-566,15232,23,"Developed, Medium Intensity","15% trees, 35% grass, and 50% buildings",15,Residential,Rural,0.4,0.4,0.4,0.9,0.6,-1,-1,-1,2,0.4,medium,#a1d99b,48.39754162,1.848,78.67766589,4.482666667,234.070122,954.85,720.4716833
-567,15233,23,"Developed, Medium Intensity","15% trees, 35% grass, and 50% buildings",15,Residential,Rural,0.4,0.4,0.4,0.9,0.6,-1,-1,-1,3,0.66,high,#31a354,68.35215504,1.0472,89.55819981,7.1624,234.070122,954.85,720.4716833
-568,15240,24,"Developed, High Intensity","10% trees, 20% grass, and 70% buildings",15,Residential,Rural,0.4,0.4,0.4,0.9,0.6,-1,-1,-1,0,0,none,#ffffff,10.98142029,1.76,44.78642515,0.245,267.9065041,3418.485,1805.616283
-569,15241,24,"Developed, High Intensity","10% trees, 20% grass, and 70% buildings",15,Residential,Rural,0.4,0.4,0.4,0.9,0.6,-1,-1,-1,1,0.15,low,#e5f5e0,23.50120467,1.496,53.63644993,1.80825,267.9065041,3418.485,1805.616283
-570,15242,24,"Developed, High Intensity","10% trees, 20% grass, and 70% buildings",15,Residential,Rural,0.4,0.4,0.4,0.9,0.6,-1,-1,-1,2,0.4,medium,#a1d99b,44.36751198,1.056,68.38649122,4.413666667,267.9065041,3418.485,1805.616283
-571,15243,24,"Developed, High Intensity","10% trees, 20% grass, and 70% buildings",15,Residential,Rural,0.4,0.4,0.4,0.9,0.6,-1,-1,-1,3,0.66,high,#31a354,66.06847158,0.5984,83.72653416,7.1233,267.9065041,3418.485,1805.616283
-572,15310,31,Barren Land,,15,Residential,Rural,0.4,0.4,0.4,0.9,0.6,-1,-1,-1,0,0,none,#ffffff,6.8,0,25.5,0,0,0,0
-573,15311,31,Barren Land,,15,Residential,Rural,0.4,0.4,0.4,0.9,0.6,-1,-1,-1,1,0.15,low,#e5f5e0,19.94699743,0,37.24298855,1.6,0,0,0
-574,15312,31,Barren Land,,15,Residential,Rural,0.4,0.4,0.4,0.9,0.6,-1,-1,-1,2,0.4,medium,#a1d99b,41.8586598,0,56.81463613,4.266666667,0,0,0
-575,15313,31,Barren Land,,15,Residential,Rural,0.4,0.4,0.4,0.9,0.6,-1,-1,-1,3,0.66,high,#31a354,64.64678868,0,77.16914961,7.04,0,0,0
-576,15410,41,Deciduous Forest,,15,Residential,Rural,-1,0.4,-1,-1,0.6,-1,-1,-1,0,0,none,#ffffff,85.88498714,0,96.08994273,8.8,0,0,0
-577,15411,41,Deciduous Forest,,15,Residential,Rural,-1,0.4,-1,-1,0.6,-1,-1,-1,1,0.15,low,#e5f5e0,85.88498714,0,96.08994273,8.8,0,0,0
-578,15412,41,Deciduous Forest,,15,Residential,Rural,-1,0.4,-1,-1,0.6,-1,-1,-1,2,0.4,medium,#a1d99b,85.88498714,0,96.08994273,8.8,0,0,0
-579,15413,41,Deciduous Forest,,15,Residential,Rural,-1,0.4,-1,-1,0.6,-1,-1,-1,3,0.66,high,#31a354,85.88498714,0,96.08994273,8.8,0,0,0
-580,15420,42,Evergreen Forest,,15,Residential,Rural,-1,0.4,-1,-1,0.6,-1,-1,-1,0,0,none,#ffffff,105.6849871,0,96.08994273,14.4,0,0,0
-581,15421,42,Evergreen Forest,,15,Residential,Rural,-1,0.4,-1,-1,0.6,-1,-1,-1,1,0.15,low,#e5f5e0,105.6849871,0,96.08994273,14.4,0,0,0
-582,15422,42,Evergreen Forest,,15,Residential,Rural,-1,0.4,-1,-1,0.6,-1,-1,-1,2,0.4,medium,#a1d99b,105.6849871,0,96.08994273,14.4,0,0,0
-583,15423,42,Evergreen Forest,,15,Residential,Rural,-1,0.4,-1,-1,0.6,-1,-1,-1,3,0.66,high,#31a354,105.6849871,0,96.08994273,14.4,0,0,0
-584,15430,43,Mixed Forest,,15,Residential,Rural,-1,0.4,-1,-1,0.6,-1,-1,-1,0,0,none,#ffffff,91.76997429,0,119.1798855,8.8,0,0,0
-585,15431,43,Mixed Forest,,15,Residential,Rural,-1,0.4,-1,-1,0.6,-1,-1,-1,1,0.15,low,#e5f5e0,91.76997429,0,119.1798855,8.8,0,0,0
-586,15432,43,Mixed Forest,,15,Residential,Rural,-1,0.4,-1,-1,0.6,-1,-1,-1,2,0.4,medium,#a1d99b,91.76997429,0,119.1798855,8.8,0,0,0
-587,15433,43,Mixed Forest,,15,Residential,Rural,-1,0.4,-1,-1,0.6,-1,-1,-1,3,0.66,high,#31a354,91.76997429,0,119.1798855,8.8,0,0,0
-588,15520,52,Shrub/Scrub,,15,Residential,Rural,0.4,0.4,0.4,0.9,0.6,-1,-1,-1,0,0,none,#ffffff,47.875,0,68.15477645,0,0,0,0
-589,15521,52,Shrub/Scrub,,15,Residential,Rural,0.4,0.4,0.4,0.9,0.6,-1,-1,-1,1,0.15,low,#e5f5e0,54.86074743,0,73.49954853,1.6,0,0,0
-590,15522,52,Shrub/Scrub,,15,Residential,Rural,0.4,0.4,0.4,0.9,0.6,-1,-1,-1,2,0.4,medium,#a1d99b,66.5036598,0,82.407502,4.266666667,0,0,0
-591,15523,52,Shrub/Scrub,,15,Residential,Rural,0.4,0.4,0.4,0.9,0.6,-1,-1,-1,3,0.66,high,#31a354,78.61228868,0,91.6717736,7.04,0,0,0
-592,15710,71,Herbaceuous,,15,Residential,Rural,0.4,0.4,0.4,0.9,0.6,-1,-1,-1,0,0,none,#ffffff,10.10660117,8,98.79264417,0,0,0,0
-593,15711,71,Herbaceuous,,15,Residential,Rural,0.4,0.4,0.4,0.9,0.6,-1,-1,-1,1,0.15,low,#e5f5e0,22.75760842,6.8,99.54173609,1.6,0,0,0
-594,15712,71,Herbaceuous,,15,Residential,Rural,0.4,0.4,0.4,0.9,0.6,-1,-1,-1,2,0.4,medium,#a1d99b,43.84262051,4.8,100.7902226,4.266666667,0,0,0
-595,15713,71,Herbaceuous,,15,Residential,Rural,0.4,0.4,0.4,0.9,0.6,-1,-1,-1,3,0.66,high,#31a354,65.77103307,2.72,102.0886486,7.04,0,0,0
-596,15810,81,Hay/Pasture,,15,Residential,Rural,0.4,0.4,0.4,0.9,0.6,-1,-1,-1,0,0,none,#ffffff,10.10660117,8,98.79264417,0,0,0,0
-597,15811,81,Hay/Pasture,,15,Residential,Rural,0.4,0.4,0.4,0.9,0.6,-1,-1,-1,1,0.15,low,#e5f5e0,22.75760842,6.8,99.54173609,1.6,0,0,0
-598,15812,81,Hay/Pasture,,15,Residential,Rural,0.4,0.4,0.4,0.9,0.6,-1,-1,-1,2,0.4,medium,#a1d99b,43.84262051,4.8,100.7902226,4.266666667,0,0,0
-599,15813,81,Hay/Pasture,,15,Residential,Rural,0.4,0.4,0.4,0.9,0.6,-1,-1,-1,3,0.66,high,#31a354,65.77103307,2.72,102.0886486,7.04,0,0,0
-600,15820,82,Cultivated Crops,,15,Residential,Rural,0.4,0.4,0.4,-1,-1,-1,-1,-1,0,0,none,#ffffff,4.793840162,0,65.75263422,0,0,0,0
-601,15821,82,Cultivated Crops,,15,Residential,Rural,0.4,0.4,0.4,-1,-1,-1,-1,-1,1,0.15,low,#e5f5e0,18.24176156,0,71.45772764,1.6,0,0,0
-602,15822,82,Cultivated Crops,,15,Residential,Rural,0.4,0.4,0.4,-1,-1,-1,-1,-1,2,0.4,medium,#a1d99b,40.6549639,0,80.96621666,4.266666667,0,0,0
-603,15823,82,Cultivated Crops,,15,Residential,Rural,0.4,0.4,0.4,-1,-1,-1,-1,-1,3,0.66,high,#31a354,63.96469433,0,90.85504525,7.04,0,0,0
-604,15900,90,Woody Wetlands,,15,Residential,Rural,0.4,0.4,-1,-1,0.6,-1,-1,-1,0,0,none,#ffffff,33.5,0,259,0,0,0,0
-605,15901,90,Woody Wetlands,,15,Residential,Rural,0.4,0.4,-1,-1,0.6,-1,-1,-1,1,0.15,low,#e5f5e0,42.64199743,0,235.7179885,1.6,0,0,0
-606,15902,90,Woody Wetlands,,15,Residential,Rural,0.4,0.4,-1,-1,0.6,-1,-1,-1,2,0.4,medium,#a1d99b,57.8786598,0,196.9146361,4.266666667,0,0,0
-607,15903,90,Woody Wetlands,,15,Residential,Rural,0.4,0.4,-1,-1,0.6,-1,-1,-1,3,0.66,high,#31a354,73.72478868,0,156.5591496,7.04,0,0,0
-608,15950,95,Emergent Herbaceuous Wetlands,,15,Residential,Rural,0.4,0.4,-1,-1,0.6,-1,-1,-1,0,0,none,#ffffff,33.5,0,259,0,0,0,0
-609,15951,95,Emergent Herbaceuous Wetlands,,15,Residential,Rural,0.4,0.4,-1,-1,0.6,-1,-1,-1,1,0.15,low,#e5f5e0,42.64199743,0,235.7179885,1.6,0,0,0
-610,15952,95,Emergent Herbaceuous Wetlands,,15,Residential,Rural,0.4,0.4,-1,-1,0.6,-1,-1,-1,2,0.4,medium,#a1d99b,57.8786598,0,196.9146361,4.266666667,0,0,0
-611,15953,95,Emergent Herbaceuous Wetlands,,15,Residential,Rural,0.4,0.4,-1,-1,0.6,-1,-1,-1,3,0.66,high,#31a354,73.72478868,0,156.5591496,7.04,0,0,0
-612,20000,0,Background,,20,Commercial,,-1,-1,-1,-1,-1,-1,-1,-1,0,0,none,#ffffff,0,0,0,0,0,0,0
-613,20001,0,Background,,20,Commercial,,-1,-1,-1,-1,-1,-1,-1,-1,1,0.15,low,#e5f5e0,14.16699743,0,15.56798855,1.6,0,0,0
-614,20002,0,Background,,20,Commercial,,-1,-1,-1,-1,-1,-1,-1,-1,2,0.4,medium,#a1d99b,37.7786598,0,41.51463613,4.266666667,0,0,0
-615,20003,0,Background,,20,Commercial,,-1,-1,-1,-1,-1,-1,-1,-1,3,0.66,high,#31a354,62.33478868,0,68.49914961,7.04,0,0,0
-616,20110,11,Open Water,,20,Commercial,,-1,-1,-1,-1,-1,0,-1,-1,0,0,none,#ffffff,0,0,0,0,0,0,0
-617,20111,11,Open Water,,20,Commercial,,-1,-1,-1,-1,-1,0,-1,-1,1,0.15,low,#e5f5e0,14.16699743,0,15.56798855,1.6,0,0,0
-618,20112,11,Open Water,,20,Commercial,,-1,-1,-1,-1,-1,0,-1,-1,2,0.4,medium,#a1d99b,37.7786598,0,41.51463613,4.266666667,0,0,0
-619,20113,11,Open Water,,20,Commercial,,-1,-1,-1,-1,-1,0,-1,-1,3,0.66,high,#31a354,62.33478868,0,68.49914961,7.04,0,0,0
-620,20120,12,Perennial Ice/Snow,,20,Commercial,,-1,-1,-1,-1,-1,-1,-1,-1,0,0,none,#ffffff,0,0,0,0,0,0,0
-621,20121,12,Perennial Ice/Snow,,20,Commercial,,-1,-1,-1,-1,-1,-1,-1,-1,1,0.15,low,#e5f5e0,14.16699743,0,15.56798855,1.6,0,0,0
-622,20122,12,Perennial Ice/Snow,,20,Commercial,,-1,-1,-1,-1,-1,-1,-1,-1,2,0.4,medium,#a1d99b,37.7786598,0,41.51463613,4.266666667,0,0,0
-623,20123,12,Perennial Ice/Snow,,20,Commercial,,-1,-1,-1,-1,-1,-1,-1,-1,3,0.66,high,#31a354,62.33478868,0,68.49914961,7.04,0,0,0
-624,20210,21,"Developed, Open Space","20% trees, 60% grass, and 10% buildings and 10% bare soil",20,Commercial,,0.6,0.6,0.6,0.1,1,0,-1,-1,0,0,none,#ffffff,25.49986095,4.08,79.01411479,1.76,51.81402439,212.31,37.03522039
-625,20211,21,"Developed, Open Space","20% trees, 60% grass, and 10% buildings and 10% bare soil",20,Commercial,,0.6,0.6,0.6,0.1,1,0,-1,-1,1,0.15,low,#e5f5e0,35.84187923,3.468,82.72998612,3.096,51.81402439,212.31,37.03522039
-626,20212,21,"Developed, Open Space","20% trees, 60% grass, and 10% buildings and 10% bare soil",20,Commercial,,0.6,0.6,0.6,0.1,1,0,-1,-1,2,0.4,medium,#a1d99b,53.07857637,2.448,88.923105,5.322666667,51.81402439,212.31,37.03522039
-627,20213,21,"Developed, Open Space","20% trees, 60% grass, and 10% buildings and 10% bare soil",20,Commercial,,0.6,0.6,0.6,0.1,1,0,-1,-1,3,0.66,high,#31a354,71.0047414,1.3872,95.36394864,7.6384,51.81402439,212.31,37.03522039
-628,20220,22,"Developed, Low Intensity","20% trees, 40% grass, and 40% buildings",20,Commercial,,0.6,0.6,0.6,0.1,1,-1,-1,-1,0,0,none,#ffffff,20.90844667,3.52,72.06732319,0.61,207.2560976,849.24,147.1338816
-629,20221,22,"Developed, Low Intensity","20% trees, 40% grass, and 40% buildings",20,Commercial,,0.6,0.6,0.6,0.1,1,-1,-1,-1,1,0.15,low,#e5f5e0,31.9391771,2.992,76.82521326,2.1185,207.2560976,849.24,147.1338816
-630,20222,22,"Developed, Low Intensity","20% trees, 40% grass, and 40% buildings",20,Commercial,,0.6,0.6,0.6,0.1,1,-1,-1,-1,2,0.4,medium,#a1d99b,50.32372781,2.112,84.75503004,4.632666667,207.2560976,849.24,147.1338816
-631,20223,22,"Developed, Low Intensity","20% trees, 40% grass, and 40% buildings",20,Commercial,,0.6,0.6,0.6,0.1,1,-1,-1,-1,3,0.66,high,#31a354,69.44366054,1.1968,93.0020395,7.2474,207.2560976,849.24,147.1338816
-632,20230,23,"Developed, Medium Intensity","15% trees, 35% grass, and 50% buildings",20,Commercial,,0.6,0.6,0.6,0.1,1,-1,-1,-1,0,0,none,#ffffff,17.69813636,3.08,61.93838294,0.36,234.070122,954.85,720.4716833
-633,20231,23,"Developed, Medium Intensity","15% trees, 35% grass, and 50% buildings",20,Commercial,,0.6,0.6,0.6,0.1,1,-1,-1,-1,1,0.15,low,#e5f5e0,29.21041333,2.618,68.21561405,1.906,234.070122,954.85,720.4716833
-634,20232,23,"Developed, Medium Intensity","15% trees, 35% grass, and 50% buildings",20,Commercial,,0.6,0.6,0.6,0.1,1,-1,-1,-1,2,0.4,medium,#a1d99b,48.39754162,1.848,78.67766589,4.482666667,234.070122,954.85,720.4716833
-635,20233,23,"Developed, Medium Intensity","15% trees, 35% grass, and 50% buildings",20,Commercial,,0.6,0.6,0.6,0.1,1,-1,-1,-1,3,0.66,high,#31a354,68.35215504,1.0472,89.55819981,7.1624,234.070122,954.85,720.4716833
-636,20240,24,"Developed, High Intensity","10% trees, 20% grass, and 70% buildings",20,Commercial,,0.6,0.6,0.6,0.1,1,-1,-1,-1,0,0,none,#ffffff,10.98142029,1.76,44.78642515,0.245,267.9065041,3418.485,1805.616283
-637,20241,24,"Developed, High Intensity","10% trees, 20% grass, and 70% buildings",20,Commercial,,0.6,0.6,0.6,0.1,1,-1,-1,-1,1,0.15,low,#e5f5e0,23.50120467,1.496,53.63644993,1.80825,267.9065041,3418.485,1805.616283
-638,20242,24,"Developed, High Intensity","10% trees, 20% grass, and 70% buildings",20,Commercial,,0.6,0.6,0.6,0.1,1,-1,-1,-1,2,0.4,medium,#a1d99b,44.36751198,1.056,68.38649122,4.413666667,267.9065041,3418.485,1805.616283
-639,20243,24,"Developed, High Intensity","10% trees, 20% grass, and 70% buildings",20,Commercial,,0.6,0.6,0.6,0.1,1,-1,-1,-1,3,0.66,high,#31a354,66.06847158,0.5984,83.72653416,7.1233,267.9065041,3418.485,1805.616283
-640,20310,31,Barren Land,,20,Commercial,,0.6,0.6,0.6,0.1,1,0,-1,-1,0,0,none,#ffffff,6.8,0,25.5,0,0,0,0
-641,20311,31,Barren Land,,20,Commercial,,0.6,0.6,0.6,0.1,1,0,-1,-1,1,0.15,low,#e5f5e0,19.94699743,0,37.24298855,1.6,0,0,0
-642,20312,31,Barren Land,,20,Commercial,,0.6,0.6,0.6,0.1,1,0,-1,-1,2,0.4,medium,#a1d99b,41.8586598,0,56.81463613,4.266666667,0,0,0
-643,20313,31,Barren Land,,20,Commercial,,0.6,0.6,0.6,0.1,1,0,-1,-1,3,0.66,high,#31a354,64.64678868,0,77.16914961,7.04,0,0,0
-644,20410,41,Deciduous Forest,,20,Commercial,,-1,0.6,-1,-1,1,0,-1,-1,0,0,none,#ffffff,85.88498714,0,96.08994273,8.8,0,0,0
-645,20411,41,Deciduous Forest,,20,Commercial,,-1,0.6,-1,-1,1,0,-1,-1,1,0.15,low,#e5f5e0,85.88498714,0,96.08994273,8.8,0,0,0
-646,20412,41,Deciduous Forest,,20,Commercial,,-1,0.6,-1,-1,1,0,-1,-1,2,0.4,medium,#a1d99b,85.88498714,0,96.08994273,8.8,0,0,0
-647,20413,41,Deciduous Forest,,20,Commercial,,-1,0.6,-1,-1,1,0,-1,-1,3,0.66,high,#31a354,85.88498714,0,96.08994273,8.8,0,0,0
-648,20420,42,Evergreen Forest,,20,Commercial,,-1,0.6,-1,-1,1,0,-1,-1,0,0,none,#ffffff,105.6849871,0,96.08994273,14.4,0,0,0
-649,20421,42,Evergreen Forest,,20,Commercial,,-1,0.6,-1,-1,1,0,-1,-1,1,0.15,low,#e5f5e0,105.6849871,0,96.08994273,14.4,0,0,0
-650,20422,42,Evergreen Forest,,20,Commercial,,-1,0.6,-1,-1,1,0,-1,-1,2,0.4,medium,#a1d99b,105.6849871,0,96.08994273,14.4,0,0,0
-651,20423,42,Evergreen Forest,,20,Commercial,,-1,0.6,-1,-1,1,0,-1,-1,3,0.66,high,#31a354,105.6849871,0,96.08994273,14.4,0,0,0
-652,20430,43,Mixed Forest,,20,Commercial,,-1,0.6,-1,-1,1,0,-1,-1,0,0,none,#ffffff,91.76997429,0,119.1798855,8.8,0,0,0
-653,20431,43,Mixed Forest,,20,Commercial,,-1,0.6,-1,-1,1,0,-1,-1,1,0.15,low,#e5f5e0,91.76997429,0,119.1798855,8.8,0,0,0
-654,20432,43,Mixed Forest,,20,Commercial,,-1,0.6,-1,-1,1,0,-1,-1,2,0.4,medium,#a1d99b,91.76997429,0,119.1798855,8.8,0,0,0
-655,20433,43,Mixed Forest,,20,Commercial,,-1,0.6,-1,-1,1,0,-1,-1,3,0.66,high,#31a354,91.76997429,0,119.1798855,8.8,0,0,0
-656,20520,52,Shrub/Scrub,,20,Commercial,,0.6,0.6,0.6,0.1,1,0,-1,-1,0,0,none,#ffffff,47.875,0,68.15477645,0,0,0,0
-657,20521,52,Shrub/Scrub,,20,Commercial,,0.6,0.6,0.6,0.1,1,0,-1,-1,1,0.15,low,#e5f5e0,54.86074743,0,73.49954853,1.6,0,0,0
-658,20522,52,Shrub/Scrub,,20,Commercial,,0.6,0.6,0.6,0.1,1,0,-1,-1,2,0.4,medium,#a1d99b,66.5036598,0,82.407502,4.266666667,0,0,0
-659,20523,52,Shrub/Scrub,,20,Commercial,,0.6,0.6,0.6,0.1,1,0,-1,-1,3,0.66,high,#31a354,78.61228868,0,91.6717736,7.04,0,0,0
-660,20710,71,Herbaceuous,,20,Commercial,,0.6,0.6,0.6,0.1,1,0,-1,-1,0,0,none,#ffffff,10.10660117,8,98.79264417,0,0,0,0
-661,20711,71,Herbaceuous,,20,Commercial,,0.6,0.6,0.6,0.1,1,0,-1,-1,1,0.15,low,#e5f5e0,22.75760842,6.8,99.54173609,1.6,0,0,0
-662,20712,71,Herbaceuous,,20,Commercial,,0.6,0.6,0.6,0.1,1,0,-1,-1,2,0.4,medium,#a1d99b,43.84262051,4.8,100.7902226,4.266666667,0,0,0
-663,20713,71,Herbaceuous,,20,Commercial,,0.6,0.6,0.6,0.1,1,0,-1,-1,3,0.66,high,#31a354,65.77103307,2.72,102.0886486,7.04,0,0,0
-664,20810,81,Hay/Pasture,,20,Commercial,,0.6,0.6,0.6,0.1,1,0,-1,-1,0,0,none,#ffffff,10.10660117,8,98.79264417,0,0,0,0
-665,20811,81,Hay/Pasture,,20,Commercial,,0.6,0.6,0.6,0.1,1,0,-1,-1,1,0.15,low,#e5f5e0,22.75760842,6.8,99.54173609,1.6,0,0,0
-666,20812,81,Hay/Pasture,,20,Commercial,,0.6,0.6,0.6,0.1,1,0,-1,-1,2,0.4,medium,#a1d99b,43.84262051,4.8,100.7902226,4.266666667,0,0,0
-667,20813,81,Hay/Pasture,,20,Commercial,,0.6,0.6,0.6,0.1,1,0,-1,-1,3,0.66,high,#31a354,65.77103307,2.72,102.0886486,7.04,0,0,0
-668,20820,82,Cultivated Crops,,20,Commercial,,0.6,0.6,0.6,-1,-1,0,-1,-1,0,0,none,#ffffff,4.793840162,0,65.75263422,0,0,0,0
-669,20821,82,Cultivated Crops,,20,Commercial,,0.6,0.6,0.6,-1,-1,0,-1,-1,1,0.15,low,#e5f5e0,18.24176156,0,71.45772764,1.6,0,0,0
-670,20822,82,Cultivated Crops,,20,Commercial,,0.6,0.6,0.6,-1,-1,0,-1,-1,2,0.4,medium,#a1d99b,40.6549639,0,80.96621666,4.266666667,0,0,0
-671,20823,82,Cultivated Crops,,20,Commercial,,0.6,0.6,0.6,-1,-1,0,-1,-1,3,0.66,high,#31a354,63.96469433,0,90.85504525,7.04,0,0,0
-672,20900,90,Woody Wetlands,,20,Commercial,,0.6,0.6,-1,-1,1,0,-1,-1,0,0,none,#ffffff,33.5,0,259,0,0,0,0
-673,20901,90,Woody Wetlands,,20,Commercial,,0.6,0.6,-1,-1,1,0,-1,-1,1,0.15,low,#e5f5e0,42.64199743,0,235.7179885,1.6,0,0,0
-674,20902,90,Woody Wetlands,,20,Commercial,,0.6,0.6,-1,-1,1,0,-1,-1,2,0.4,medium,#a1d99b,57.8786598,0,196.9146361,4.266666667,0,0,0
-675,20903,90,Woody Wetlands,,20,Commercial,,0.6,0.6,-1,-1,1,0,-1,-1,3,0.66,high,#31a354,73.72478868,0,156.5591496,7.04,0,0,0
-676,20950,95,Emergent Herbaceuous Wetlands,,20,Commercial,,0.6,0.6,-1,-1,1,0,-1,-1,0,0,none,#ffffff,33.5,0,259,0,0,0,0
-677,20951,95,Emergent Herbaceuous Wetlands,,20,Commercial,,0.6,0.6,-1,-1,1,0,-1,-1,1,0.15,low,#e5f5e0,42.64199743,0,235.7179885,1.6,0,0,0
-678,20952,95,Emergent Herbaceuous Wetlands,,20,Commercial,,0.6,0.6,-1,-1,1,0,-1,-1,2,0.4,medium,#a1d99b,57.8786598,0,196.9146361,4.266666667,0,0,0
-679,20953,95,Emergent Herbaceuous Wetlands,,20,Commercial,,0.6,0.6,-1,-1,1,0,-1,-1,3,0.66,high,#31a354,73.72478868,0,156.5591496,7.04,0,0,0
-680,30000,0,Background,,30,Industrial,,-1,-1,-1,-1,-1,-1,-1,-1,0,0,none,#ffffff,0,0,0,0,0,0,0
-681,30001,0,Background,,30,Industrial,,-1,-1,-1,-1,-1,-1,-1,-1,1,0.15,low,#e5f5e0,14.16699743,0,15.56798855,1.6,0,0,0
-682,30002,0,Background,,30,Industrial,,-1,-1,-1,-1,-1,-1,-1,-1,2,0.4,medium,#a1d99b,37.7786598,0,41.51463613,4.266666667,0,0,0
-683,30003,0,Background,,30,Industrial,,-1,-1,-1,-1,-1,-1,-1,-1,3,0.66,high,#31a354,62.33478868,0,68.49914961,7.04,0,0,0
-684,30110,11,Open Water,,30,Industrial,,-1,-1,-1,-1,-1,0,-1,-1,0,0,none,#ffffff,0,0,0,0,0,0,0
-685,30111,11,Open Water,,30,Industrial,,-1,-1,-1,-1,-1,0,-1,-1,1,0.15,low,#e5f5e0,14.16699743,0,15.56798855,1.6,0,0,0
-686,30112,11,Open Water,,30,Industrial,,-1,-1,-1,-1,-1,0,-1,-1,2,0.4,medium,#a1d99b,37.7786598,0,41.51463613,4.266666667,0,0,0
-687,30113,11,Open Water,,30,Industrial,,-1,-1,-1,-1,-1,0,-1,-1,3,0.66,high,#31a354,62.33478868,0,68.49914961,7.04,0,0,0
-688,30120,12,Perennial Ice/Snow,,30,Industrial,,-1,-1,-1,-1,-1,-1,-1,-1,0,0,none,#ffffff,0,0,0,0,0,0,0
-689,30121,12,Perennial Ice/Snow,,30,Industrial,,-1,-1,-1,-1,-1,-1,-1,-1,1,0.15,low,#e5f5e0,14.16699743,0,15.56798855,1.6,0,0,0
-690,30122,12,Perennial Ice/Snow,,30,Industrial,,-1,-1,-1,-1,-1,-1,-1,-1,2,0.4,medium,#a1d99b,37.7786598,0,41.51463613,4.266666667,0,0,0
-691,30123,12,Perennial Ice/Snow,,30,Industrial,,-1,-1,-1,-1,-1,-1,-1,-1,3,0.66,high,#31a354,62.33478868,0,68.49914961,7.04,0,0,0
-692,30210,21,"Developed, Open Space","20% trees, 60% grass, and 10% buildings and 10% bare soil",30,Industrial,,0.1,0.1,0.1,0.1,0.2,0,-1,-1,0,0,none,#ffffff,25.49986095,4.08,79.01411479,1.76,51.81402439,212.31,37.03522039
-693,30211,21,"Developed, Open Space","20% trees, 60% grass, and 10% buildings and 10% bare soil",30,Industrial,,0.1,0.1,0.1,0.1,0.2,0,-1,-1,1,0.15,low,#e5f5e0,35.84187923,3.468,82.72998612,3.096,51.81402439,212.31,37.03522039
-694,30212,21,"Developed, Open Space","20% trees, 60% grass, and 10% buildings and 10% bare soil",30,Industrial,,0.1,0.1,0.1,0.1,0.2,0,-1,-1,2,0.4,medium,#a1d99b,53.07857637,2.448,88.923105,5.322666667,51.81402439,212.31,37.03522039
-695,30213,21,"Developed, Open Space","20% trees, 60% grass, and 10% buildings and 10% bare soil",30,Industrial,,0.1,0.1,0.1,0.1,0.2,0,-1,-1,3,0.66,high,#31a354,71.0047414,1.3872,95.36394864,7.6384,51.81402439,212.31,37.03522039
-696,30220,22,"Developed, Low Intensity","20% trees, 40% grass, and 40% buildings",30,Industrial,,0.1,0.1,0.1,0.1,0.2,-1,-1,-1,0,0,none,#ffffff,20.90844667,3.52,72.06732319,0.61,207.2560976,849.24,147.1338816
-697,30221,22,"Developed, Low Intensity","20% trees, 40% grass, and 40% buildings",30,Industrial,,0.1,0.1,0.1,0.1,0.2,-1,-1,-1,1,0.15,low,#e5f5e0,31.9391771,2.992,76.82521326,2.1185,207.2560976,849.24,147.1338816
-698,30222,22,"Developed, Low Intensity","20% trees, 40% grass, and 40% buildings",30,Industrial,,0.1,0.1,0.1,0.1,0.2,-1,-1,-1,2,0.4,medium,#a1d99b,50.32372781,2.112,84.75503004,4.632666667,207.2560976,849.24,147.1338816
-699,30223,22,"Developed, Low Intensity","20% trees, 40% grass, and 40% buildings",30,Industrial,,0.1,0.1,0.1,0.1,0.2,-1,-1,-1,3,0.66,high,#31a354,69.44366054,1.1968,93.0020395,7.2474,207.2560976,849.24,147.1338816
-700,30230,23,"Developed, Medium Intensity","15% trees, 35% grass, and 50% buildings",30,Industrial,,0.1,0.1,0.1,0.1,0.2,-1,-1,-1,0,0,none,#ffffff,17.69813636,3.08,61.93838294,0.36,234.070122,954.85,720.4716833
-701,30231,23,"Developed, Medium Intensity","15% trees, 35% grass, and 50% buildings",30,Industrial,,0.1,0.1,0.1,0.1,0.2,-1,-1,-1,1,0.15,low,#e5f5e0,29.21041333,2.618,68.21561405,1.906,234.070122,954.85,720.4716833
-702,30232,23,"Developed, Medium Intensity","15% trees, 35% grass, and 50% buildings",30,Industrial,,0.1,0.1,0.1,0.1,0.2,-1,-1,-1,2,0.4,medium,#a1d99b,48.39754162,1.848,78.67766589,4.482666667,234.070122,954.85,720.4716833
-703,30233,23,"Developed, Medium Intensity","15% trees, 35% grass, and 50% buildings",30,Industrial,,0.1,0.1,0.1,0.1,0.2,-1,-1,-1,3,0.66,high,#31a354,68.35215504,1.0472,89.55819981,7.1624,234.070122,954.85,720.4716833
-704,30240,24,"Developed, High Intensity","10% trees, 20% grass, and 70% buildings",30,Industrial,,0.1,0.1,0.1,0.1,0.2,-1,-1,-1,0,0,none,#ffffff,10.98142029,1.76,44.78642515,0.245,267.9065041,3418.485,1805.616283
-705,30241,24,"Developed, High Intensity","10% trees, 20% grass, and 70% buildings",30,Industrial,,0.1,0.1,0.1,0.1,0.2,-1,-1,-1,1,0.15,low,#e5f5e0,23.50120467,1.496,53.63644993,1.80825,267.9065041,3418.485,1805.616283
-706,30242,24,"Developed, High Intensity","10% trees, 20% grass, and 70% buildings",30,Industrial,,0.1,0.1,0.1,0.1,0.2,-1,-1,-1,2,0.4,medium,#a1d99b,44.36751198,1.056,68.38649122,4.413666667,267.9065041,3418.485,1805.616283
-707,30243,24,"Developed, High Intensity","10% trees, 20% grass, and 70% buildings",30,Industrial,,0.1,0.1,0.1,0.1,0.2,-1,-1,-1,3,0.66,high,#31a354,66.06847158,0.5984,83.72653416,7.1233,267.9065041,3418.485,1805.616283
-708,30310,31,Barren Land,,30,Industrial,,0.1,0.1,0.1,0.1,0.2,0,-1,-1,0,0,none,#ffffff,6.8,0,25.5,0,0,0,0
-709,30311,31,Barren Land,,30,Industrial,,0.1,0.1,0.1,0.1,0.2,0,-1,-1,1,0.15,low,#e5f5e0,19.94699743,0,37.24298855,1.6,0,0,0
-710,30312,31,Barren Land,,30,Industrial,,0.1,0.1,0.1,0.1,0.2,0,-1,-1,2,0.4,medium,#a1d99b,41.8586598,0,56.81463613,4.266666667,0,0,0
-711,30313,31,Barren Land,,30,Industrial,,0.1,0.1,0.1,0.1,0.2,0,-1,-1,3,0.66,high,#31a354,64.64678868,0,77.16914961,7.04,0,0,0
-712,30410,41,Deciduous Forest,,30,Industrial,,-1,0.1,-1,-1,0.2,0,-1,-1,0,0,none,#ffffff,85.88498714,0,96.08994273,8.8,0,0,0
-713,30411,41,Deciduous Forest,,30,Industrial,,-1,0.1,-1,-1,0.2,0,-1,-1,1,0.15,low,#e5f5e0,85.88498714,0,96.08994273,8.8,0,0,0
-714,30412,41,Deciduous Forest,,30,Industrial,,-1,0.1,-1,-1,0.2,0,-1,-1,2,0.4,medium,#a1d99b,85.88498714,0,96.08994273,8.8,0,0,0
-715,30413,41,Deciduous Forest,,30,Industrial,,-1,0.1,-1,-1,0.2,0,-1,-1,3,0.66,high,#31a354,85.88498714,0,96.08994273,8.8,0,0,0
-716,30420,42,Evergreen Forest,,30,Industrial,,-1,0.1,-1,-1,0.2,0,-1,-1,0,0,none,#ffffff,105.6849871,0,96.08994273,14.4,0,0,0
-717,30421,42,Evergreen Forest,,30,Industrial,,-1,0.1,-1,-1,0.2,0,-1,-1,1,0.15,low,#e5f5e0,105.6849871,0,96.08994273,14.4,0,0,0
-718,30422,42,Evergreen Forest,,30,Industrial,,-1,0.1,-1,-1,0.2,0,-1,-1,2,0.4,medium,#a1d99b,105.6849871,0,96.08994273,14.4,0,0,0
-719,30423,42,Evergreen Forest,,30,Industrial,,-1,0.1,-1,-1,0.2,0,-1,-1,3,0.66,high,#31a354,105.6849871,0,96.08994273,14.4,0,0,0
-720,30430,43,Mixed Forest,,30,Industrial,,-1,0.1,-1,-1,0.2,0,-1,-1,0,0,none,#ffffff,91.76997429,0,119.1798855,8.8,0,0,0
-721,30431,43,Mixed Forest,,30,Industrial,,-1,0.1,-1,-1,0.2,0,-1,-1,1,0.15,low,#e5f5e0,91.76997429,0,119.1798855,8.8,0,0,0
-722,30432,43,Mixed Forest,,30,Industrial,,-1,0.1,-1,-1,0.2,0,-1,-1,2,0.4,medium,#a1d99b,91.76997429,0,119.1798855,8.8,0,0,0
-723,30433,43,Mixed Forest,,30,Industrial,,-1,0.1,-1,-1,0.2,0,-1,-1,3,0.66,high,#31a354,91.76997429,0,119.1798855,8.8,0,0,0
-724,30520,52,Shrub/Scrub,,30,Industrial,,0.1,0.1,0.1,0.1,0.2,0,-1,-1,0,0,none,#ffffff,47.875,0,68.15477645,0,0,0,0
-725,30521,52,Shrub/Scrub,,30,Industrial,,0.1,0.1,0.1,0.1,0.2,0,-1,-1,1,0.15,low,#e5f5e0,54.86074743,0,73.49954853,1.6,0,0,0
-726,30522,52,Shrub/Scrub,,30,Industrial,,0.1,0.1,0.1,0.1,0.2,0,-1,-1,2,0.4,medium,#a1d99b,66.5036598,0,82.407502,4.266666667,0,0,0
-727,30523,52,Shrub/Scrub,,30,Industrial,,0.1,0.1,0.1,0.1,0.2,0,-1,-1,3,0.66,high,#31a354,78.61228868,0,91.6717736,7.04,0,0,0
-728,30710,71,Herbaceuous,,30,Industrial,,0.1,0.1,0.1,0.1,0.2,0,-1,-1,0,0,none,#ffffff,10.10660117,8,98.79264417,0,0,0,0
-729,30711,71,Herbaceuous,,30,Industrial,,0.1,0.1,0.1,0.1,0.2,0,-1,-1,1,0.15,low,#e5f5e0,22.75760842,6.8,99.54173609,1.6,0,0,0
-730,30712,71,Herbaceuous,,30,Industrial,,0.1,0.1,0.1,0.1,0.2,0,-1,-1,2,0.4,medium,#a1d99b,43.84262051,4.8,100.7902226,4.266666667,0,0,0
-731,30713,71,Herbaceuous,,30,Industrial,,0.1,0.1,0.1,0.1,0.2,0,-1,-1,3,0.66,high,#31a354,65.77103307,2.72,102.0886486,7.04,0,0,0
-732,30810,81,Hay/Pasture,,30,Industrial,,0.1,0.1,0.1,0.1,0.2,0,-1,-1,0,0,none,#ffffff,10.10660117,8,98.79264417,0,0,0,0
-733,30811,81,Hay/Pasture,,30,Industrial,,0.1,0.1,0.1,0.1,0.2,0,-1,-1,1,0.15,low,#e5f5e0,22.75760842,6.8,99.54173609,1.6,0,0,0
-734,30812,81,Hay/Pasture,,30,Industrial,,0.1,0.1,0.1,0.1,0.2,0,-1,-1,2,0.4,medium,#a1d99b,43.84262051,4.8,100.7902226,4.266666667,0,0,0
-735,30813,81,Hay/Pasture,,30,Industrial,,0.1,0.1,0.1,0.1,0.2,0,-1,-1,3,0.66,high,#31a354,65.77103307,2.72,102.0886486,7.04,0,0,0
-736,30820,82,Cultivated Crops,,30,Industrial,,0.1,0.1,0.1,-1,-1,0,-1,-1,0,0,none,#ffffff,4.793840162,0,65.75263422,0,0,0,0
-737,30821,82,Cultivated Crops,,30,Industrial,,0.1,0.1,0.1,-1,-1,0,-1,-1,1,0.15,low,#e5f5e0,18.24176156,0,71.45772764,1.6,0,0,0
-738,30822,82,Cultivated Crops,,30,Industrial,,0.1,0.1,0.1,-1,-1,0,-1,-1,2,0.4,medium,#a1d99b,40.6549639,0,80.96621666,4.266666667,0,0,0
-739,30823,82,Cultivated Crops,,30,Industrial,,0.1,0.1,0.1,-1,-1,0,-1,-1,3,0.66,high,#31a354,63.96469433,0,90.85504525,7.04,0,0,0
-740,30900,90,Woody Wetlands,,30,Industrial,,0.1,0.1,-1,-1,0.2,0,-1,-1,0,0,none,#ffffff,33.5,0,259,0,0,0,0
-741,30901,90,Woody Wetlands,,30,Industrial,,0.1,0.1,-1,-1,0.2,0,-1,-1,1,0.15,low,#e5f5e0,42.64199743,0,235.7179885,1.6,0,0,0
-742,30902,90,Woody Wetlands,,30,Industrial,,0.1,0.1,-1,-1,0.2,0,-1,-1,2,0.4,medium,#a1d99b,57.8786598,0,196.9146361,4.266666667,0,0,0
-743,30903,90,Woody Wetlands,,30,Industrial,,0.1,0.1,-1,-1,0.2,0,-1,-1,3,0.66,high,#31a354,73.72478868,0,156.5591496,7.04,0,0,0
-744,30950,95,Emergent Herbaceuous Wetlands,,30,Industrial,,0.1,0.1,-1,-1,0.2,0,-1,-1,0,0,none,#ffffff,33.5,0,259,0,0,0,0
-745,30951,95,Emergent Herbaceuous Wetlands,,30,Industrial,,0.1,0.1,-1,-1,0.2,0,-1,-1,1,0.15,low,#e5f5e0,42.64199743,0,235.7179885,1.6,0,0,0
-746,30952,95,Emergent Herbaceuous Wetlands,,30,Industrial,,0.1,0.1,-1,-1,0.2,0,-1,-1,2,0.4,medium,#a1d99b,57.8786598,0,196.9146361,4.266666667,0,0,0
-747,30953,95,Emergent Herbaceuous Wetlands,,30,Industrial,,0.1,0.1,-1,-1,0.2,0,-1,-1,3,0.66,high,#31a354,73.72478868,0,156.5591496,7.04,0,0,0
-748,41000,0,Background,,41,Institutional,Private,-1,-1,-1,-1,-1,-1,-1,-1,0,0,none,#ffffff,0,0,0,0,0,0,0
-749,41001,0,Background,,41,Institutional,Private,-1,-1,-1,-1,-1,-1,-1,-1,1,0.15,low,#e5f5e0,14.16699743,0,15.56798855,1.6,0,0,0
-750,41002,0,Background,,41,Institutional,Private,-1,-1,-1,-1,-1,-1,-1,-1,2,0.4,medium,#a1d99b,37.7786598,0,41.51463613,4.266666667,0,0,0
-751,41003,0,Background,,41,Institutional,Private,-1,-1,-1,-1,-1,-1,-1,-1,3,0.66,high,#31a354,62.33478868,0,68.49914961,7.04,0,0,0
-752,41110,11,Open Water,,41,Institutional,Private,-1,-1,-1,-1,-1,0,-1,-1,0,0,none,#ffffff,0,0,0,0,0,0,0
-753,41111,11,Open Water,,41,Institutional,Private,-1,-1,-1,-1,-1,0,-1,-1,1,0.15,low,#e5f5e0,14.16699743,0,15.56798855,1.6,0,0,0
-754,41112,11,Open Water,,41,Institutional,Private,-1,-1,-1,-1,-1,0,-1,-1,2,0.4,medium,#a1d99b,37.7786598,0,41.51463613,4.266666667,0,0,0
-755,41113,11,Open Water,,41,Institutional,Private,-1,-1,-1,-1,-1,0,-1,-1,3,0.66,high,#31a354,62.33478868,0,68.49914961,7.04,0,0,0
-756,41120,12,Perennial Ice/Snow,,41,Institutional,Private,-1,-1,-1,-1,-1,-1,-1,-1,0,0,none,#ffffff,0,0,0,0,0,0,0
-757,41121,12,Perennial Ice/Snow,,41,Institutional,Private,-1,-1,-1,-1,-1,-1,-1,-1,1,0.15,low,#e5f5e0,14.16699743,0,15.56798855,1.6,0,0,0
-758,41122,12,Perennial Ice/Snow,,41,Institutional,Private,-1,-1,-1,-1,-1,-1,-1,-1,2,0.4,medium,#a1d99b,37.7786598,0,41.51463613,4.266666667,0,0,0
-759,41123,12,Perennial Ice/Snow,,41,Institutional,Private,-1,-1,-1,-1,-1,-1,-1,-1,3,0.66,high,#31a354,62.33478868,0,68.49914961,7.04,0,0,0
-760,41210,21,"Developed, Open Space","20% trees, 60% grass, and 10% buildings and 10% bare soil",41,Institutional,Private,0.6,0.4,0.4,0.3,0.8,0,-1,-1,0,0,none,#ffffff,25.49986095,4.08,79.01411479,1.76,51.81402439,212.31,37.03522039
-761,41211,21,"Developed, Open Space","20% trees, 60% grass, and 10% buildings and 10% bare soil",41,Institutional,Private,0.6,0.4,0.4,0.3,0.8,0,-1,-1,1,0.15,low,#e5f5e0,35.84187923,3.468,82.72998612,3.096,51.81402439,212.31,37.03522039
-762,41212,21,"Developed, Open Space","20% trees, 60% grass, and 10% buildings and 10% bare soil",41,Institutional,Private,0.6,0.4,0.4,0.3,0.8,0,-1,-1,2,0.4,medium,#a1d99b,53.07857637,2.448,88.923105,5.322666667,51.81402439,212.31,37.03522039
-763,41213,21,"Developed, Open Space","20% trees, 60% grass, and 10% buildings and 10% bare soil",41,Institutional,Private,0.6,0.4,0.4,0.3,0.8,0,-1,-1,3,0.66,high,#31a354,71.0047414,1.3872,95.36394864,7.6384,51.81402439,212.31,37.03522039
-764,41220,22,"Developed, Low Intensity","20% trees, 40% grass, and 40% buildings",41,Institutional,Private,0.6,0.4,0.4,0.3,0.8,-1,-1,-1,0,0,none,#ffffff,20.90844667,3.52,72.06732319,0.61,207.2560976,849.24,147.1338816
-765,41221,22,"Developed, Low Intensity","20% trees, 40% grass, and 40% buildings",41,Institutional,Private,0.6,0.4,0.4,0.3,0.8,-1,-1,-1,1,0.15,low,#e5f5e0,31.9391771,2.992,76.82521326,2.1185,207.2560976,849.24,147.1338816
-766,41222,22,"Developed, Low Intensity","20% trees, 40% grass, and 40% buildings",41,Institutional,Private,0.6,0.4,0.4,0.3,0.8,-1,-1,-1,2,0.4,medium,#a1d99b,50.32372781,2.112,84.75503004,4.632666667,207.2560976,849.24,147.1338816
-767,41223,22,"Developed, Low Intensity","20% trees, 40% grass, and 40% buildings",41,Institutional,Private,0.6,0.4,0.4,0.3,0.8,-1,-1,-1,3,0.66,high,#31a354,69.44366054,1.1968,93.0020395,7.2474,207.2560976,849.24,147.1338816
-768,41230,23,"Developed, Medium Intensity","15% trees, 35% grass, and 50% buildings",41,Institutional,Private,0.6,0.4,0.4,0.3,0.8,-1,-1,-1,0,0,none,#ffffff,17.69813636,3.08,61.93838294,0.36,234.070122,954.85,720.4716833
-769,41231,23,"Developed, Medium Intensity","15% trees, 35% grass, and 50% buildings",41,Institutional,Private,0.6,0.4,0.4,0.3,0.8,-1,-1,-1,1,0.15,low,#e5f5e0,29.21041333,2.618,68.21561405,1.906,234.070122,954.85,720.4716833
-770,41232,23,"Developed, Medium Intensity","15% trees, 35% grass, and 50% buildings",41,Institutional,Private,0.6,0.4,0.4,0.3,0.8,-1,-1,-1,2,0.4,medium,#a1d99b,48.39754162,1.848,78.67766589,4.482666667,234.070122,954.85,720.4716833
-771,41233,23,"Developed, Medium Intensity","15% trees, 35% grass, and 50% buildings",41,Institutional,Private,0.6,0.4,0.4,0.3,0.8,-1,-1,-1,3,0.66,high,#31a354,68.35215504,1.0472,89.55819981,7.1624,234.070122,954.85,720.4716833
-772,41240,24,"Developed, High Intensity","10% trees, 20% grass, and 70% buildings",41,Institutional,Private,0.6,0.4,0.4,0.3,0.8,-1,-1,-1,0,0,none,#ffffff,10.98142029,1.76,44.78642515,0.245,267.9065041,3418.485,1805.616283
-773,41241,24,"Developed, High Intensity","10% trees, 20% grass, and 70% buildings",41,Institutional,Private,0.6,0.4,0.4,0.3,0.8,-1,-1,-1,1,0.15,low,#e5f5e0,23.50120467,1.496,53.63644993,1.80825,267.9065041,3418.485,1805.616283
-774,41242,24,"Developed, High Intensity","10% trees, 20% grass, and 70% buildings",41,Institutional,Private,0.6,0.4,0.4,0.3,0.8,-1,-1,-1,2,0.4,medium,#a1d99b,44.36751198,1.056,68.38649122,4.413666667,267.9065041,3418.485,1805.616283
-775,41243,24,"Developed, High Intensity","10% trees, 20% grass, and 70% buildings",41,Institutional,Private,0.6,0.4,0.4,0.3,0.8,-1,-1,-1,3,0.66,high,#31a354,66.06847158,0.5984,83.72653416,7.1233,267.9065041,3418.485,1805.616283
-776,41310,31,Barren Land,,41,Institutional,Private,0.6,0.4,0.4,0.3,0.8,0,-1,-1,0,0,none,#ffffff,6.8,0,25.5,0,0,0,0
-777,41311,31,Barren Land,,41,Institutional,Private,0.6,0.4,0.4,0.3,0.8,0,-1,-1,1,0.15,low,#e5f5e0,19.94699743,0,37.24298855,1.6,0,0,0
-778,41312,31,Barren Land,,41,Institutional,Private,0.6,0.4,0.4,0.3,0.8,0,-1,-1,2,0.4,medium,#a1d99b,41.8586598,0,56.81463613,4.266666667,0,0,0
-779,41313,31,Barren Land,,41,Institutional,Private,0.6,0.4,0.4,0.3,0.8,0,-1,-1,3,0.66,high,#31a354,64.64678868,0,77.16914961,7.04,0,0,0
-780,41410,41,Deciduous Forest,,41,Institutional,Private,-1,0.4,-1,-1,0.8,0,-1,-1,0,0,none,#ffffff,85.88498714,0,96.08994273,8.8,0,0,0
-781,41411,41,Deciduous Forest,,41,Institutional,Private,-1,0.4,-1,-1,0.8,0,-1,-1,1,0.15,low,#e5f5e0,85.88498714,0,96.08994273,8.8,0,0,0
-782,41412,41,Deciduous Forest,,41,Institutional,Private,-1,0.4,-1,-1,0.8,0,-1,-1,2,0.4,medium,#a1d99b,85.88498714,0,96.08994273,8.8,0,0,0
-783,41413,41,Deciduous Forest,,41,Institutional,Private,-1,0.4,-1,-1,0.8,0,-1,-1,3,0.66,high,#31a354,85.88498714,0,96.08994273,8.8,0,0,0
-784,41420,42,Evergreen Forest,,41,Institutional,Private,-1,0.4,-1,-1,0.8,0,-1,-1,0,0,none,#ffffff,105.6849871,0,96.08994273,14.4,0,0,0
-785,41421,42,Evergreen Forest,,41,Institutional,Private,-1,0.4,-1,-1,0.8,0,-1,-1,1,0.15,low,#e5f5e0,105.6849871,0,96.08994273,14.4,0,0,0
-786,41422,42,Evergreen Forest,,41,Institutional,Private,-1,0.4,-1,-1,0.8,0,-1,-1,2,0.4,medium,#a1d99b,105.6849871,0,96.08994273,14.4,0,0,0
-787,41423,42,Evergreen Forest,,41,Institutional,Private,-1,0.4,-1,-1,0.8,0,-1,-1,3,0.66,high,#31a354,105.6849871,0,96.08994273,14.4,0,0,0
-788,41430,43,Mixed Forest,,41,Institutional,Private,-1,0.4,-1,-1,0.8,0,-1,-1,0,0,none,#ffffff,91.76997429,0,119.1798855,8.8,0,0,0
-789,41431,43,Mixed Forest,,41,Institutional,Private,-1,0.4,-1,-1,0.8,0,-1,-1,1,0.15,low,#e5f5e0,91.76997429,0,119.1798855,8.8,0,0,0
-790,41432,43,Mixed Forest,,41,Institutional,Private,-1,0.4,-1,-1,0.8,0,-1,-1,2,0.4,medium,#a1d99b,91.76997429,0,119.1798855,8.8,0,0,0
-791,41433,43,Mixed Forest,,41,Institutional,Private,-1,0.4,-1,-1,0.8,0,-1,-1,3,0.66,high,#31a354,91.76997429,0,119.1798855,8.8,0,0,0
-792,41520,52,Shrub/Scrub,,41,Institutional,Private,0.6,0.4,0.4,0.3,0.8,0,-1,-1,0,0,none,#ffffff,47.875,0,68.15477645,0,0,0,0
-793,41521,52,Shrub/Scrub,,41,Institutional,Private,0.6,0.4,0.4,0.3,0.8,0,-1,-1,1,0.15,low,#e5f5e0,54.86074743,0,73.49954853,1.6,0,0,0
-794,41522,52,Shrub/Scrub,,41,Institutional,Private,0.6,0.4,0.4,0.3,0.8,0,-1,-1,2,0.4,medium,#a1d99b,66.5036598,0,82.407502,4.266666667,0,0,0
-795,41523,52,Shrub/Scrub,,41,Institutional,Private,0.6,0.4,0.4,0.3,0.8,0,-1,-1,3,0.66,high,#31a354,78.61228868,0,91.6717736,7.04,0,0,0
-796,41710,71,Herbaceuous,,41,Institutional,Private,0.6,0.4,0.4,0.3,0.8,0,-1,-1,0,0,none,#ffffff,10.10660117,8,98.79264417,0,0,0,0
-797,41711,71,Herbaceuous,,41,Institutional,Private,0.6,0.4,0.4,0.3,0.8,0,-1,-1,1,0.15,low,#e5f5e0,22.75760842,6.8,99.54173609,1.6,0,0,0
-798,41712,71,Herbaceuous,,41,Institutional,Private,0.6,0.4,0.4,0.3,0.8,0,-1,-1,2,0.4,medium,#a1d99b,43.84262051,4.8,100.7902226,4.266666667,0,0,0
-799,41713,71,Herbaceuous,,41,Institutional,Private,0.6,0.4,0.4,0.3,0.8,0,-1,-1,3,0.66,high,#31a354,65.77103307,2.72,102.0886486,7.04,0,0,0
-800,41810,81,Hay/Pasture,,41,Institutional,Private,0.6,0.4,0.4,0.3,0.8,0,-1,-1,0,0,none,#ffffff,10.10660117,8,98.79264417,0,0,0,0
-801,41811,81,Hay/Pasture,,41,Institutional,Private,0.6,0.4,0.4,0.3,0.8,0,-1,-1,1,0.15,low,#e5f5e0,22.75760842,6.8,99.54173609,1.6,0,0,0
-802,41812,81,Hay/Pasture,,41,Institutional,Private,0.6,0.4,0.4,0.3,0.8,0,-1,-1,2,0.4,medium,#a1d99b,43.84262051,4.8,100.7902226,4.266666667,0,0,0
-803,41813,81,Hay/Pasture,,41,Institutional,Private,0.6,0.4,0.4,0.3,0.8,0,-1,-1,3,0.66,high,#31a354,65.77103307,2.72,102.0886486,7.04,0,0,0
-804,41820,82,Cultivated Crops,,41,Institutional,Private,0.6,0.4,0.4,-1,-1,0,-1,-1,0,0,none,#ffffff,4.793840162,0,65.75263422,0,0,0,0
-805,41821,82,Cultivated Crops,,41,Institutional,Private,0.6,0.4,0.4,-1,-1,0,-1,-1,1,0.15,low,#e5f5e0,18.24176156,0,71.45772764,1.6,0,0,0
-806,41822,82,Cultivated Crops,,41,Institutional,Private,0.6,0.4,0.4,-1,-1,0,-1,-1,2,0.4,medium,#a1d99b,40.6549639,0,80.96621666,4.266666667,0,0,0
-807,41823,82,Cultivated Crops,,41,Institutional,Private,0.6,0.4,0.4,-1,-1,0,-1,-1,3,0.66,high,#31a354,63.96469433,0,90.85504525,7.04,0,0,0
-808,41900,90,Woody Wetlands,,41,Institutional,Private,0.6,0.4,-1,-1,0.8,0,-1,-1,0,0,none,#ffffff,33.5,0,259,0,0,0,0
-809,41901,90,Woody Wetlands,,41,Institutional,Private,0.6,0.4,-1,-1,0.8,0,-1,-1,1,0.15,low,#e5f5e0,42.64199743,0,235.7179885,1.6,0,0,0
-810,41902,90,Woody Wetlands,,41,Institutional,Private,0.6,0.4,-1,-1,0.8,0,-1,-1,2,0.4,medium,#a1d99b,57.8786598,0,196.9146361,4.266666667,0,0,0
-811,41903,90,Woody Wetlands,,41,Institutional,Private,0.6,0.4,-1,-1,0.8,0,-1,-1,3,0.66,high,#31a354,73.72478868,0,156.5591496,7.04,0,0,0
-812,41950,95,Emergent Herbaceuous Wetlands,,41,Institutional,Private,0.6,0.4,-1,-1,0.8,0,-1,-1,0,0,none,#ffffff,33.5,0,259,0,0,0,0
-813,41951,95,Emergent Herbaceuous Wetlands,,41,Institutional,Private,0.6,0.4,-1,-1,0.8,0,-1,-1,1,0.15,low,#e5f5e0,42.64199743,0,235.7179885,1.6,0,0,0
-814,41952,95,Emergent Herbaceuous Wetlands,,41,Institutional,Private,0.6,0.4,-1,-1,0.8,0,-1,-1,2,0.4,medium,#a1d99b,57.8786598,0,196.9146361,4.266666667,0,0,0
-815,41953,95,Emergent Herbaceuous Wetlands,,41,Institutional,Private,0.6,0.4,-1,-1,0.8,0,-1,-1,3,0.66,high,#31a354,73.72478868,0,156.5591496,7.04,0,0,0
-816,42000,0,Background,,42,Institutional,Public,-1,-1,-1,-1,-1,-1,-1,-1,0,0,none,#ffffff,0,0,0,0,0,0,0
-817,42001,0,Background,,42,Institutional,Public,-1,-1,-1,-1,-1,-1,-1,-1,1,0.15,low,#e5f5e0,14.16699743,0,15.56798855,1.6,0,0,0
-818,42002,0,Background,,42,Institutional,Public,-1,-1,-1,-1,-1,-1,-1,-1,2,0.4,medium,#a1d99b,37.7786598,0,41.51463613,4.266666667,0,0,0
-819,42003,0,Background,,42,Institutional,Public,-1,-1,-1,-1,-1,-1,-1,-1,3,0.66,high,#31a354,62.33478868,0,68.49914961,7.04,0,0,0
-820,42110,11,Open Water,,42,Institutional,Public,-1,-1,-1,-1,-1,-1,-1,-1,0,0,none,#ffffff,0,0,0,0,0,0,0
-821,42111,11,Open Water,,42,Institutional,Public,-1,-1,-1,-1,-1,-1,-1,-1,1,0.15,low,#e5f5e0,14.16699743,0,15.56798855,1.6,0,0,0
-822,42112,11,Open Water,,42,Institutional,Public,-1,-1,-1,-1,-1,-1,-1,-1,2,0.4,medium,#a1d99b,37.7786598,0,41.51463613,4.266666667,0,0,0
-823,42113,11,Open Water,,42,Institutional,Public,-1,-1,-1,-1,-1,-1,-1,-1,3,0.66,high,#31a354,62.33478868,0,68.49914961,7.04,0,0,0
-824,42120,12,Perennial Ice/Snow,,42,Institutional,Public,-1,-1,-1,-1,-1,-1,-1,-1,0,0,none,#ffffff,0,0,0,0,0,0,0
-825,42121,12,Perennial Ice/Snow,,42,Institutional,Public,-1,-1,-1,-1,-1,-1,-1,-1,1,0.15,low,#e5f5e0,14.16699743,0,15.56798855,1.6,0,0,0
-826,42122,12,Perennial Ice/Snow,,42,Institutional,Public,-1,-1,-1,-1,-1,-1,-1,-1,2,0.4,medium,#a1d99b,37.7786598,0,41.51463613,4.266666667,0,0,0
-827,42123,12,Perennial Ice/Snow,,42,Institutional,Public,-1,-1,-1,-1,-1,-1,-1,-1,3,0.66,high,#31a354,62.33478868,0,68.49914961,7.04,0,0,0
-828,42210,21,"Developed, Open Space","20% trees, 60% grass, and 10% buildings and 10% bare soil",42,Institutional,Public,0.6,0.4,0.4,0.3,0.8,-1,-1,-1,0,0,none,#ffffff,25.49986095,4.08,79.01411479,1.76,51.81402439,212.31,37.03522039
-829,42211,21,"Developed, Open Space","20% trees, 60% grass, and 10% buildings and 10% bare soil",42,Institutional,Public,0.6,0.4,0.4,0.3,0.8,-1,-1,-1,1,0.15,low,#e5f5e0,35.84187923,3.468,82.72998612,3.096,51.81402439,212.31,37.03522039
-830,42212,21,"Developed, Open Space","20% trees, 60% grass, and 10% buildings and 10% bare soil",42,Institutional,Public,0.6,0.4,0.4,0.3,0.8,-1,-1,-1,2,0.4,medium,#a1d99b,53.07857637,2.448,88.923105,5.322666667,51.81402439,212.31,37.03522039
-831,42213,21,"Developed, Open Space","20% trees, 60% grass, and 10% buildings and 10% bare soil",42,Institutional,Public,0.6,0.4,0.4,0.3,0.8,-1,-1,-1,3,0.66,high,#31a354,71.0047414,1.3872,95.36394864,7.6384,51.81402439,212.31,37.03522039
-832,42220,22,"Developed, Low Intensity","20% trees, 40% grass, and 40% buildings",42,Institutional,Public,0.6,0.4,0.4,0.3,0.8,-1,-1,-1,0,0,none,#ffffff,20.90844667,3.52,72.06732319,0.61,207.2560976,849.24,147.1338816
-833,42221,22,"Developed, Low Intensity","20% trees, 40% grass, and 40% buildings",42,Institutional,Public,0.6,0.4,0.4,0.3,0.8,-1,-1,-1,1,0.15,low,#e5f5e0,31.9391771,2.992,76.82521326,2.1185,207.2560976,849.24,147.1338816
-834,42222,22,"Developed, Low Intensity","20% trees, 40% grass, and 40% buildings",42,Institutional,Public,0.6,0.4,0.4,0.3,0.8,-1,-1,-1,2,0.4,medium,#a1d99b,50.32372781,2.112,84.75503004,4.632666667,207.2560976,849.24,147.1338816
-835,42223,22,"Developed, Low Intensity","20% trees, 40% grass, and 40% buildings",42,Institutional,Public,0.6,0.4,0.4,0.3,0.8,-1,-1,-1,3,0.66,high,#31a354,69.44366054,1.1968,93.0020395,7.2474,207.2560976,849.24,147.1338816
-836,42230,23,"Developed, Medium Intensity","15% trees, 35% grass, and 50% buildings",42,Institutional,Public,0.6,0.4,0.4,0.3,0.8,-1,-1,-1,0,0,none,#ffffff,17.69813636,3.08,61.93838294,0.36,234.070122,954.85,720.4716833
-837,42231,23,"Developed, Medium Intensity","15% trees, 35% grass, and 50% buildings",42,Institutional,Public,0.6,0.4,0.4,0.3,0.8,-1,-1,-1,1,0.15,low,#e5f5e0,29.21041333,2.618,68.21561405,1.906,234.070122,954.85,720.4716833
-838,42232,23,"Developed, Medium Intensity","15% trees, 35% grass, and 50% buildings",42,Institutional,Public,0.6,0.4,0.4,0.3,0.8,-1,-1,-1,2,0.4,medium,#a1d99b,48.39754162,1.848,78.67766589,4.482666667,234.070122,954.85,720.4716833
-839,42233,23,"Developed, Medium Intensity","15% trees, 35% grass, and 50% buildings",42,Institutional,Public,0.6,0.4,0.4,0.3,0.8,-1,-1,-1,3,0.66,high,#31a354,68.35215504,1.0472,89.55819981,7.1624,234.070122,954.85,720.4716833
-840,42240,24,"Developed, High Intensity","10% trees, 20% grass, and 70% buildings",42,Institutional,Public,0.6,0.4,0.4,0.3,0.8,-1,-1,-1,0,0,none,#ffffff,10.98142029,1.76,44.78642515,0.245,267.9065041,3418.485,1805.616283
-841,42241,24,"Developed, High Intensity","10% trees, 20% grass, and 70% buildings",42,Institutional,Public,0.6,0.4,0.4,0.3,0.8,-1,-1,-1,1,0.15,low,#e5f5e0,23.50120467,1.496,53.63644993,1.80825,267.9065041,3418.485,1805.616283
-842,42242,24,"Developed, High Intensity","10% trees, 20% grass, and 70% buildings",42,Institutional,Public,0.6,0.4,0.4,0.3,0.8,-1,-1,-1,2,0.4,medium,#a1d99b,44.36751198,1.056,68.38649122,4.413666667,267.9065041,3418.485,1805.616283
-843,42243,24,"Developed, High Intensity","10% trees, 20% grass, and 70% buildings",42,Institutional,Public,0.6,0.4,0.4,0.3,0.8,-1,-1,-1,3,0.66,high,#31a354,66.06847158,0.5984,83.72653416,7.1233,267.9065041,3418.485,1805.616283
-844,42310,31,Barren Land,,42,Institutional,Public,0.6,0.4,0.4,0.3,0.8,-1,-1,-1,0,0,none,#ffffff,6.8,0,25.5,0,0,0,0
-845,42311,31,Barren Land,,42,Institutional,Public,0.6,0.4,0.4,0.3,0.8,-1,-1,-1,1,0.15,low,#e5f5e0,19.94699743,0,37.24298855,1.6,0,0,0
-846,42312,31,Barren Land,,42,Institutional,Public,0.6,0.4,0.4,0.3,0.8,-1,-1,-1,2,0.4,medium,#a1d99b,41.8586598,0,56.81463613,4.266666667,0,0,0
-847,42313,31,Barren Land,,42,Institutional,Public,0.6,0.4,0.4,0.3,0.8,-1,-1,-1,3,0.66,high,#31a354,64.64678868,0,77.16914961,7.04,0,0,0
-848,42410,41,Deciduous Forest,,42,Institutional,Public,-1,0.4,-1,-1,0.8,-1,-1,-1,0,0,none,#ffffff,85.88498714,0,96.08994273,8.8,0,0,0
-849,42411,41,Deciduous Forest,,42,Institutional,Public,-1,0.4,-1,-1,0.8,-1,-1,-1,1,0.15,low,#e5f5e0,85.88498714,0,96.08994273,8.8,0,0,0
-850,42412,41,Deciduous Forest,,42,Institutional,Public,-1,0.4,-1,-1,0.8,-1,-1,-1,2,0.4,medium,#a1d99b,85.88498714,0,96.08994273,8.8,0,0,0
-851,42413,41,Deciduous Forest,,42,Institutional,Public,-1,0.4,-1,-1,0.8,-1,-1,-1,3,0.66,high,#31a354,85.88498714,0,96.08994273,8.8,0,0,0
-852,42420,42,Evergreen Forest,,42,Institutional,Public,-1,0.4,-1,-1,0.8,-1,-1,-1,0,0,none,#ffffff,105.6849871,0,96.08994273,14.4,0,0,0
-853,42421,42,Evergreen Forest,,42,Institutional,Public,-1,0.4,-1,-1,0.8,-1,-1,-1,1,0.15,low,#e5f5e0,105.6849871,0,96.08994273,14.4,0,0,0
-854,42422,42,Evergreen Forest,,42,Institutional,Public,-1,0.4,-1,-1,0.8,-1,-1,-1,2,0.4,medium,#a1d99b,105.6849871,0,96.08994273,14.4,0,0,0
-855,42423,42,Evergreen Forest,,42,Institutional,Public,-1,0.4,-1,-1,0.8,-1,-1,-1,3,0.66,high,#31a354,105.6849871,0,96.08994273,14.4,0,0,0
-856,42430,43,Mixed Forest,,42,Institutional,Public,-1,0.4,-1,-1,0.8,-1,-1,-1,0,0,none,#ffffff,91.76997429,0,119.1798855,8.8,0,0,0
-857,42431,43,Mixed Forest,,42,Institutional,Public,-1,0.4,-1,-1,0.8,-1,-1,-1,1,0.15,low,#e5f5e0,91.76997429,0,119.1798855,8.8,0,0,0
-858,42432,43,Mixed Forest,,42,Institutional,Public,-1,0.4,-1,-1,0.8,-1,-1,-1,2,0.4,medium,#a1d99b,91.76997429,0,119.1798855,8.8,0,0,0
-859,42433,43,Mixed Forest,,42,Institutional,Public,-1,0.4,-1,-1,0.8,-1,-1,-1,3,0.66,high,#31a354,91.76997429,0,119.1798855,8.8,0,0,0
-860,42520,52,Shrub/Scrub,,42,Institutional,Public,0.6,0.4,0.4,0.3,0.8,-1,-1,-1,0,0,none,#ffffff,47.875,0,68.15477645,0,0,0,0
-861,42521,52,Shrub/Scrub,,42,Institutional,Public,0.6,0.4,0.4,0.3,0.8,-1,-1,-1,1,0.15,low,#e5f5e0,54.86074743,0,73.49954853,1.6,0,0,0
-862,42522,52,Shrub/Scrub,,42,Institutional,Public,0.6,0.4,0.4,0.3,0.8,-1,-1,-1,2,0.4,medium,#a1d99b,66.5036598,0,82.407502,4.266666667,0,0,0
-863,42523,52,Shrub/Scrub,,42,Institutional,Public,0.6,0.4,0.4,0.3,0.8,-1,-1,-1,3,0.66,high,#31a354,78.61228868,0,91.6717736,7.04,0,0,0
-864,42710,71,Herbaceuous,,42,Institutional,Public,0.6,0.4,0.4,0.3,0.8,-1,-1,-1,0,0,none,#ffffff,10.10660117,8,98.79264417,0,0,0,0
-865,42711,71,Herbaceuous,,42,Institutional,Public,0.6,0.4,0.4,0.3,0.8,-1,-1,-1,1,0.15,low,#e5f5e0,22.75760842,6.8,99.54173609,1.6,0,0,0
-866,42712,71,Herbaceuous,,42,Institutional,Public,0.6,0.4,0.4,0.3,0.8,-1,-1,-1,2,0.4,medium,#a1d99b,43.84262051,4.8,100.7902226,4.266666667,0,0,0
-867,42713,71,Herbaceuous,,42,Institutional,Public,0.6,0.4,0.4,0.3,0.8,-1,-1,-1,3,0.66,high,#31a354,65.77103307,2.72,102.0886486,7.04,0,0,0
-868,42810,81,Hay/Pasture,,42,Institutional,Public,0.6,0.4,0.4,0.3,0.8,-1,-1,-1,0,0,none,#ffffff,10.10660117,8,98.79264417,0,0,0,0
-869,42811,81,Hay/Pasture,,42,Institutional,Public,0.6,0.4,0.4,0.3,0.8,-1,-1,-1,1,0.15,low,#e5f5e0,22.75760842,6.8,99.54173609,1.6,0,0,0
-870,42812,81,Hay/Pasture,,42,Institutional,Public,0.6,0.4,0.4,0.3,0.8,-1,-1,-1,2,0.4,medium,#a1d99b,43.84262051,4.8,100.7902226,4.266666667,0,0,0
-871,42813,81,Hay/Pasture,,42,Institutional,Public,0.6,0.4,0.4,0.3,0.8,-1,-1,-1,3,0.66,high,#31a354,65.77103307,2.72,102.0886486,7.04,0,0,0
-872,42820,82,Cultivated Crops,,42,Institutional,Public,0.6,0.4,0.4,-1,-1,-1,-1,-1,0,0,none,#ffffff,4.793840162,0,65.75263422,0,0,0,0
-873,42821,82,Cultivated Crops,,42,Institutional,Public,0.6,0.4,0.4,-1,-1,-1,-1,-1,1,0.15,low,#e5f5e0,18.24176156,0,71.45772764,1.6,0,0,0
-874,42822,82,Cultivated Crops,,42,Institutional,Public,0.6,0.4,0.4,-1,-1,-1,-1,-1,2,0.4,medium,#a1d99b,40.6549639,0,80.96621666,4.266666667,0,0,0
-875,42823,82,Cultivated Crops,,42,Institutional,Public,0.6,0.4,0.4,-1,-1,-1,-1,-1,3,0.66,high,#31a354,63.96469433,0,90.85504525,7.04,0,0,0
-876,42900,90,Woody Wetlands,,42,Institutional,Public,0.6,0.4,-1,-1,0.8,-1,-1,-1,0,0,none,#ffffff,33.5,0,259,0,0,0,0
-877,42901,90,Woody Wetlands,,42,Institutional,Public,0.6,0.4,-1,-1,0.8,-1,-1,-1,1,0.15,low,#e5f5e0,42.64199743,0,235.7179885,1.6,0,0,0
-878,42902,90,Woody Wetlands,,42,Institutional,Public,0.6,0.4,-1,-1,0.8,-1,-1,-1,2,0.4,medium,#a1d99b,57.8786598,0,196.9146361,4.266666667,0,0,0
-879,42903,90,Woody Wetlands,,42,Institutional,Public,0.6,0.4,-1,-1,0.8,-1,-1,-1,3,0.66,high,#31a354,73.72478868,0,156.5591496,7.04,0,0,0
-880,42950,95,Emergent Herbaceuous Wetlands,,42,Institutional,Public,0.6,0.4,-1,-1,0.8,-1,-1,-1,0,0,none,#ffffff,33.5,0,259,0,0,0,0
-881,42951,95,Emergent Herbaceuous Wetlands,,42,Institutional,Public,0.6,0.4,-1,-1,0.8,-1,-1,-1,1,0.15,low,#e5f5e0,42.64199743,0,235.7179885,1.6,0,0,0
-882,42952,95,Emergent Herbaceuous Wetlands,,42,Institutional,Public,0.6,0.4,-1,-1,0.8,-1,-1,-1,2,0.4,medium,#a1d99b,57.8786598,0,196.9146361,4.266666667,0,0,0
-883,42953,95,Emergent Herbaceuous Wetlands,,42,Institutional,Public,0.6,0.4,-1,-1,0.8,-1,-1,-1,3,0.66,high,#31a354,73.72478868,0,156.5591496,7.04,0,0,0
-884,51000,0,Background,,51,Transportation,Airport,-1,-1,-1,-1,-1,-1,-1,-1,0,0,none,#ffffff,0,0,0,0,0,0,0
-885,51001,0,Background,,51,Transportation,Airport,-1,-1,-1,-1,-1,-1,-1,-1,1,0.15,low,#e5f5e0,14.16699743,0,15.56798855,1.6,0,0,0
-886,51002,0,Background,,51,Transportation,Airport,-1,-1,-1,-1,-1,-1,-1,-1,2,0.4,medium,#a1d99b,37.7786598,0,41.51463613,4.266666667,0,0,0
-887,51003,0,Background,,51,Transportation,Airport,-1,-1,-1,-1,-1,-1,-1,-1,3,0.66,high,#31a354,62.33478868,0,68.49914961,7.04,0,0,0
-888,51110,11,Open Water,,51,Transportation,Airport,-1,-1,-1,-1,-1,0,-1,-1,0,0,none,#ffffff,0,0,0,0,0,0,0
-889,51111,11,Open Water,,51,Transportation,Airport,-1,-1,-1,-1,-1,0,-1,-1,1,0.15,low,#e5f5e0,14.16699743,0,15.56798855,1.6,0,0,0
-890,51112,11,Open Water,,51,Transportation,Airport,-1,-1,-1,-1,-1,0,-1,-1,2,0.4,medium,#a1d99b,37.7786598,0,41.51463613,4.266666667,0,0,0
-891,51113,11,Open Water,,51,Transportation,Airport,-1,-1,-1,-1,-1,0,-1,-1,3,0.66,high,#31a354,62.33478868,0,68.49914961,7.04,0,0,0
-892,51120,12,Perennial Ice/Snow,,51,Transportation,Airport,-1,-1,-1,-1,-1,-1,-1,-1,0,0,none,#ffffff,0,0,0,0,0,0,0
-893,51121,12,Perennial Ice/Snow,,51,Transportation,Airport,-1,-1,-1,-1,-1,-1,-1,-1,1,0.15,low,#e5f5e0,14.16699743,0,15.56798855,1.6,0,0,0
-894,51122,12,Perennial Ice/Snow,,51,Transportation,Airport,-1,-1,-1,-1,-1,-1,-1,-1,2,0.4,medium,#a1d99b,37.7786598,0,41.51463613,4.266666667,0,0,0
-895,51123,12,Perennial Ice/Snow,,51,Transportation,Airport,-1,-1,-1,-1,-1,-1,-1,-1,3,0.66,high,#31a354,62.33478868,0,68.49914961,7.04,0,0,0
-896,51210,21,"Developed, Open Space","20% trees, 60% grass, and 10% buildings and 10% bare soil",51,Transportation,Airport,-1,-1,-1,-1,1,0,-1,-1,0,0,none,#ffffff,25.49986095,4.08,79.01411479,1.76,51.81402439,212.31,37.03522039
-897,51211,21,"Developed, Open Space","20% trees, 60% grass, and 10% buildings and 10% bare soil",51,Transportation,Airport,-1,-1,-1,-1,1,0,-1,-1,1,0.15,low,#e5f5e0,35.84187923,3.468,82.72998612,3.096,51.81402439,212.31,37.03522039
-898,51212,21,"Developed, Open Space","20% trees, 60% grass, and 10% buildings and 10% bare soil",51,Transportation,Airport,-1,-1,-1,-1,1,0,-1,-1,2,0.4,medium,#a1d99b,53.07857637,2.448,88.923105,5.322666667,51.81402439,212.31,37.03522039
-899,51213,21,"Developed, Open Space","20% trees, 60% grass, and 10% buildings and 10% bare soil",51,Transportation,Airport,-1,-1,-1,-1,1,0,-1,-1,3,0.66,high,#31a354,71.0047414,1.3872,95.36394864,7.6384,51.81402439,212.31,37.03522039
-900,51220,22,"Developed, Low Intensity","20% trees, 40% grass, and 40% buildings",51,Transportation,Airport,-1,-1,-1,-1,1,-1,-1,-1,0,0,none,#ffffff,20.90844667,3.52,72.06732319,0.61,207.2560976,849.24,147.1338816
-901,51221,22,"Developed, Low Intensity","20% trees, 40% grass, and 40% buildings",51,Transportation,Airport,-1,-1,-1,-1,1,-1,-1,-1,1,0.15,low,#e5f5e0,31.9391771,2.992,76.82521326,2.1185,207.2560976,849.24,147.1338816
-902,51222,22,"Developed, Low Intensity","20% trees, 40% grass, and 40% buildings",51,Transportation,Airport,-1,-1,-1,-1,1,-1,-1,-1,2,0.4,medium,#a1d99b,50.32372781,2.112,84.75503004,4.632666667,207.2560976,849.24,147.1338816
-903,51223,22,"Developed, Low Intensity","20% trees, 40% grass, and 40% buildings",51,Transportation,Airport,-1,-1,-1,-1,1,-1,-1,-1,3,0.66,high,#31a354,69.44366054,1.1968,93.0020395,7.2474,207.2560976,849.24,147.1338816
-904,51230,23,"Developed, Medium Intensity","15% trees, 35% grass, and 50% buildings",51,Transportation,Airport,-1,-1,-1,-1,1,-1,-1,-1,0,0,none,#ffffff,17.69813636,3.08,61.93838294,0.36,234.070122,954.85,720.4716833
-905,51231,23,"Developed, Medium Intensity","15% trees, 35% grass, and 50% buildings",51,Transportation,Airport,-1,-1,-1,-1,1,-1,-1,-1,1,0.15,low,#e5f5e0,29.21041333,2.618,68.21561405,1.906,234.070122,954.85,720.4716833
-906,51232,23,"Developed, Medium Intensity","15% trees, 35% grass, and 50% buildings",51,Transportation,Airport,-1,-1,-1,-1,1,-1,-1,-1,2,0.4,medium,#a1d99b,48.39754162,1.848,78.67766589,4.482666667,234.070122,954.85,720.4716833
-907,51233,23,"Developed, Medium Intensity","15% trees, 35% grass, and 50% buildings",51,Transportation,Airport,-1,-1,-1,-1,1,-1,-1,-1,3,0.66,high,#31a354,68.35215504,1.0472,89.55819981,7.1624,234.070122,954.85,720.4716833
-908,51240,24,"Developed, High Intensity","10% trees, 20% grass, and 70% buildings",51,Transportation,Airport,-1,-1,-1,-1,1,-1,-1,-1,0,0,none,#ffffff,10.98142029,1.76,44.78642515,0.245,267.9065041,3418.485,1805.616283
-909,51241,24,"Developed, High Intensity","10% trees, 20% grass, and 70% buildings",51,Transportation,Airport,-1,-1,-1,-1,1,-1,-1,-1,1,0.15,low,#e5f5e0,23.50120467,1.496,53.63644993,1.80825,267.9065041,3418.485,1805.616283
-910,51242,24,"Developed, High Intensity","10% trees, 20% grass, and 70% buildings",51,Transportation,Airport,-1,-1,-1,-1,1,-1,-1,-1,2,0.4,medium,#a1d99b,44.36751198,1.056,68.38649122,4.413666667,267.9065041,3418.485,1805.616283
-911,51243,24,"Developed, High Intensity","10% trees, 20% grass, and 70% buildings",51,Transportation,Airport,-1,-1,-1,-1,1,-1,-1,-1,3,0.66,high,#31a354,66.06847158,0.5984,83.72653416,7.1233,267.9065041,3418.485,1805.616283
-912,51310,31,Barren Land,,51,Transportation,Airport,-1,-1,-1,-1,1,0,-1,-1,0,0,none,#ffffff,6.8,0,25.5,0,0,0,0
-913,51311,31,Barren Land,,51,Transportation,Airport,-1,-1,-1,-1,1,0,-1,-1,1,0.15,low,#e5f5e0,19.94699743,0,37.24298855,1.6,0,0,0
-914,51312,31,Barren Land,,51,Transportation,Airport,-1,-1,-1,-1,1,0,-1,-1,2,0.4,medium,#a1d99b,41.8586598,0,56.81463613,4.266666667,0,0,0
-915,51313,31,Barren Land,,51,Transportation,Airport,-1,-1,-1,-1,1,0,-1,-1,3,0.66,high,#31a354,64.64678868,0,77.16914961,7.04,0,0,0
-916,51410,41,Deciduous Forest,,51,Transportation,Airport,-1,-1,-1,-1,1,0,-1,-1,0,0,none,#ffffff,85.88498714,0,96.08994273,8.8,0,0,0
-917,51411,41,Deciduous Forest,,51,Transportation,Airport,-1,-1,-1,-1,1,0,-1,-1,1,0.15,low,#e5f5e0,85.88498714,0,96.08994273,8.8,0,0,0
-918,51412,41,Deciduous Forest,,51,Transportation,Airport,-1,-1,-1,-1,1,0,-1,-1,2,0.4,medium,#a1d99b,85.88498714,0,96.08994273,8.8,0,0,0
-919,51413,41,Deciduous Forest,,51,Transportation,Airport,-1,-1,-1,-1,1,0,-1,-1,3,0.66,high,#31a354,85.88498714,0,96.08994273,8.8,0,0,0
-920,51420,42,Evergreen Forest,,51,Transportation,Airport,-1,-1,-1,-1,1,0,-1,-1,0,0,none,#ffffff,105.6849871,0,96.08994273,14.4,0,0,0
-921,51421,42,Evergreen Forest,,51,Transportation,Airport,-1,-1,-1,-1,1,0,-1,-1,1,0.15,low,#e5f5e0,105.6849871,0,96.08994273,14.4,0,0,0
-922,51422,42,Evergreen Forest,,51,Transportation,Airport,-1,-1,-1,-1,1,0,-1,-1,2,0.4,medium,#a1d99b,105.6849871,0,96.08994273,14.4,0,0,0
-923,51423,42,Evergreen Forest,,51,Transportation,Airport,-1,-1,-1,-1,1,0,-1,-1,3,0.66,high,#31a354,105.6849871,0,96.08994273,14.4,0,0,0
-924,51430,43,Mixed Forest,,51,Transportation,Airport,-1,-1,-1,-1,1,0,-1,-1,0,0,none,#ffffff,91.76997429,0,119.1798855,8.8,0,0,0
-925,51431,43,Mixed Forest,,51,Transportation,Airport,-1,-1,-1,-1,1,0,-1,-1,1,0.15,low,#e5f5e0,91.76997429,0,119.1798855,8.8,0,0,0
-926,51432,43,Mixed Forest,,51,Transportation,Airport,-1,-1,-1,-1,1,0,-1,-1,2,0.4,medium,#a1d99b,91.76997429,0,119.1798855,8.8,0,0,0
-927,51433,43,Mixed Forest,,51,Transportation,Airport,-1,-1,-1,-1,1,0,-1,-1,3,0.66,high,#31a354,91.76997429,0,119.1798855,8.8,0,0,0
-928,51520,52,Shrub/Scrub,,51,Transportation,Airport,-1,-1,-1,-1,1,0,-1,-1,0,0,none,#ffffff,47.875,0,68.15477645,0,0,0,0
-929,51521,52,Shrub/Scrub,,51,Transportation,Airport,-1,-1,-1,-1,1,0,-1,-1,1,0.15,low,#e5f5e0,54.86074743,0,73.49954853,1.6,0,0,0
-930,51522,52,Shrub/Scrub,,51,Transportation,Airport,-1,-1,-1,-1,1,0,-1,-1,2,0.4,medium,#a1d99b,66.5036598,0,82.407502,4.266666667,0,0,0
-931,51523,52,Shrub/Scrub,,51,Transportation,Airport,-1,-1,-1,-1,1,0,-1,-1,3,0.66,high,#31a354,78.61228868,0,91.6717736,7.04,0,0,0
-932,51710,71,Herbaceuous,,51,Transportation,Airport,-1,-1,-1,-1,1,0,-1,-1,0,0,none,#ffffff,10.10660117,8,98.79264417,0,0,0,0
-933,51711,71,Herbaceuous,,51,Transportation,Airport,-1,-1,-1,-1,1,0,-1,-1,1,0.15,low,#e5f5e0,22.75760842,6.8,99.54173609,1.6,0,0,0
-934,51712,71,Herbaceuous,,51,Transportation,Airport,-1,-1,-1,-1,1,0,-1,-1,2,0.4,medium,#a1d99b,43.84262051,4.8,100.7902226,4.266666667,0,0,0
-935,51713,71,Herbaceuous,,51,Transportation,Airport,-1,-1,-1,-1,1,0,-1,-1,3,0.66,high,#31a354,65.77103307,2.72,102.0886486,7.04,0,0,0
-936,51810,81,Hay/Pasture,,51,Transportation,Airport,-1,-1,-1,-1,1,0,-1,-1,0,0,none,#ffffff,10.10660117,8,98.79264417,0,0,0,0
-937,51811,81,Hay/Pasture,,51,Transportation,Airport,-1,-1,-1,-1,1,0,-1,-1,1,0.15,low,#e5f5e0,22.75760842,6.8,99.54173609,1.6,0,0,0
-938,51812,81,Hay/Pasture,,51,Transportation,Airport,-1,-1,-1,-1,1,0,-1,-1,2,0.4,medium,#a1d99b,43.84262051,4.8,100.7902226,4.266666667,0,0,0
-939,51813,81,Hay/Pasture,,51,Transportation,Airport,-1,-1,-1,-1,1,0,-1,-1,3,0.66,high,#31a354,65.77103307,2.72,102.0886486,7.04,0,0,0
-940,51820,82,Cultivated Crops,,51,Transportation,Airport,-1,-1,-1,-1,-1,0,-1,-1,0,0,none,#ffffff,4.793840162,0,65.75263422,0,0,0,0
-941,51821,82,Cultivated Crops,,51,Transportation,Airport,-1,-1,-1,-1,-1,0,-1,-1,1,0.15,low,#e5f5e0,18.24176156,0,71.45772764,1.6,0,0,0
-942,51822,82,Cultivated Crops,,51,Transportation,Airport,-1,-1,-1,-1,-1,0,-1,-1,2,0.4,medium,#a1d99b,40.6549639,0,80.96621666,4.266666667,0,0,0
-943,51823,82,Cultivated Crops,,51,Transportation,Airport,-1,-1,-1,-1,-1,0,-1,-1,3,0.66,high,#31a354,63.96469433,0,90.85504525,7.04,0,0,0
-944,51900,90,Woody Wetlands,,51,Transportation,Airport,-1,-1,-1,-1,1,0,-1,-1,0,0,none,#ffffff,33.5,0,259,0,0,0,0
-945,51901,90,Woody Wetlands,,51,Transportation,Airport,-1,-1,-1,-1,1,0,-1,-1,1,0.15,low,#e5f5e0,42.64199743,0,235.7179885,1.6,0,0,0
-946,51902,90,Woody Wetlands,,51,Transportation,Airport,-1,-1,-1,-1,1,0,-1,-1,2,0.4,medium,#a1d99b,57.8786598,0,196.9146361,4.266666667,0,0,0
-947,51903,90,Woody Wetlands,,51,Transportation,Airport,-1,-1,-1,-1,1,0,-1,-1,3,0.66,high,#31a354,73.72478868,0,156.5591496,7.04,0,0,0
-948,51950,95,Emergent Herbaceuous Wetlands,,51,Transportation,Airport,-1,-1,-1,-1,1,0,-1,-1,0,0,none,#ffffff,33.5,0,259,0,0,0,0
-949,51951,95,Emergent Herbaceuous Wetlands,,51,Transportation,Airport,-1,-1,-1,-1,1,0,-1,-1,1,0.15,low,#e5f5e0,42.64199743,0,235.7179885,1.6,0,0,0
-950,51952,95,Emergent Herbaceuous Wetlands,,51,Transportation,Airport,-1,-1,-1,-1,1,0,-1,-1,2,0.4,medium,#a1d99b,57.8786598,0,196.9146361,4.266666667,0,0,0
-951,51953,95,Emergent Herbaceuous Wetlands,,51,Transportation,Airport,-1,-1,-1,-1,1,0,-1,-1,3,0.66,high,#31a354,73.72478868,0,156.5591496,7.04,0,0,0
-952,52000,0,Background,,52,Transportation,Road and Rail,-1,-1,-1,-1,-1,-1,-1,-1,0,0,none,#ffffff,0,0,0,0,0,0,0
-953,52001,0,Background,,52,Transportation,Road and Rail,-1,-1,-1,-1,-1,-1,-1,-1,1,0.15,low,#e5f5e0,14.16699743,0,15.56798855,1.6,0,0,0
-954,52002,0,Background,,52,Transportation,Road and Rail,-1,-1,-1,-1,-1,-1,-1,-1,2,0.4,medium,#a1d99b,37.7786598,0,41.51463613,4.266666667,0,0,0
-955,52003,0,Background,,52,Transportation,Road and Rail,-1,-1,-1,-1,-1,-1,-1,-1,3,0.66,high,#31a354,62.33478868,0,68.49914961,7.04,0,0,0
-956,52110,11,Open Water,,52,Transportation,Road and Rail,-1,-1,-1,-1,-1,0,-1,-1,0,0,none,#ffffff,0,0,0,0,0,0,0
-957,52111,11,Open Water,,52,Transportation,Road and Rail,-1,-1,-1,-1,-1,0,-1,-1,1,0.15,low,#e5f5e0,14.16699743,0,15.56798855,1.6,0,0,0
-958,52112,11,Open Water,,52,Transportation,Road and Rail,-1,-1,-1,-1,-1,0,-1,-1,2,0.4,medium,#a1d99b,37.7786598,0,41.51463613,4.266666667,0,0,0
-959,52113,11,Open Water,,52,Transportation,Road and Rail,-1,-1,-1,-1,-1,0,-1,-1,3,0.66,high,#31a354,62.33478868,0,68.49914961,7.04,0,0,0
-960,52120,12,Perennial Ice/Snow,,52,Transportation,Road and Rail,-1,-1,-1,-1,-1,-1,-1,-1,0,0,none,#ffffff,0,0,0,0,0,0,0
-961,52121,12,Perennial Ice/Snow,,52,Transportation,Road and Rail,-1,-1,-1,-1,-1,-1,-1,-1,1,0.15,low,#e5f5e0,14.16699743,0,15.56798855,1.6,0,0,0
-962,52122,12,Perennial Ice/Snow,,52,Transportation,Road and Rail,-1,-1,-1,-1,-1,-1,-1,-1,2,0.4,medium,#a1d99b,37.7786598,0,41.51463613,4.266666667,0,0,0
-963,52123,12,Perennial Ice/Snow,,52,Transportation,Road and Rail,-1,-1,-1,-1,-1,-1,-1,-1,3,0.66,high,#31a354,62.33478868,0,68.49914961,7.04,0,0,0
-964,52210,21,"Developed, Open Space","20% trees, 60% grass, and 10% buildings and 10% bare soil",52,Transportation,Road and Rail,-1,-1,-1,-1,1,0,-1,-1,0,0,none,#ffffff,25.49986095,4.08,79.01411479,1.76,51.81402439,212.31,37.03522039
-965,52211,21,"Developed, Open Space","20% trees, 60% grass, and 10% buildings and 10% bare soil",52,Transportation,Road and Rail,-1,-1,-1,-1,1,0,-1,-1,1,0.15,low,#e5f5e0,35.84187923,3.468,82.72998612,3.096,51.81402439,212.31,37.03522039
-966,52212,21,"Developed, Open Space","20% trees, 60% grass, and 10% buildings and 10% bare soil",52,Transportation,Road and Rail,-1,-1,-1,-1,1,0,-1,-1,2,0.4,medium,#a1d99b,53.07857637,2.448,88.923105,5.322666667,51.81402439,212.31,37.03522039
-967,52213,21,"Developed, Open Space","20% trees, 60% grass, and 10% buildings and 10% bare soil",52,Transportation,Road and Rail,-1,-1,-1,-1,1,0,-1,-1,3,0.66,high,#31a354,71.0047414,1.3872,95.36394864,7.6384,51.81402439,212.31,37.03522039
-968,52220,22,"Developed, Low Intensity","20% trees, 40% grass, and 40% buildings",52,Transportation,Road and Rail,-1,-1,-1,-1,1,-1,-1,-1,0,0,none,#ffffff,20.90844667,3.52,72.06732319,0.61,207.2560976,849.24,147.1338816
-969,52221,22,"Developed, Low Intensity","20% trees, 40% grass, and 40% buildings",52,Transportation,Road and Rail,-1,-1,-1,-1,1,-1,-1,-1,1,0.15,low,#e5f5e0,31.9391771,2.992,76.82521326,2.1185,207.2560976,849.24,147.1338816
-970,52222,22,"Developed, Low Intensity","20% trees, 40% grass, and 40% buildings",52,Transportation,Road and Rail,-1,-1,-1,-1,1,-1,-1,-1,2,0.4,medium,#a1d99b,50.32372781,2.112,84.75503004,4.632666667,207.2560976,849.24,147.1338816
-971,52223,22,"Developed, Low Intensity","20% trees, 40% grass, and 40% buildings",52,Transportation,Road and Rail,-1,-1,-1,-1,1,-1,-1,-1,3,0.66,high,#31a354,69.44366054,1.1968,93.0020395,7.2474,207.2560976,849.24,147.1338816
-972,52230,23,"Developed, Medium Intensity","15% trees, 35% grass, and 50% buildings",52,Transportation,Road and Rail,-1,-1,-1,-1,1,-1,-1,-1,0,0,none,#ffffff,17.69813636,3.08,61.93838294,0.36,234.070122,954.85,720.4716833
-973,52231,23,"Developed, Medium Intensity","15% trees, 35% grass, and 50% buildings",52,Transportation,Road and Rail,-1,-1,-1,-1,1,-1,-1,-1,1,0.15,low,#e5f5e0,29.21041333,2.618,68.21561405,1.906,234.070122,954.85,720.4716833
-974,52232,23,"Developed, Medium Intensity","15% trees, 35% grass, and 50% buildings",52,Transportation,Road and Rail,-1,-1,-1,-1,1,-1,-1,-1,2,0.4,medium,#a1d99b,48.39754162,1.848,78.67766589,4.482666667,234.070122,954.85,720.4716833
-975,52233,23,"Developed, Medium Intensity","15% trees, 35% grass, and 50% buildings",52,Transportation,Road and Rail,-1,-1,-1,-1,1,-1,-1,-1,3,0.66,high,#31a354,68.35215504,1.0472,89.55819981,7.1624,234.070122,954.85,720.4716833
-976,52240,24,"Developed, High Intensity","10% trees, 20% grass, and 70% buildings",52,Transportation,Road and Rail,-1,-1,-1,-1,1,-1,-1,-1,0,0,none,#ffffff,10.98142029,1.76,44.78642515,0.245,267.9065041,3418.485,1805.616283
-977,52241,24,"Developed, High Intensity","10% trees, 20% grass, and 70% buildings",52,Transportation,Road and Rail,-1,-1,-1,-1,1,-1,-1,-1,1,0.15,low,#e5f5e0,23.50120467,1.496,53.63644993,1.80825,267.9065041,3418.485,1805.616283
-978,52242,24,"Developed, High Intensity","10% trees, 20% grass, and 70% buildings",52,Transportation,Road and Rail,-1,-1,-1,-1,1,-1,-1,-1,2,0.4,medium,#a1d99b,44.36751198,1.056,68.38649122,4.413666667,267.9065041,3418.485,1805.616283
-979,52243,24,"Developed, High Intensity","10% trees, 20% grass, and 70% buildings",52,Transportation,Road and Rail,-1,-1,-1,-1,1,-1,-1,-1,3,0.66,high,#31a354,66.06847158,0.5984,83.72653416,7.1233,267.9065041,3418.485,1805.616283
-980,52310,31,Barren Land,,52,Transportation,Road and Rail,-1,-1,-1,-1,1,0,-1,-1,0,0,none,#ffffff,6.8,0,25.5,0,0,0,0
-981,52311,31,Barren Land,,52,Transportation,Road and Rail,-1,-1,-1,-1,1,0,-1,-1,1,0.15,low,#e5f5e0,19.94699743,0,37.24298855,1.6,0,0,0
-982,52312,31,Barren Land,,52,Transportation,Road and Rail,-1,-1,-1,-1,1,0,-1,-1,2,0.4,medium,#a1d99b,41.8586598,0,56.81463613,4.266666667,0,0,0
-983,52313,31,Barren Land,,52,Transportation,Road and Rail,-1,-1,-1,-1,1,0,-1,-1,3,0.66,high,#31a354,64.64678868,0,77.16914961,7.04,0,0,0
-984,52410,41,Deciduous Forest,,52,Transportation,Road and Rail,-1,-1,-1,-1,1,0,-1,-1,0,0,none,#ffffff,85.88498714,0,96.08994273,8.8,0,0,0
-985,52411,41,Deciduous Forest,,52,Transportation,Road and Rail,-1,-1,-1,-1,1,0,-1,-1,1,0.15,low,#e5f5e0,85.88498714,0,96.08994273,8.8,0,0,0
-986,52412,41,Deciduous Forest,,52,Transportation,Road and Rail,-1,-1,-1,-1,1,0,-1,-1,2,0.4,medium,#a1d99b,85.88498714,0,96.08994273,8.8,0,0,0
-987,52413,41,Deciduous Forest,,52,Transportation,Road and Rail,-1,-1,-1,-1,1,0,-1,-1,3,0.66,high,#31a354,85.88498714,0,96.08994273,8.8,0,0,0
-988,52420,42,Evergreen Forest,,52,Transportation,Road and Rail,-1,-1,-1,-1,1,0,-1,-1,0,0,none,#ffffff,105.6849871,0,96.08994273,14.4,0,0,0
-989,52421,42,Evergreen Forest,,52,Transportation,Road and Rail,-1,-1,-1,-1,1,0,-1,-1,1,0.15,low,#e5f5e0,105.6849871,0,96.08994273,14.4,0,0,0
-990,52422,42,Evergreen Forest,,52,Transportation,Road and Rail,-1,-1,-1,-1,1,0,-1,-1,2,0.4,medium,#a1d99b,105.6849871,0,96.08994273,14.4,0,0,0
-991,52423,42,Evergreen Forest,,52,Transportation,Road and Rail,-1,-1,-1,-1,1,0,-1,-1,3,0.66,high,#31a354,105.6849871,0,96.08994273,14.4,0,0,0
-992,52430,43,Mixed Forest,,52,Transportation,Road and Rail,-1,-1,-1,-1,1,0,-1,-1,0,0,none,#ffffff,91.76997429,0,119.1798855,8.8,0,0,0
-993,52431,43,Mixed Forest,,52,Transportation,Road and Rail,-1,-1,-1,-1,1,0,-1,-1,1,0.15,low,#e5f5e0,91.76997429,0,119.1798855,8.8,0,0,0
-994,52432,43,Mixed Forest,,52,Transportation,Road and Rail,-1,-1,-1,-1,1,0,-1,-1,2,0.4,medium,#a1d99b,91.76997429,0,119.1798855,8.8,0,0,0
-995,52433,43,Mixed Forest,,52,Transportation,Road and Rail,-1,-1,-1,-1,1,0,-1,-1,3,0.66,high,#31a354,91.76997429,0,119.1798855,8.8,0,0,0
-996,52520,52,Shrub/Scrub,,52,Transportation,Road and Rail,-1,-1,-1,-1,1,0,-1,-1,0,0,none,#ffffff,47.875,0,68.15477645,0,0,0,0
-997,52521,52,Shrub/Scrub,,52,Transportation,Road and Rail,-1,-1,-1,-1,1,0,-1,-1,1,0.15,low,#e5f5e0,54.86074743,0,73.49954853,1.6,0,0,0
-998,52522,52,Shrub/Scrub,,52,Transportation,Road and Rail,-1,-1,-1,-1,1,0,-1,-1,2,0.4,medium,#a1d99b,66.5036598,0,82.407502,4.266666667,0,0,0
-999,52523,52,Shrub/Scrub,,52,Transportation,Road and Rail,-1,-1,-1,-1,1,0,-1,-1,3,0.66,high,#31a354,78.61228868,0,91.6717736,7.04,0,0,0
-1000,52710,71,Herbaceuous,,52,Transportation,Road and Rail,-1,-1,-1,-1,1,0,-1,-1,0,0,none,#ffffff,10.10660117,8,98.79264417,0,0,0,0
-1001,52711,71,Herbaceuous,,52,Transportation,Road and Rail,-1,-1,-1,-1,1,0,-1,-1,1,0.15,low,#e5f5e0,22.75760842,6.8,99.54173609,1.6,0,0,0
-1002,52712,71,Herbaceuous,,52,Transportation,Road and Rail,-1,-1,-1,-1,1,0,-1,-1,2,0.4,medium,#a1d99b,43.84262051,4.8,100.7902226,4.266666667,0,0,0
-1003,52713,71,Herbaceuous,,52,Transportation,Road and Rail,-1,-1,-1,-1,1,0,-1,-1,3,0.66,high,#31a354,65.77103307,2.72,102.0886486,7.04,0,0,0
-1004,52810,81,Hay/Pasture,,52,Transportation,Road and Rail,-1,-1,-1,-1,1,0,-1,-1,0,0,none,#ffffff,10.10660117,8,98.79264417,0,0,0,0
-1005,52811,81,Hay/Pasture,,52,Transportation,Road and Rail,-1,-1,-1,-1,1,0,-1,-1,1,0.15,low,#e5f5e0,22.75760842,6.8,99.54173609,1.6,0,0,0
-1006,52812,81,Hay/Pasture,,52,Transportation,Road and Rail,-1,-1,-1,-1,1,0,-1,-1,2,0.4,medium,#a1d99b,43.84262051,4.8,100.7902226,4.266666667,0,0,0
-1007,52813,81,Hay/Pasture,,52,Transportation,Road and Rail,-1,-1,-1,-1,1,0,-1,-1,3,0.66,high,#31a354,65.77103307,2.72,102.0886486,7.04,0,0,0
-1008,52820,82,Cultivated Crops,,52,Transportation,Road and Rail,-1,-1,-1,-1,-1,0,-1,-1,0,0,none,#ffffff,4.793840162,0,65.75263422,0,0,0,0
-1009,52821,82,Cultivated Crops,,52,Transportation,Road and Rail,-1,-1,-1,-1,-1,0,-1,-1,1,0.15,low,#e5f5e0,18.24176156,0,71.45772764,1.6,0,0,0
-1010,52822,82,Cultivated Crops,,52,Transportation,Road and Rail,-1,-1,-1,-1,-1,0,-1,-1,2,0.4,medium,#a1d99b,40.6549639,0,80.96621666,4.266666667,0,0,0
-1011,52823,82,Cultivated Crops,,52,Transportation,Road and Rail,-1,-1,-1,-1,-1,0,-1,-1,3,0.66,high,#31a354,63.96469433,0,90.85504525,7.04,0,0,0
-1012,52900,90,Woody Wetlands,,52,Transportation,Road and Rail,-1,-1,-1,-1,1,0,-1,-1,0,0,none,#ffffff,33.5,0,259,0,0,0,0
-1013,52901,90,Woody Wetlands,,52,Transportation,Road and Rail,-1,-1,-1,-1,1,0,-1,-1,1,0.15,low,#e5f5e0,42.64199743,0,235.7179885,1.6,0,0,0
-1014,52902,90,Woody Wetlands,,52,Transportation,Road and Rail,-1,-1,-1,-1,1,0,-1,-1,2,0.4,medium,#a1d99b,57.8786598,0,196.9146361,4.266666667,0,0,0
-1015,52903,90,Woody Wetlands,,52,Transportation,Road and Rail,-1,-1,-1,-1,1,0,-1,-1,3,0.66,high,#31a354,73.72478868,0,156.5591496,7.04,0,0,0
-1016,52950,95,Emergent Herbaceuous Wetlands,,52,Transportation,Road and Rail,-1,-1,-1,-1,1,0,-1,-1,0,0,none,#ffffff,33.5,0,259,0,0,0,0
-1017,52951,95,Emergent Herbaceuous Wetlands,,52,Transportation,Road and Rail,-1,-1,-1,-1,1,0,-1,-1,1,0.15,low,#e5f5e0,42.64199743,0,235.7179885,1.6,0,0,0
-1018,52952,95,Emergent Herbaceuous Wetlands,,52,Transportation,Road and Rail,-1,-1,-1,-1,1,0,-1,-1,2,0.4,medium,#a1d99b,57.8786598,0,196.9146361,4.266666667,0,0,0
-1019,52953,95,Emergent Herbaceuous Wetlands,,52,Transportation,Road and Rail,-1,-1,-1,-1,1,0,-1,-1,3,0.66,high,#31a354,73.72478868,0,156.5591496,7.04,0,0,0
-1020,53000,0,Background,,53,Transportation,Other,-1,-1,-1,-1,-1,-1,-1,-1,0,0,none,#ffffff,0,0,0,0,0,0,0
-1021,53001,0,Background,,53,Transportation,Other,-1,-1,-1,-1,-1,-1,-1,-1,1,0.15,low,#e5f5e0,14.16699743,0,15.56798855,1.6,0,0,0
-1022,53002,0,Background,,53,Transportation,Other,-1,-1,-1,-1,-1,-1,-1,-1,2,0.4,medium,#a1d99b,37.7786598,0,41.51463613,4.266666667,0,0,0
-1023,53003,0,Background,,53,Transportation,Other,-1,-1,-1,-1,-1,-1,-1,-1,3,0.66,high,#31a354,62.33478868,0,68.49914961,7.04,0,0,0
-1024,53110,11,Open Water,,53,Transportation,Other,-1,-1,-1,-1,-1,0,-1,-1,0,0,none,#ffffff,0,0,0,0,0,0,0
-1025,53111,11,Open Water,,53,Transportation,Other,-1,-1,-1,-1,-1,0,-1,-1,1,0.15,low,#e5f5e0,14.16699743,0,15.56798855,1.6,0,0,0
-1026,53112,11,Open Water,,53,Transportation,Other,-1,-1,-1,-1,-1,0,-1,-1,2,0.4,medium,#a1d99b,37.7786598,0,41.51463613,4.266666667,0,0,0
-1027,53113,11,Open Water,,53,Transportation,Other,-1,-1,-1,-1,-1,0,-1,-1,3,0.66,high,#31a354,62.33478868,0,68.49914961,7.04,0,0,0
-1028,53120,12,Perennial Ice/Snow,,53,Transportation,Other,-1,-1,-1,-1,-1,-1,-1,-1,0,0,none,#ffffff,0,0,0,0,0,0,0
-1029,53121,12,Perennial Ice/Snow,,53,Transportation,Other,-1,-1,-1,-1,-1,-1,-1,-1,1,0.15,low,#e5f5e0,14.16699743,0,15.56798855,1.6,0,0,0
-1030,53122,12,Perennial Ice/Snow,,53,Transportation,Other,-1,-1,-1,-1,-1,-1,-1,-1,2,0.4,medium,#a1d99b,37.7786598,0,41.51463613,4.266666667,0,0,0
-1031,53123,12,Perennial Ice/Snow,,53,Transportation,Other,-1,-1,-1,-1,-1,-1,-1,-1,3,0.66,high,#31a354,62.33478868,0,68.49914961,7.04,0,0,0
-1032,53210,21,"Developed, Open Space","20% trees, 60% grass, and 10% buildings and 10% bare soil",53,Transportation,Other,-1,-1,-1,-1,1,0,-1,-1,0,0,none,#ffffff,25.49986095,4.08,79.01411479,1.76,51.81402439,212.31,37.03522039
-1033,53211,21,"Developed, Open Space","20% trees, 60% grass, and 10% buildings and 10% bare soil",53,Transportation,Other,-1,-1,-1,-1,1,0,-1,-1,1,0.15,low,#e5f5e0,35.84187923,3.468,82.72998612,3.096,51.81402439,212.31,37.03522039
-1034,53212,21,"Developed, Open Space","20% trees, 60% grass, and 10% buildings and 10% bare soil",53,Transportation,Other,-1,-1,-1,-1,1,0,-1,-1,2,0.4,medium,#a1d99b,53.07857637,2.448,88.923105,5.322666667,51.81402439,212.31,37.03522039
-1035,53213,21,"Developed, Open Space","20% trees, 60% grass, and 10% buildings and 10% bare soil",53,Transportation,Other,-1,-1,-1,-1,1,0,-1,-1,3,0.66,high,#31a354,71.0047414,1.3872,95.36394864,7.6384,51.81402439,212.31,37.03522039
-1036,53220,22,"Developed, Low Intensity","20% trees, 40% grass, and 40% buildings",53,Transportation,Other,-1,-1,-1,-1,1,-1,-1,-1,0,0,none,#ffffff,20.90844667,3.52,72.06732319,0.61,207.2560976,849.24,147.1338816
-1037,53221,22,"Developed, Low Intensity","20% trees, 40% grass, and 40% buildings",53,Transportation,Other,-1,-1,-1,-1,1,-1,-1,-1,1,0.15,low,#e5f5e0,31.9391771,2.992,76.82521326,2.1185,207.2560976,849.24,147.1338816
-1038,53222,22,"Developed, Low Intensity","20% trees, 40% grass, and 40% buildings",53,Transportation,Other,-1,-1,-1,-1,1,-1,-1,-1,2,0.4,medium,#a1d99b,50.32372781,2.112,84.75503004,4.632666667,207.2560976,849.24,147.1338816
-1039,53223,22,"Developed, Low Intensity","20% trees, 40% grass, and 40% buildings",53,Transportation,Other,-1,-1,-1,-1,1,-1,-1,-1,3,0.66,high,#31a354,69.44366054,1.1968,93.0020395,7.2474,207.2560976,849.24,147.1338816
-1040,53230,23,"Developed, Medium Intensity","15% trees, 35% grass, and 50% buildings",53,Transportation,Other,-1,-1,-1,-1,1,-1,-1,-1,0,0,none,#ffffff,17.69813636,3.08,61.93838294,0.36,234.070122,954.85,720.4716833
-1041,53231,23,"Developed, Medium Intensity","15% trees, 35% grass, and 50% buildings",53,Transportation,Other,-1,-1,-1,-1,1,-1,-1,-1,1,0.15,low,#e5f5e0,29.21041333,2.618,68.21561405,1.906,234.070122,954.85,720.4716833
-1042,53232,23,"Developed, Medium Intensity","15% trees, 35% grass, and 50% buildings",53,Transportation,Other,-1,-1,-1,-1,1,-1,-1,-1,2,0.4,medium,#a1d99b,48.39754162,1.848,78.67766589,4.482666667,234.070122,954.85,720.4716833
-1043,53233,23,"Developed, Medium Intensity","15% trees, 35% grass, and 50% buildings",53,Transportation,Other,-1,-1,-1,-1,1,-1,-1,-1,3,0.66,high,#31a354,68.35215504,1.0472,89.55819981,7.1624,234.070122,954.85,720.4716833
-1044,53240,24,"Developed, High Intensity","10% trees, 20% grass, and 70% buildings",53,Transportation,Other,-1,-1,-1,-1,1,-1,-1,-1,0,0,none,#ffffff,10.98142029,1.76,44.78642515,0.245,267.9065041,3418.485,1805.616283
-1045,53241,24,"Developed, High Intensity","10% trees, 20% grass, and 70% buildings",53,Transportation,Other,-1,-1,-1,-1,1,-1,-1,-1,1,0.15,low,#e5f5e0,23.50120467,1.496,53.63644993,1.80825,267.9065041,3418.485,1805.616283
-1046,53242,24,"Developed, High Intensity","10% trees, 20% grass, and 70% buildings",53,Transportation,Other,-1,-1,-1,-1,1,-1,-1,-1,2,0.4,medium,#a1d99b,44.36751198,1.056,68.38649122,4.413666667,267.9065041,3418.485,1805.616283
-1047,53243,24,"Developed, High Intensity","10% trees, 20% grass, and 70% buildings",53,Transportation,Other,-1,-1,-1,-1,1,-1,-1,-1,3,0.66,high,#31a354,66.06847158,0.5984,83.72653416,7.1233,267.9065041,3418.485,1805.616283
-1048,53310,31,Barren Land,,53,Transportation,Other,-1,-1,-1,-1,1,0,-1,-1,0,0,none,#ffffff,6.8,0,25.5,0,0,0,0
-1049,53311,31,Barren Land,,53,Transportation,Other,-1,-1,-1,-1,1,0,-1,-1,1,0.15,low,#e5f5e0,19.94699743,0,37.24298855,1.6,0,0,0
-1050,53312,31,Barren Land,,53,Transportation,Other,-1,-1,-1,-1,1,0,-1,-1,2,0.4,medium,#a1d99b,41.8586598,0,56.81463613,4.266666667,0,0,0
-1051,53313,31,Barren Land,,53,Transportation,Other,-1,-1,-1,-1,1,0,-1,-1,3,0.66,high,#31a354,64.64678868,0,77.16914961,7.04,0,0,0
-1052,53410,41,Deciduous Forest,,53,Transportation,Other,-1,-1,-1,-1,1,0,-1,-1,0,0,none,#ffffff,85.88498714,0,96.08994273,8.8,0,0,0
-1053,53411,41,Deciduous Forest,,53,Transportation,Other,-1,-1,-1,-1,1,0,-1,-1,1,0.15,low,#e5f5e0,85.88498714,0,96.08994273,8.8,0,0,0
-1054,53412,41,Deciduous Forest,,53,Transportation,Other,-1,-1,-1,-1,1,0,-1,-1,2,0.4,medium,#a1d99b,85.88498714,0,96.08994273,8.8,0,0,0
-1055,53413,41,Deciduous Forest,,53,Transportation,Other,-1,-1,-1,-1,1,0,-1,-1,3,0.66,high,#31a354,85.88498714,0,96.08994273,8.8,0,0,0
-1056,53420,42,Evergreen Forest,,53,Transportation,Other,-1,-1,-1,-1,1,0,-1,-1,0,0,none,#ffffff,105.6849871,0,96.08994273,14.4,0,0,0
-1057,53421,42,Evergreen Forest,,53,Transportation,Other,-1,-1,-1,-1,1,0,-1,-1,1,0.15,low,#e5f5e0,105.6849871,0,96.08994273,14.4,0,0,0
-1058,53422,42,Evergreen Forest,,53,Transportation,Other,-1,-1,-1,-1,1,0,-1,-1,2,0.4,medium,#a1d99b,105.6849871,0,96.08994273,14.4,0,0,0
-1059,53423,42,Evergreen Forest,,53,Transportation,Other,-1,-1,-1,-1,1,0,-1,-1,3,0.66,high,#31a354,105.6849871,0,96.08994273,14.4,0,0,0
-1060,53430,43,Mixed Forest,,53,Transportation,Other,-1,-1,-1,-1,1,0,-1,-1,0,0,none,#ffffff,91.76997429,0,119.1798855,8.8,0,0,0
-1061,53431,43,Mixed Forest,,53,Transportation,Other,-1,-1,-1,-1,1,0,-1,-1,1,0.15,low,#e5f5e0,91.76997429,0,119.1798855,8.8,0,0,0
-1062,53432,43,Mixed Forest,,53,Transportation,Other,-1,-1,-1,-1,1,0,-1,-1,2,0.4,medium,#a1d99b,91.76997429,0,119.1798855,8.8,0,0,0
-1063,53433,43,Mixed Forest,,53,Transportation,Other,-1,-1,-1,-1,1,0,-1,-1,3,0.66,high,#31a354,91.76997429,0,119.1798855,8.8,0,0,0
-1064,53520,52,Shrub/Scrub,,53,Transportation,Other,-1,-1,-1,-1,1,0,-1,-1,0,0,none,#ffffff,47.875,0,68.15477645,0,0,0,0
-1065,53521,52,Shrub/Scrub,,53,Transportation,Other,-1,-1,-1,-1,1,0,-1,-1,1,0.15,low,#e5f5e0,54.86074743,0,73.49954853,1.6,0,0,0
-1066,53522,52,Shrub/Scrub,,53,Transportation,Other,-1,-1,-1,-1,1,0,-1,-1,2,0.4,medium,#a1d99b,66.5036598,0,82.407502,4.266666667,0,0,0
-1067,53523,52,Shrub/Scrub,,53,Transportation,Other,-1,-1,-1,-1,1,0,-1,-1,3,0.66,high,#31a354,78.61228868,0,91.6717736,7.04,0,0,0
-1068,53710,71,Herbaceuous,,53,Transportation,Other,-1,-1,-1,-1,1,0,-1,-1,0,0,none,#ffffff,10.10660117,8,98.79264417,0,0,0,0
-1069,53711,71,Herbaceuous,,53,Transportation,Other,-1,-1,-1,-1,1,0,-1,-1,1,0.15,low,#e5f5e0,22.75760842,6.8,99.54173609,1.6,0,0,0
-1070,53712,71,Herbaceuous,,53,Transportation,Other,-1,-1,-1,-1,1,0,-1,-1,2,0.4,medium,#a1d99b,43.84262051,4.8,100.7902226,4.266666667,0,0,0
-1071,53713,71,Herbaceuous,,53,Transportation,Other,-1,-1,-1,-1,1,0,-1,-1,3,0.66,high,#31a354,65.77103307,2.72,102.0886486,7.04,0,0,0
-1072,53810,81,Hay/Pasture,,53,Transportation,Other,-1,-1,-1,-1,1,0,-1,-1,0,0,none,#ffffff,10.10660117,8,98.79264417,0,0,0,0
-1073,53811,81,Hay/Pasture,,53,Transportation,Other,-1,-1,-1,-1,1,0,-1,-1,1,0.15,low,#e5f5e0,22.75760842,6.8,99.54173609,1.6,0,0,0
-1074,53812,81,Hay/Pasture,,53,Transportation,Other,-1,-1,-1,-1,1,0,-1,-1,2,0.4,medium,#a1d99b,43.84262051,4.8,100.7902226,4.266666667,0,0,0
-1075,53813,81,Hay/Pasture,,53,Transportation,Other,-1,-1,-1,-1,1,0,-1,-1,3,0.66,high,#31a354,65.77103307,2.72,102.0886486,7.04,0,0,0
-1076,53820,82,Cultivated Crops,,53,Transportation,Other,-1,-1,-1,-1,-1,0,-1,-1,0,0,none,#ffffff,4.793840162,0,65.75263422,0,0,0,0
-1077,53821,82,Cultivated Crops,,53,Transportation,Other,-1,-1,-1,-1,-1,0,-1,-1,1,0.15,low,#e5f5e0,18.24176156,0,71.45772764,1.6,0,0,0
-1078,53822,82,Cultivated Crops,,53,Transportation,Other,-1,-1,-1,-1,-1,0,-1,-1,2,0.4,medium,#a1d99b,40.6549639,0,80.96621666,4.266666667,0,0,0
-1079,53823,82,Cultivated Crops,,53,Transportation,Other,-1,-1,-1,-1,-1,0,-1,-1,3,0.66,high,#31a354,63.96469433,0,90.85504525,7.04,0,0,0
-1080,53900,90,Woody Wetlands,,53,Transportation,Other,-1,-1,-1,-1,1,0,-1,-1,0,0,none,#ffffff,33.5,0,259,0,0,0,0
-1081,53901,90,Woody Wetlands,,53,Transportation,Other,-1,-1,-1,-1,1,0,-1,-1,1,0.15,low,#e5f5e0,42.64199743,0,235.7179885,1.6,0,0,0
-1082,53902,90,Woody Wetlands,,53,Transportation,Other,-1,-1,-1,-1,1,0,-1,-1,2,0.4,medium,#a1d99b,57.8786598,0,196.9146361,4.266666667,0,0,0
-1083,53903,90,Woody Wetlands,,53,Transportation,Other,-1,-1,-1,-1,1,0,-1,-1,3,0.66,high,#31a354,73.72478868,0,156.5591496,7.04,0,0,0
-1084,53950,95,Emergent Herbaceuous Wetlands,,53,Transportation,Other,-1,-1,-1,-1,1,0,-1,-1,0,0,none,#ffffff,33.5,0,259,0,0,0,0
-1085,53951,95,Emergent Herbaceuous Wetlands,,53,Transportation,Other,-1,-1,-1,-1,1,0,-1,-1,1,0.15,low,#e5f5e0,42.64199743,0,235.7179885,1.6,0,0,0
-1086,53952,95,Emergent Herbaceuous Wetlands,,53,Transportation,Other,-1,-1,-1,-1,1,0,-1,-1,2,0.4,medium,#a1d99b,57.8786598,0,196.9146361,4.266666667,0,0,0
-1087,53953,95,Emergent Herbaceuous Wetlands,,53,Transportation,Other,-1,-1,-1,-1,1,0,-1,-1,3,0.66,high,#31a354,73.72478868,0,156.5591496,7.04,0,0,0
-1088,60000,0,Background,,60,Other Development,,-1,-1,-1,-1,-1,-1,-1,-1,0,0,none,#ffffff,0,0,0,0,0,0,0
-1089,60001,0,Background,,60,Other Development,,-1,-1,-1,-1,-1,-1,-1,-1,1,0.15,low,#e5f5e0,14.16699743,0,15.56798855,1.6,0,0,0
-1090,60002,0,Background,,60,Other Development,,-1,-1,-1,-1,-1,-1,-1,-1,2,0.4,medium,#a1d99b,37.7786598,0,41.51463613,4.266666667,0,0,0
-1091,60003,0,Background,,60,Other Development,,-1,-1,-1,-1,-1,-1,-1,-1,3,0.66,high,#31a354,62.33478868,0,68.49914961,7.04,0,0,0
-1092,60110,11,Open Water,,60,Other Development,,-1,-1,-1,-1,-1,-1,-1,-1,0,0,none,#ffffff,0,0,0,0,0,0,0
-1093,60111,11,Open Water,,60,Other Development,,-1,-1,-1,-1,-1,-1,-1,-1,1,0.15,low,#e5f5e0,14.16699743,0,15.56798855,1.6,0,0,0
-1094,60112,11,Open Water,,60,Other Development,,-1,-1,-1,-1,-1,-1,-1,-1,2,0.4,medium,#a1d99b,37.7786598,0,41.51463613,4.266666667,0,0,0
-1095,60113,11,Open Water,,60,Other Development,,-1,-1,-1,-1,-1,-1,-1,-1,3,0.66,high,#31a354,62.33478868,0,68.49914961,7.04,0,0,0
-1096,60120,12,Perennial Ice/Snow,,60,Other Development,,-1,-1,-1,-1,-1,-1,-1,-1,0,0,none,#ffffff,0,0,0,0,0,0,0
-1097,60121,12,Perennial Ice/Snow,,60,Other Development,,-1,-1,-1,-1,-1,-1,-1,-1,1,0.15,low,#e5f5e0,14.16699743,0,15.56798855,1.6,0,0,0
-1098,60122,12,Perennial Ice/Snow,,60,Other Development,,-1,-1,-1,-1,-1,-1,-1,-1,2,0.4,medium,#a1d99b,37.7786598,0,41.51463613,4.266666667,0,0,0
-1099,60123,12,Perennial Ice/Snow,,60,Other Development,,-1,-1,-1,-1,-1,-1,-1,-1,3,0.66,high,#31a354,62.33478868,0,68.49914961,7.04,0,0,0
-1100,60210,21,"Developed, Open Space","20% trees, 60% grass, and 10% buildings and 10% bare soil",60,Other Development,,-1,-1,-1,-1,-1,-1,-1,-1,0,0,none,#ffffff,25.49986095,4.08,79.01411479,1.76,51.81402439,212.31,37.03522039
-1101,60211,21,"Developed, Open Space","20% trees, 60% grass, and 10% buildings and 10% bare soil",60,Other Development,,-1,-1,-1,-1,-1,-1,-1,-1,1,0.15,low,#e5f5e0,35.84187923,3.468,82.72998612,3.096,51.81402439,212.31,37.03522039
-1102,60212,21,"Developed, Open Space","20% trees, 60% grass, and 10% buildings and 10% bare soil",60,Other Development,,-1,-1,-1,-1,-1,-1,-1,-1,2,0.4,medium,#a1d99b,53.07857637,2.448,88.923105,5.322666667,51.81402439,212.31,37.03522039
-1103,60213,21,"Developed, Open Space","20% trees, 60% grass, and 10% buildings and 10% bare soil",60,Other Development,,-1,-1,-1,-1,-1,-1,-1,-1,3,0.66,high,#31a354,71.0047414,1.3872,95.36394864,7.6384,51.81402439,212.31,37.03522039
-1104,60220,22,"Developed, Low Intensity","20% trees, 40% grass, and 40% buildings",60,Other Development,,-1,-1,-1,-1,-1,-1,-1,-1,0,0,none,#ffffff,20.90844667,3.52,72.06732319,0.61,207.2560976,849.24,147.1338816
-1105,60221,22,"Developed, Low Intensity","20% trees, 40% grass, and 40% buildings",60,Other Development,,-1,-1,-1,-1,-1,-1,-1,-1,1,0.15,low,#e5f5e0,31.9391771,2.992,76.82521326,2.1185,207.2560976,849.24,147.1338816
-1106,60222,22,"Developed, Low Intensity","20% trees, 40% grass, and 40% buildings",60,Other Development,,-1,-1,-1,-1,-1,-1,-1,-1,2,0.4,medium,#a1d99b,50.32372781,2.112,84.75503004,4.632666667,207.2560976,849.24,147.1338816
-1107,60223,22,"Developed, Low Intensity","20% trees, 40% grass, and 40% buildings",60,Other Development,,-1,-1,-1,-1,-1,-1,-1,-1,3,0.66,high,#31a354,69.44366054,1.1968,93.0020395,7.2474,207.2560976,849.24,147.1338816
-1108,60230,23,"Developed, Medium Intensity","15% trees, 35% grass, and 50% buildings",60,Other Development,,-1,-1,-1,-1,-1,-1,-1,-1,0,0,none,#ffffff,17.69813636,3.08,61.93838294,0.36,234.070122,954.85,720.4716833
-1109,60231,23,"Developed, Medium Intensity","15% trees, 35% grass, and 50% buildings",60,Other Development,,-1,-1,-1,-1,-1,-1,-1,-1,1,0.15,low,#e5f5e0,29.21041333,2.618,68.21561405,1.906,234.070122,954.85,720.4716833
-1110,60232,23,"Developed, Medium Intensity","15% trees, 35% grass, and 50% buildings",60,Other Development,,-1,-1,-1,-1,-1,-1,-1,-1,2,0.4,medium,#a1d99b,48.39754162,1.848,78.67766589,4.482666667,234.070122,954.85,720.4716833
-1111,60233,23,"Developed, Medium Intensity","15% trees, 35% grass, and 50% buildings",60,Other Development,,-1,-1,-1,-1,-1,-1,-1,-1,3,0.66,high,#31a354,68.35215504,1.0472,89.55819981,7.1624,234.070122,954.85,720.4716833
-1112,60240,24,"Developed, High Intensity","10% trees, 20% grass, and 70% buildings",60,Other Development,,-1,-1,-1,-1,-1,-1,-1,-1,0,0,none,#ffffff,10.98142029,1.76,44.78642515,0.245,267.9065041,3418.485,1805.616283
-1113,60241,24,"Developed, High Intensity","10% trees, 20% grass, and 70% buildings",60,Other Development,,-1,-1,-1,-1,-1,-1,-1,-1,1,0.15,low,#e5f5e0,23.50120467,1.496,53.63644993,1.80825,267.9065041,3418.485,1805.616283
-1114,60242,24,"Developed, High Intensity","10% trees, 20% grass, and 70% buildings",60,Other Development,,-1,-1,-1,-1,-1,-1,-1,-1,2,0.4,medium,#a1d99b,44.36751198,1.056,68.38649122,4.413666667,267.9065041,3418.485,1805.616283
-1115,60243,24,"Developed, High Intensity","10% trees, 20% grass, and 70% buildings",60,Other Development,,-1,-1,-1,-1,-1,-1,-1,-1,3,0.66,high,#31a354,66.06847158,0.5984,83.72653416,7.1233,267.9065041,3418.485,1805.616283
-1116,60310,31,Barren Land,,60,Other Development,,-1,-1,-1,-1,-1,-1,-1,-1,0,0,none,#ffffff,6.8,0,25.5,0,0,0,0
-1117,60311,31,Barren Land,,60,Other Development,,-1,-1,-1,-1,-1,-1,-1,-1,1,0.15,low,#e5f5e0,19.94699743,0,37.24298855,1.6,0,0,0
-1118,60312,31,Barren Land,,60,Other Development,,-1,-1,-1,-1,-1,-1,-1,-1,2,0.4,medium,#a1d99b,41.8586598,0,56.81463613,4.266666667,0,0,0
-1119,60313,31,Barren Land,,60,Other Development,,-1,-1,-1,-1,-1,-1,-1,-1,3,0.66,high,#31a354,64.64678868,0,77.16914961,7.04,0,0,0
-1120,60410,41,Deciduous Forest,,60,Other Development,,-1,-1,-1,-1,-1,-1,-1,-1,0,0,none,#ffffff,85.88498714,0,96.08994273,8.8,0,0,0
-1121,60411,41,Deciduous Forest,,60,Other Development,,-1,-1,-1,-1,-1,-1,-1,-1,1,0.15,low,#e5f5e0,85.88498714,0,96.08994273,8.8,0,0,0
-1122,60412,41,Deciduous Forest,,60,Other Development,,-1,-1,-1,-1,-1,-1,-1,-1,2,0.4,medium,#a1d99b,85.88498714,0,96.08994273,8.8,0,0,0
-1123,60413,41,Deciduous Forest,,60,Other Development,,-1,-1,-1,-1,-1,-1,-1,-1,3,0.66,high,#31a354,85.88498714,0,96.08994273,8.8,0,0,0
-1124,60420,42,Evergreen Forest,,60,Other Development,,-1,-1,-1,-1,-1,-1,-1,-1,0,0,none,#ffffff,105.6849871,0,96.08994273,14.4,0,0,0
-1125,60421,42,Evergreen Forest,,60,Other Development,,-1,-1,-1,-1,-1,-1,-1,-1,1,0.15,low,#e5f5e0,105.6849871,0,96.08994273,14.4,0,0,0
-1126,60422,42,Evergreen Forest,,60,Other Development,,-1,-1,-1,-1,-1,-1,-1,-1,2,0.4,medium,#a1d99b,105.6849871,0,96.08994273,14.4,0,0,0
-1127,60423,42,Evergreen Forest,,60,Other Development,,-1,-1,-1,-1,-1,-1,-1,-1,3,0.66,high,#31a354,105.6849871,0,96.08994273,14.4,0,0,0
-1128,60430,43,Mixed Forest,,60,Other Development,,-1,-1,-1,-1,-1,-1,-1,-1,0,0,none,#ffffff,91.76997429,0,119.1798855,8.8,0,0,0
-1129,60431,43,Mixed Forest,,60,Other Development,,-1,-1,-1,-1,-1,-1,-1,-1,1,0.15,low,#e5f5e0,91.76997429,0,119.1798855,8.8,0,0,0
-1130,60432,43,Mixed Forest,,60,Other Development,,-1,-1,-1,-1,-1,-1,-1,-1,2,0.4,medium,#a1d99b,91.76997429,0,119.1798855,8.8,0,0,0
-1131,60433,43,Mixed Forest,,60,Other Development,,-1,-1,-1,-1,-1,-1,-1,-1,3,0.66,high,#31a354,91.76997429,0,119.1798855,8.8,0,0,0
-1132,60520,52,Shrub/Scrub,,60,Other Development,,-1,-1,-1,-1,-1,-1,-1,-1,0,0,none,#ffffff,47.875,0,68.15477645,0,0,0,0
-1133,60521,52,Shrub/Scrub,,60,Other Development,,-1,-1,-1,-1,-1,-1,-1,-1,1,0.15,low,#e5f5e0,54.86074743,0,73.49954853,1.6,0,0,0
-1134,60522,52,Shrub/Scrub,,60,Other Development,,-1,-1,-1,-1,-1,-1,-1,-1,2,0.4,medium,#a1d99b,66.5036598,0,82.407502,4.266666667,0,0,0
-1135,60523,52,Shrub/Scrub,,60,Other Development,,-1,-1,-1,-1,-1,-1,-1,-1,3,0.66,high,#31a354,78.61228868,0,91.6717736,7.04,0,0,0
-1136,60710,71,Herbaceuous,,60,Other Development,,-1,-1,-1,-1,-1,-1,-1,-1,0,0,none,#ffffff,10.10660117,8,98.79264417,0,0,0,0
-1137,60711,71,Herbaceuous,,60,Other Development,,-1,-1,-1,-1,-1,-1,-1,-1,1,0.15,low,#e5f5e0,22.75760842,6.8,99.54173609,1.6,0,0,0
-1138,60712,71,Herbaceuous,,60,Other Development,,-1,-1,-1,-1,-1,-1,-1,-1,2,0.4,medium,#a1d99b,43.84262051,4.8,100.7902226,4.266666667,0,0,0
-1139,60713,71,Herbaceuous,,60,Other Development,,-1,-1,-1,-1,-1,-1,-1,-1,3,0.66,high,#31a354,65.77103307,2.72,102.0886486,7.04,0,0,0
-1140,60810,81,Hay/Pasture,,60,Other Development,,-1,-1,-1,-1,-1,-1,-1,-1,0,0,none,#ffffff,10.10660117,8,98.79264417,0,0,0,0
-1141,60811,81,Hay/Pasture,,60,Other Development,,-1,-1,-1,-1,-1,-1,-1,-1,1,0.15,low,#e5f5e0,22.75760842,6.8,99.54173609,1.6,0,0,0
-1142,60812,81,Hay/Pasture,,60,Other Development,,-1,-1,-1,-1,-1,-1,-1,-1,2,0.4,medium,#a1d99b,43.84262051,4.8,100.7902226,4.266666667,0,0,0
-1143,60813,81,Hay/Pasture,,60,Other Development,,-1,-1,-1,-1,-1,-1,-1,-1,3,0.66,high,#31a354,65.77103307,2.72,102.0886486,7.04,0,0,0
-1144,60820,82,Cultivated Crops,,60,Other Development,,-1,-1,-1,-1,-1,-1,-1,-1,0,0,none,#ffffff,4.793840162,0,65.75263422,0,0,0,0
-1145,60821,82,Cultivated Crops,,60,Other Development,,-1,-1,-1,-1,-1,-1,-1,-1,1,0.15,low,#e5f5e0,18.24176156,0,71.45772764,1.6,0,0,0
-1146,60822,82,Cultivated Crops,,60,Other Development,,-1,-1,-1,-1,-1,-1,-1,-1,2,0.4,medium,#a1d99b,40.6549639,0,80.96621666,4.266666667,0,0,0
-1147,60823,82,Cultivated Crops,,60,Other Development,,-1,-1,-1,-1,-1,-1,-1,-1,3,0.66,high,#31a354,63.96469433,0,90.85504525,7.04,0,0,0
-1148,60900,90,Woody Wetlands,,60,Other Development,,-1,-1,-1,-1,-1,-1,-1,-1,0,0,none,#ffffff,33.5,0,259,0,0,0,0
-1149,60901,90,Woody Wetlands,,60,Other Development,,-1,-1,-1,-1,-1,-1,-1,-1,1,0.15,low,#e5f5e0,42.64199743,0,235.7179885,1.6,0,0,0
-1150,60902,90,Woody Wetlands,,60,Other Development,,-1,-1,-1,-1,-1,-1,-1,-1,2,0.4,medium,#a1d99b,57.8786598,0,196.9146361,4.266666667,0,0,0
-1151,60903,90,Woody Wetlands,,60,Other Development,,-1,-1,-1,-1,-1,-1,-1,-1,3,0.66,high,#31a354,73.72478868,0,156.5591496,7.04,0,0,0
-1152,60950,95,Emergent Herbaceuous Wetlands,,60,Other Development,,-1,-1,-1,-1,-1,-1,-1,-1,0,0,none,#ffffff,33.5,0,259,0,0,0,0
-1153,60951,95,Emergent Herbaceuous Wetlands,,60,Other Development,,-1,-1,-1,-1,-1,-1,-1,-1,1,0.15,low,#e5f5e0,42.64199743,0,235.7179885,1.6,0,0,0
-1154,60952,95,Emergent Herbaceuous Wetlands,,60,Other Development,,-1,-1,-1,-1,-1,-1,-1,-1,2,0.4,medium,#a1d99b,57.8786598,0,196.9146361,4.266666667,0,0,0
-1155,60953,95,Emergent Herbaceuous Wetlands,,60,Other Development,,-1,-1,-1,-1,-1,-1,-1,-1,3,0.66,high,#31a354,73.72478868,0,156.5591496,7.04,0,0,0
-1156,70000,0,Background,,70,Agriculture,,-1,-1,-1,-1,-1,-1,-1,-1,0,0,none,#ffffff,0,0,0,0,0,0,0
-1157,70001,0,Background,,70,Agriculture,,-1,-1,-1,-1,-1,-1,-1,-1,1,0.15,low,#e5f5e0,14.16699743,0,15.56798855,1.6,0,0,0
-1158,70002,0,Background,,70,Agriculture,,-1,-1,-1,-1,-1,-1,-1,-1,2,0.4,medium,#a1d99b,37.7786598,0,41.51463613,4.266666667,0,0,0
-1159,70003,0,Background,,70,Agriculture,,-1,-1,-1,-1,-1,-1,-1,-1,3,0.66,high,#31a354,62.33478868,0,68.49914961,7.04,0,0,0
-1160,70110,11,Open Water,,70,Agriculture,,-1,-1,-1,-1,-1,0,-1,-1,0,0,none,#ffffff,0,0,0,0,0,0,0
-1161,70111,11,Open Water,,70,Agriculture,,-1,-1,-1,-1,-1,0,-1,-1,1,0.15,low,#e5f5e0,14.16699743,0,15.56798855,1.6,0,0,0
-1162,70112,11,Open Water,,70,Agriculture,,-1,-1,-1,-1,-1,0,-1,-1,2,0.4,medium,#a1d99b,37.7786598,0,41.51463613,4.266666667,0,0,0
-1163,70113,11,Open Water,,70,Agriculture,,-1,-1,-1,-1,-1,0,-1,-1,3,0.66,high,#31a354,62.33478868,0,68.49914961,7.04,0,0,0
-1164,70120,12,Perennial Ice/Snow,,70,Agriculture,,-1,-1,-1,-1,-1,-1,-1,-1,0,0,none,#ffffff,0,0,0,0,0,0,0
-1165,70121,12,Perennial Ice/Snow,,70,Agriculture,,-1,-1,-1,-1,-1,-1,-1,-1,1,0.15,low,#e5f5e0,14.16699743,0,15.56798855,1.6,0,0,0
-1166,70122,12,Perennial Ice/Snow,,70,Agriculture,,-1,-1,-1,-1,-1,-1,-1,-1,2,0.4,medium,#a1d99b,37.7786598,0,41.51463613,4.266666667,0,0,0
-1167,70123,12,Perennial Ice/Snow,,70,Agriculture,,-1,-1,-1,-1,-1,-1,-1,-1,3,0.66,high,#31a354,62.33478868,0,68.49914961,7.04,0,0,0
-1168,70210,21,"Developed, Open Space","20% trees, 60% grass, and 10% buildings and 10% bare soil",70,Agriculture,,1,1,1,0,-1,0,-1,-1,0,0,none,#ffffff,25.49986095,4.08,79.01411479,1.76,51.81402439,212.31,37.03522039
-1169,70211,21,"Developed, Open Space","20% trees, 60% grass, and 10% buildings and 10% bare soil",70,Agriculture,,1,1,1,0,-1,0,-1,-1,1,0.15,low,#e5f5e0,35.84187923,3.468,82.72998612,3.096,51.81402439,212.31,37.03522039
-1170,70212,21,"Developed, Open Space","20% trees, 60% grass, and 10% buildings and 10% bare soil",70,Agriculture,,1,1,1,0,-1,0,-1,-1,2,0.4,medium,#a1d99b,53.07857637,2.448,88.923105,5.322666667,51.81402439,212.31,37.03522039
-1171,70213,21,"Developed, Open Space","20% trees, 60% grass, and 10% buildings and 10% bare soil",70,Agriculture,,1,1,1,0,-1,0,-1,-1,3,0.66,high,#31a354,71.0047414,1.3872,95.36394864,7.6384,51.81402439,212.31,37.03522039
-1172,70220,22,"Developed, Low Intensity","20% trees, 40% grass, and 40% buildings",70,Agriculture,,1,1,1,0,-1,-1,-1,-1,0,0,none,#ffffff,20.90844667,3.52,72.06732319,0.61,207.2560976,849.24,147.1338816
-1173,70221,22,"Developed, Low Intensity","20% trees, 40% grass, and 40% buildings",70,Agriculture,,1,1,1,0,-1,-1,-1,-1,1,0.15,low,#e5f5e0,31.9391771,2.992,76.82521326,2.1185,207.2560976,849.24,147.1338816
-1174,70222,22,"Developed, Low Intensity","20% trees, 40% grass, and 40% buildings",70,Agriculture,,1,1,1,0,-1,-1,-1,-1,2,0.4,medium,#a1d99b,50.32372781,2.112,84.75503004,4.632666667,207.2560976,849.24,147.1338816
-1175,70223,22,"Developed, Low Intensity","20% trees, 40% grass, and 40% buildings",70,Agriculture,,1,1,1,0,-1,-1,-1,-1,3,0.66,high,#31a354,69.44366054,1.1968,93.0020395,7.2474,207.2560976,849.24,147.1338816
-1176,70230,23,"Developed, Medium Intensity","15% trees, 35% grass, and 50% buildings",70,Agriculture,,1,1,1,0,-1,-1,-1,-1,0,0,none,#ffffff,17.69813636,3.08,61.93838294,0.36,234.070122,954.85,720.4716833
-1177,70231,23,"Developed, Medium Intensity","15% trees, 35% grass, and 50% buildings",70,Agriculture,,1,1,1,0,-1,-1,-1,-1,1,0.15,low,#e5f5e0,29.21041333,2.618,68.21561405,1.906,234.070122,954.85,720.4716833
-1178,70232,23,"Developed, Medium Intensity","15% trees, 35% grass, and 50% buildings",70,Agriculture,,1,1,1,0,-1,-1,-1,-1,2,0.4,medium,#a1d99b,48.39754162,1.848,78.67766589,4.482666667,234.070122,954.85,720.4716833
-1179,70233,23,"Developed, Medium Intensity","15% trees, 35% grass, and 50% buildings",70,Agriculture,,1,1,1,0,-1,-1,-1,-1,3,0.66,high,#31a354,68.35215504,1.0472,89.55819981,7.1624,234.070122,954.85,720.4716833
-1180,70240,24,"Developed, High Intensity","10% trees, 20% grass, and 70% buildings",70,Agriculture,,1,1,1,0,-1,-1,-1,-1,0,0,none,#ffffff,10.98142029,1.76,44.78642515,0.245,267.9065041,3418.485,1805.616283
-1181,70241,24,"Developed, High Intensity","10% trees, 20% grass, and 70% buildings",70,Agriculture,,1,1,1,0,-1,-1,-1,-1,1,0.15,low,#e5f5e0,23.50120467,1.496,53.63644993,1.80825,267.9065041,3418.485,1805.616283
-1182,70242,24,"Developed, High Intensity","10% trees, 20% grass, and 70% buildings",70,Agriculture,,1,1,1,0,-1,-1,-1,-1,2,0.4,medium,#a1d99b,44.36751198,1.056,68.38649122,4.413666667,267.9065041,3418.485,1805.616283
-1183,70243,24,"Developed, High Intensity","10% trees, 20% grass, and 70% buildings",70,Agriculture,,1,1,1,0,-1,-1,-1,-1,3,0.66,high,#31a354,66.06847158,0.5984,83.72653416,7.1233,267.9065041,3418.485,1805.616283
-1184,70310,31,Barren Land,,70,Agriculture,,1,1,1,0,-1,0,-1,-1,0,0,none,#ffffff,6.8,0,25.5,0,0,0,0
-1185,70311,31,Barren Land,,70,Agriculture,,1,1,1,0,-1,0,-1,-1,1,0.15,low,#e5f5e0,19.94699743,0,37.24298855,1.6,0,0,0
-1186,70312,31,Barren Land,,70,Agriculture,,1,1,1,0,-1,0,-1,-1,2,0.4,medium,#a1d99b,41.8586598,0,56.81463613,4.266666667,0,0,0
-1187,70313,31,Barren Land,,70,Agriculture,,1,1,1,0,-1,0,-1,-1,3,0.66,high,#31a354,64.64678868,0,77.16914961,7.04,0,0,0
-1188,70410,41,Deciduous Forest,,70,Agriculture,,-1,1,-1,-1,-1,0,-1,-1,0,0,none,#ffffff,85.88498714,0,96.08994273,8.8,0,0,0
-1189,70411,41,Deciduous Forest,,70,Agriculture,,-1,1,-1,-1,-1,0,-1,-1,1,0.15,low,#e5f5e0,85.88498714,0,96.08994273,8.8,0,0,0
-1190,70412,41,Deciduous Forest,,70,Agriculture,,-1,1,-1,-1,-1,0,-1,-1,2,0.4,medium,#a1d99b,85.88498714,0,96.08994273,8.8,0,0,0
-1191,70413,41,Deciduous Forest,,70,Agriculture,,-1,1,-1,-1,-1,0,-1,-1,3,0.66,high,#31a354,85.88498714,0,96.08994273,8.8,0,0,0
-1192,70420,42,Evergreen Forest,,70,Agriculture,,-1,1,-1,-1,-1,0,-1,-1,0,0,none,#ffffff,105.6849871,0,96.08994273,14.4,0,0,0
-1193,70421,42,Evergreen Forest,,70,Agriculture,,-1,1,-1,-1,-1,0,-1,-1,1,0.15,low,#e5f5e0,105.6849871,0,96.08994273,14.4,0,0,0
-1194,70422,42,Evergreen Forest,,70,Agriculture,,-1,1,-1,-1,-1,0,-1,-1,2,0.4,medium,#a1d99b,105.6849871,0,96.08994273,14.4,0,0,0
-1195,70423,42,Evergreen Forest,,70,Agriculture,,-1,1,-1,-1,-1,0,-1,-1,3,0.66,high,#31a354,105.6849871,0,96.08994273,14.4,0,0,0
-1196,70430,43,Mixed Forest,,70,Agriculture,,-1,1,-1,-1,-1,0,-1,-1,0,0,none,#ffffff,91.76997429,0,119.1798855,8.8,0,0,0
-1197,70431,43,Mixed Forest,,70,Agriculture,,-1,1,-1,-1,-1,0,-1,-1,1,0.15,low,#e5f5e0,91.76997429,0,119.1798855,8.8,0,0,0
-1198,70432,43,Mixed Forest,,70,Agriculture,,-1,1,-1,-1,-1,0,-1,-1,2,0.4,medium,#a1d99b,91.76997429,0,119.1798855,8.8,0,0,0
-1199,70433,43,Mixed Forest,,70,Agriculture,,-1,1,-1,-1,-1,0,-1,-1,3,0.66,high,#31a354,91.76997429,0,119.1798855,8.8,0,0,0
-1200,70520,52,Shrub/Scrub,,70,Agriculture,,1,1,1,0,-1,0,-1,-1,0,0,none,#ffffff,47.875,0,68.15477645,0,0,0,0
-1201,70521,52,Shrub/Scrub,,70,Agriculture,,1,1,1,0,-1,0,-1,-1,1,0.15,low,#e5f5e0,54.86074743,0,73.49954853,1.6,0,0,0
-1202,70522,52,Shrub/Scrub,,70,Agriculture,,1,1,1,0,-1,0,-1,-1,2,0.4,medium,#a1d99b,66.5036598,0,82.407502,4.266666667,0,0,0
-1203,70523,52,Shrub/Scrub,,70,Agriculture,,1,1,1,0,-1,0,-1,-1,3,0.66,high,#31a354,78.61228868,0,91.6717736,7.04,0,0,0
-1204,70710,71,Herbaceuous,,70,Agriculture,,1,1,1,0,-1,0,-1,-1,0,0,none,#ffffff,10.10660117,8,98.79264417,0,0,0,0
-1205,70711,71,Herbaceuous,,70,Agriculture,,1,1,1,0,-1,0,-1,-1,1,0.15,low,#e5f5e0,22.75760842,6.8,99.54173609,1.6,0,0,0
-1206,70712,71,Herbaceuous,,70,Agriculture,,1,1,1,0,-1,0,-1,-1,2,0.4,medium,#a1d99b,43.84262051,4.8,100.7902226,4.266666667,0,0,0
-1207,70713,71,Herbaceuous,,70,Agriculture,,1,1,1,0,-1,0,-1,-1,3,0.66,high,#31a354,65.77103307,2.72,102.0886486,7.04,0,0,0
-1208,70810,81,Hay/Pasture,,70,Agriculture,,1,1,1,0,-1,0,-1,-1,0,0,none,#ffffff,10.10660117,8,98.79264417,0,0,0,0
-1209,70811,81,Hay/Pasture,,70,Agriculture,,1,1,1,0,-1,0,-1,-1,1,0.15,low,#e5f5e0,22.75760842,6.8,99.54173609,1.6,0,0,0
-1210,70812,81,Hay/Pasture,,70,Agriculture,,1,1,1,0,-1,0,-1,-1,2,0.4,medium,#a1d99b,43.84262051,4.8,100.7902226,4.266666667,0,0,0
-1211,70813,81,Hay/Pasture,,70,Agriculture,,1,1,1,0,-1,0,-1,-1,3,0.66,high,#31a354,65.77103307,2.72,102.0886486,7.04,0,0,0
-1212,70820,82,Cultivated Crops,,70,Agriculture,,1,1,1,-1,-1,0,-1,-1,0,0,none,#ffffff,4.793840162,0,65.75263422,0,0,0,0
-1213,70821,82,Cultivated Crops,,70,Agriculture,,1,1,1,-1,-1,0,-1,-1,1,0.15,low,#e5f5e0,18.24176156,0,71.45772764,1.6,0,0,0
-1214,70822,82,Cultivated Crops,,70,Agriculture,,1,1,1,-1,-1,0,-1,-1,2,0.4,medium,#a1d99b,40.6549639,0,80.96621666,4.266666667,0,0,0
-1215,70823,82,Cultivated Crops,,70,Agriculture,,1,1,1,-1,-1,0,-1,-1,3,0.66,high,#31a354,63.96469433,0,90.85504525,7.04,0,0,0
-1216,70900,90,Woody Wetlands,,70,Agriculture,,1,1,-1,-1,-1,0,-1,-1,0,0,none,#ffffff,33.5,0,259,0,0,0,0
-1217,70901,90,Woody Wetlands,,70,Agriculture,,1,1,-1,-1,-1,0,-1,-1,1,0.15,low,#e5f5e0,42.64199743,0,235.7179885,1.6,0,0,0
-1218,70902,90,Woody Wetlands,,70,Agriculture,,1,1,-1,-1,-1,0,-1,-1,2,0.4,medium,#a1d99b,57.8786598,0,196.9146361,4.266666667,0,0,0
-1219,70903,90,Woody Wetlands,,70,Agriculture,,1,1,-1,-1,-1,0,-1,-1,3,0.66,high,#31a354,73.72478868,0,156.5591496,7.04,0,0,0
-1220,70950,95,Emergent Herbaceuous Wetlands,,70,Agriculture,,1,1,-1,-1,-1,0,-1,-1,0,0,none,#ffffff,33.5,0,259,0,0,0,0
-1221,70951,95,Emergent Herbaceuous Wetlands,,70,Agriculture,,1,1,-1,-1,-1,0,-1,-1,1,0.15,low,#e5f5e0,42.64199743,0,235.7179885,1.6,0,0,0
-1222,70952,95,Emergent Herbaceuous Wetlands,,70,Agriculture,,1,1,-1,-1,-1,0,-1,-1,2,0.4,medium,#a1d99b,57.8786598,0,196.9146361,4.266666667,0,0,0
-1223,70953,95,Emergent Herbaceuous Wetlands,,70,Agriculture,,1,1,-1,-1,-1,0,-1,-1,3,0.66,high,#31a354,73.72478868,0,156.5591496,7.04,0,0,0
-1224,80000,0,Background,,80,Rangeland,,-1,-1,-1,-1,-1,-1,-1,-1,0,0,none,#ffffff,0,0,0,0,0,0,0
-1225,80001,0,Background,,80,Rangeland,,-1,-1,-1,-1,-1,-1,-1,-1,1,0.15,low,#e5f5e0,14.16699743,0,15.56798855,1.6,0,0,0
-1226,80002,0,Background,,80,Rangeland,,-1,-1,-1,-1,-1,-1,-1,-1,2,0.4,medium,#a1d99b,37.7786598,0,41.51463613,4.266666667,0,0,0
-1227,80003,0,Background,,80,Rangeland,,-1,-1,-1,-1,-1,-1,-1,-1,3,0.66,high,#31a354,62.33478868,0,68.49914961,7.04,0,0,0
-1228,80110,11,Open Water,,80,Rangeland,,-1,-1,-1,-1,-1,0,1,-1,0,0,none,#ffffff,0,0,0,0,0,0,0
-1229,80111,11,Open Water,,80,Rangeland,,-1,-1,-1,-1,-1,0,1,-1,1,0.15,low,#e5f5e0,14.16699743,0,15.56798855,1.6,0,0,0
-1230,80112,11,Open Water,,80,Rangeland,,-1,-1,-1,-1,-1,0,1,-1,2,0.4,medium,#a1d99b,37.7786598,0,41.51463613,4.266666667,0,0,0
-1231,80113,11,Open Water,,80,Rangeland,,-1,-1,-1,-1,-1,0,1,-1,3,0.66,high,#31a354,62.33478868,0,68.49914961,7.04,0,0,0
-1232,80120,12,Perennial Ice/Snow,,80,Rangeland,,-1,-1,-1,-1,-1,-1,-1,-1,0,0,none,#ffffff,0,0,0,0,0,0,0
-1233,80121,12,Perennial Ice/Snow,,80,Rangeland,,-1,-1,-1,-1,-1,-1,-1,-1,1,0.15,low,#e5f5e0,14.16699743,0,15.56798855,1.6,0,0,0
-1234,80122,12,Perennial Ice/Snow,,80,Rangeland,,-1,-1,-1,-1,-1,-1,-1,-1,2,0.4,medium,#a1d99b,37.7786598,0,41.51463613,4.266666667,0,0,0
-1235,80123,12,Perennial Ice/Snow,,80,Rangeland,,-1,-1,-1,-1,-1,-1,-1,-1,3,0.66,high,#31a354,62.33478868,0,68.49914961,7.04,0,0,0
-1236,80210,21,"Developed, Open Space","20% trees, 60% grass, and 10% buildings and 10% bare soil",80,Rangeland,,-1,-1,-1,0.5,0.3,0,1,-1,0,0,none,#ffffff,25.49986095,4.08,79.01411479,1.76,51.81402439,212.31,37.03522039
-1237,80211,21,"Developed, Open Space","20% trees, 60% grass, and 10% buildings and 10% bare soil",80,Rangeland,,-1,-1,-1,0.5,0.3,0,1,-1,1,0.15,low,#e5f5e0,35.84187923,3.468,82.72998612,3.096,51.81402439,212.31,37.03522039
-1238,80212,21,"Developed, Open Space","20% trees, 60% grass, and 10% buildings and 10% bare soil",80,Rangeland,,-1,-1,-1,0.5,0.3,0,1,-1,2,0.4,medium,#a1d99b,53.07857637,2.448,88.923105,5.322666667,51.81402439,212.31,37.03522039
-1239,80213,21,"Developed, Open Space","20% trees, 60% grass, and 10% buildings and 10% bare soil",80,Rangeland,,-1,-1,-1,0.5,0.3,0,1,-1,3,0.66,high,#31a354,71.0047414,1.3872,95.36394864,7.6384,51.81402439,212.31,37.03522039
-1240,80220,22,"Developed, Low Intensity","20% trees, 40% grass, and 40% buildings",80,Rangeland,,-1,-1,-1,0.5,0.3,-1,1,-1,0,0,none,#ffffff,20.90844667,3.52,72.06732319,0.61,207.2560976,849.24,147.1338816
-1241,80221,22,"Developed, Low Intensity","20% trees, 40% grass, and 40% buildings",80,Rangeland,,-1,-1,-1,0.5,0.3,-1,1,-1,1,0.15,low,#e5f5e0,31.9391771,2.992,76.82521326,2.1185,207.2560976,849.24,147.1338816
-1242,80222,22,"Developed, Low Intensity","20% trees, 40% grass, and 40% buildings",80,Rangeland,,-1,-1,-1,0.5,0.3,-1,1,-1,2,0.4,medium,#a1d99b,50.32372781,2.112,84.75503004,4.632666667,207.2560976,849.24,147.1338816
-1243,80223,22,"Developed, Low Intensity","20% trees, 40% grass, and 40% buildings",80,Rangeland,,-1,-1,-1,0.5,0.3,-1,1,-1,3,0.66,high,#31a354,69.44366054,1.1968,93.0020395,7.2474,207.2560976,849.24,147.1338816
-1244,80230,23,"Developed, Medium Intensity","15% trees, 35% grass, and 50% buildings",80,Rangeland,,-1,-1,-1,0.5,0.3,-1,1,-1,0,0,none,#ffffff,17.69813636,3.08,61.93838294,0.36,234.070122,954.85,720.4716833
-1245,80231,23,"Developed, Medium Intensity","15% trees, 35% grass, and 50% buildings",80,Rangeland,,-1,-1,-1,0.5,0.3,-1,1,-1,1,0.15,low,#e5f5e0,29.21041333,2.618,68.21561405,1.906,234.070122,954.85,720.4716833
-1246,80232,23,"Developed, Medium Intensity","15% trees, 35% grass, and 50% buildings",80,Rangeland,,-1,-1,-1,0.5,0.3,-1,1,-1,2,0.4,medium,#a1d99b,48.39754162,1.848,78.67766589,4.482666667,234.070122,954.85,720.4716833
-1247,80233,23,"Developed, Medium Intensity","15% trees, 35% grass, and 50% buildings",80,Rangeland,,-1,-1,-1,0.5,0.3,-1,1,-1,3,0.66,high,#31a354,68.35215504,1.0472,89.55819981,7.1624,234.070122,954.85,720.4716833
-1248,80240,24,"Developed, High Intensity","10% trees, 20% grass, and 70% buildings",80,Rangeland,,-1,-1,-1,0.5,0.3,-1,1,-1,0,0,none,#ffffff,10.98142029,1.76,44.78642515,0.245,267.9065041,3418.485,1805.616283
-1249,80241,24,"Developed, High Intensity","10% trees, 20% grass, and 70% buildings",80,Rangeland,,-1,-1,-1,0.5,0.3,-1,1,-1,1,0.15,low,#e5f5e0,23.50120467,1.496,53.63644993,1.80825,267.9065041,3418.485,1805.616283
-1250,80242,24,"Developed, High Intensity","10% trees, 20% grass, and 70% buildings",80,Rangeland,,-1,-1,-1,0.5,0.3,-1,1,-1,2,0.4,medium,#a1d99b,44.36751198,1.056,68.38649122,4.413666667,267.9065041,3418.485,1805.616283
-1251,80243,24,"Developed, High Intensity","10% trees, 20% grass, and 70% buildings",80,Rangeland,,-1,-1,-1,0.5,0.3,-1,1,-1,3,0.66,high,#31a354,66.06847158,0.5984,83.72653416,7.1233,267.9065041,3418.485,1805.616283
-1252,80310,31,Barren Land,,80,Rangeland,,-1,-1,-1,0.5,0.3,0,1,-1,0,0,none,#ffffff,6.8,0,25.5,0,0,0,0
-1253,80311,31,Barren Land,,80,Rangeland,,-1,-1,-1,0.5,0.3,0,1,-1,1,0.15,low,#e5f5e0,19.94699743,0,37.24298855,1.6,0,0,0
-1254,80312,31,Barren Land,,80,Rangeland,,-1,-1,-1,0.5,0.3,0,1,-1,2,0.4,medium,#a1d99b,41.8586598,0,56.81463613,4.266666667,0,0,0
-1255,80313,31,Barren Land,,80,Rangeland,,-1,-1,-1,0.5,0.3,0,1,-1,3,0.66,high,#31a354,64.64678868,0,77.16914961,7.04,0,0,0
-1256,80410,41,Deciduous Forest,,80,Rangeland,,-1,-1,-1,-1,0.3,0,1,-1,0,0,none,#ffffff,85.88498714,0,96.08994273,8.8,0,0,0
-1257,80411,41,Deciduous Forest,,80,Rangeland,,-1,-1,-1,-1,0.3,0,1,-1,1,0.15,low,#e5f5e0,85.88498714,0,96.08994273,8.8,0,0,0
-1258,80412,41,Deciduous Forest,,80,Rangeland,,-1,-1,-1,-1,0.3,0,1,-1,2,0.4,medium,#a1d99b,85.88498714,0,96.08994273,8.8,0,0,0
-1259,80413,41,Deciduous Forest,,80,Rangeland,,-1,-1,-1,-1,0.3,0,1,-1,3,0.66,high,#31a354,85.88498714,0,96.08994273,8.8,0,0,0
-1260,80420,42,Evergreen Forest,,80,Rangeland,,-1,-1,-1,-1,0.3,0,1,-1,0,0,none,#ffffff,105.6849871,0,96.08994273,14.4,0,0,0
-1261,80421,42,Evergreen Forest,,80,Rangeland,,-1,-1,-1,-1,0.3,0,1,-1,1,0.15,low,#e5f5e0,105.6849871,0,96.08994273,14.4,0,0,0
-1262,80422,42,Evergreen Forest,,80,Rangeland,,-1,-1,-1,-1,0.3,0,1,-1,2,0.4,medium,#a1d99b,105.6849871,0,96.08994273,14.4,0,0,0
-1263,80423,42,Evergreen Forest,,80,Rangeland,,-1,-1,-1,-1,0.3,0,1,-1,3,0.66,high,#31a354,105.6849871,0,96.08994273,14.4,0,0,0
-1264,80430,43,Mixed Forest,,80,Rangeland,,-1,-1,-1,-1,0.3,0,1,-1,0,0,none,#ffffff,91.76997429,0,119.1798855,8.8,0,0,0
-1265,80431,43,Mixed Forest,,80,Rangeland,,-1,-1,-1,-1,0.3,0,1,-1,1,0.15,low,#e5f5e0,91.76997429,0,119.1798855,8.8,0,0,0
-1266,80432,43,Mixed Forest,,80,Rangeland,,-1,-1,-1,-1,0.3,0,1,-1,2,0.4,medium,#a1d99b,91.76997429,0,119.1798855,8.8,0,0,0
-1267,80433,43,Mixed Forest,,80,Rangeland,,-1,-1,-1,-1,0.3,0,1,-1,3,0.66,high,#31a354,91.76997429,0,119.1798855,8.8,0,0,0
-1268,80520,52,Shrub/Scrub,,80,Rangeland,,-1,-1,-1,0.5,0.3,0,1,-1,0,0,none,#ffffff,47.875,0,68.15477645,0,0,0,0
-1269,80521,52,Shrub/Scrub,,80,Rangeland,,-1,-1,-1,0.5,0.3,0,1,-1,1,0.15,low,#e5f5e0,54.86074743,0,73.49954853,1.6,0,0,0
-1270,80522,52,Shrub/Scrub,,80,Rangeland,,-1,-1,-1,0.5,0.3,0,1,-1,2,0.4,medium,#a1d99b,66.5036598,0,82.407502,4.266666667,0,0,0
-1271,80523,52,Shrub/Scrub,,80,Rangeland,,-1,-1,-1,0.5,0.3,0,1,-1,3,0.66,high,#31a354,78.61228868,0,91.6717736,7.04,0,0,0
-1272,80710,71,Herbaceuous,,80,Rangeland,,-1,-1,-1,0.5,0.3,0,1,-1,0,0,none,#ffffff,10.10660117,8,98.79264417,0,0,0,0
-1273,80711,71,Herbaceuous,,80,Rangeland,,-1,-1,-1,0.5,0.3,0,1,-1,1,0.15,low,#e5f5e0,22.75760842,6.8,99.54173609,1.6,0,0,0
-1274,80712,71,Herbaceuous,,80,Rangeland,,-1,-1,-1,0.5,0.3,0,1,-1,2,0.4,medium,#a1d99b,43.84262051,4.8,100.7902226,4.266666667,0,0,0
-1275,80713,71,Herbaceuous,,80,Rangeland,,-1,-1,-1,0.5,0.3,0,1,-1,3,0.66,high,#31a354,65.77103307,2.72,102.0886486,7.04,0,0,0
-1276,80810,81,Hay/Pasture,,80,Rangeland,,-1,-1,-1,0.5,0.3,0,1,-1,0,0,none,#ffffff,10.10660117,8,98.79264417,0,0,0,0
-1277,80811,81,Hay/Pasture,,80,Rangeland,,-1,-1,-1,0.5,0.3,0,1,-1,1,0.15,low,#e5f5e0,22.75760842,6.8,99.54173609,1.6,0,0,0
-1278,80812,81,Hay/Pasture,,80,Rangeland,,-1,-1,-1,0.5,0.3,0,1,-1,2,0.4,medium,#a1d99b,43.84262051,4.8,100.7902226,4.266666667,0,0,0
-1279,80813,81,Hay/Pasture,,80,Rangeland,,-1,-1,-1,0.5,0.3,0,1,-1,3,0.66,high,#31a354,65.77103307,2.72,102.0886486,7.04,0,0,0
-1280,80820,82,Cultivated Crops,,80,Rangeland,,-1,-1,-1,-1,-1,0,1,-1,0,0,none,#ffffff,4.793840162,0,65.75263422,0,0,0,0
-1281,80821,82,Cultivated Crops,,80,Rangeland,,-1,-1,-1,-1,-1,0,1,-1,1,0.15,low,#e5f5e0,18.24176156,0,71.45772764,1.6,0,0,0
-1282,80822,82,Cultivated Crops,,80,Rangeland,,-1,-1,-1,-1,-1,0,1,-1,2,0.4,medium,#a1d99b,40.6549639,0,80.96621666,4.266666667,0,0,0
-1283,80823,82,Cultivated Crops,,80,Rangeland,,-1,-1,-1,-1,-1,0,1,-1,3,0.66,high,#31a354,63.96469433,0,90.85504525,7.04,0,0,0
-1284,80900,90,Woody Wetlands,,80,Rangeland,,-1,-1,-1,-1,0.3,0,1,-1,0,0,none,#ffffff,33.5,0,259,0,0,0,0
-1285,80901,90,Woody Wetlands,,80,Rangeland,,-1,-1,-1,-1,0.3,0,1,-1,1,0.15,low,#e5f5e0,42.64199743,0,235.7179885,1.6,0,0,0
-1286,80902,90,Woody Wetlands,,80,Rangeland,,-1,-1,-1,-1,0.3,0,1,-1,2,0.4,medium,#a1d99b,57.8786598,0,196.9146361,4.266666667,0,0,0
-1287,80903,90,Woody Wetlands,,80,Rangeland,,-1,-1,-1,-1,0.3,0,1,-1,3,0.66,high,#31a354,73.72478868,0,156.5591496,7.04,0,0,0
-1288,80950,95,Emergent Herbaceuous Wetlands,,80,Rangeland,,-1,-1,-1,-1,0.3,0,1,-1,0,0,none,#ffffff,33.5,0,259,0,0,0,0
-1289,80951,95,Emergent Herbaceuous Wetlands,,80,Rangeland,,-1,-1,-1,-1,0.3,0,1,-1,1,0.15,low,#e5f5e0,42.64199743,0,235.7179885,1.6,0,0,0
-1290,80952,95,Emergent Herbaceuous Wetlands,,80,Rangeland,,-1,-1,-1,-1,0.3,0,1,-1,2,0.4,medium,#a1d99b,57.8786598,0,196.9146361,4.266666667,0,0,0
-1291,80953,95,Emergent Herbaceuous Wetlands,,80,Rangeland,,-1,-1,-1,-1,0.3,0,1,-1,3,0.66,high,#31a354,73.72478868,0,156.5591496,7.04,0,0,0
-1292,90000,0,Background,,90,Extractive/Mining,,-1,-1,-1,-1,-1,-1,-1,-1,0,0,none,#ffffff,0,0,0,0,0,0,0
-1293,90001,0,Background,,90,Extractive/Mining,,-1,-1,-1,-1,-1,-1,-1,-1,1,0.15,low,#e5f5e0,14.16699743,0,15.56798855,1.6,0,0,0
-1294,90002,0,Background,,90,Extractive/Mining,,-1,-1,-1,-1,-1,-1,-1,-1,2,0.4,medium,#a1d99b,37.7786598,0,41.51463613,4.266666667,0,0,0
-1295,90003,0,Background,,90,Extractive/Mining,,-1,-1,-1,-1,-1,-1,-1,-1,3,0.66,high,#31a354,62.33478868,0,68.49914961,7.04,0,0,0
-1296,90110,11,Open Water,,90,Extractive/Mining,,-1,-1,-1,-1,-1,0,-1,-1,0,0,none,#ffffff,0,0,0,0,0,0,0
-1297,90111,11,Open Water,,90,Extractive/Mining,,-1,-1,-1,-1,-1,0,-1,-1,1,0.15,low,#e5f5e0,14.16699743,0,15.56798855,1.6,0,0,0
-1298,90112,11,Open Water,,90,Extractive/Mining,,-1,-1,-1,-1,-1,0,-1,-1,2,0.4,medium,#a1d99b,37.7786598,0,41.51463613,4.266666667,0,0,0
-1299,90113,11,Open Water,,90,Extractive/Mining,,-1,-1,-1,-1,-1,0,-1,-1,3,0.66,high,#31a354,62.33478868,0,68.49914961,7.04,0,0,0
-1300,90120,12,Perennial Ice/Snow,,90,Extractive/Mining,,-1,-1,-1,-1,-1,-1,-1,-1,0,0,none,#ffffff,0,0,0,0,0,0,0
-1301,90121,12,Perennial Ice/Snow,,90,Extractive/Mining,,-1,-1,-1,-1,-1,-1,-1,-1,1,0.15,low,#e5f5e0,14.16699743,0,15.56798855,1.6,0,0,0
-1302,90122,12,Perennial Ice/Snow,,90,Extractive/Mining,,-1,-1,-1,-1,-1,-1,-1,-1,2,0.4,medium,#a1d99b,37.7786598,0,41.51463613,4.266666667,0,0,0
-1303,90123,12,Perennial Ice/Snow,,90,Extractive/Mining,,-1,-1,-1,-1,-1,-1,-1,-1,3,0.66,high,#31a354,62.33478868,0,68.49914961,7.04,0,0,0
-1304,90210,21,"Developed, Open Space","20% trees, 60% grass, and 10% buildings and 10% bare soil",90,Extractive/Mining,,-1,-1,-1,-1,-1,0,-1,-1,0,0,none,#ffffff,25.49986095,4.08,79.01411479,1.76,51.81402439,212.31,37.03522039
-1305,90211,21,"Developed, Open Space","20% trees, 60% grass, and 10% buildings and 10% bare soil",90,Extractive/Mining,,-1,-1,-1,-1,-1,0,-1,-1,1,0.15,low,#e5f5e0,35.84187923,3.468,82.72998612,3.096,51.81402439,212.31,37.03522039
-1306,90212,21,"Developed, Open Space","20% trees, 60% grass, and 10% buildings and 10% bare soil",90,Extractive/Mining,,-1,-1,-1,-1,-1,0,-1,-1,2,0.4,medium,#a1d99b,53.07857637,2.448,88.923105,5.322666667,51.81402439,212.31,37.03522039
-1307,90213,21,"Developed, Open Space","20% trees, 60% grass, and 10% buildings and 10% bare soil",90,Extractive/Mining,,-1,-1,-1,-1,-1,0,-1,-1,3,0.66,high,#31a354,71.0047414,1.3872,95.36394864,7.6384,51.81402439,212.31,37.03522039
-1308,90220,22,"Developed, Low Intensity","20% trees, 40% grass, and 40% buildings",90,Extractive/Mining,,-1,-1,-1,-1,-1,-1,-1,-1,0,0,none,#ffffff,20.90844667,3.52,72.06732319,0.61,207.2560976,849.24,147.1338816
-1309,90221,22,"Developed, Low Intensity","20% trees, 40% grass, and 40% buildings",90,Extractive/Mining,,-1,-1,-1,-1,-1,-1,-1,-1,1,0.15,low,#e5f5e0,31.9391771,2.992,76.82521326,2.1185,207.2560976,849.24,147.1338816
-1310,90222,22,"Developed, Low Intensity","20% trees, 40% grass, and 40% buildings",90,Extractive/Mining,,-1,-1,-1,-1,-1,-1,-1,-1,2,0.4,medium,#a1d99b,50.32372781,2.112,84.75503004,4.632666667,207.2560976,849.24,147.1338816
-1311,90223,22,"Developed, Low Intensity","20% trees, 40% grass, and 40% buildings",90,Extractive/Mining,,-1,-1,-1,-1,-1,-1,-1,-1,3,0.66,high,#31a354,69.44366054,1.1968,93.0020395,7.2474,207.2560976,849.24,147.1338816
-1312,90230,23,"Developed, Medium Intensity","15% trees, 35% grass, and 50% buildings",90,Extractive/Mining,,-1,-1,-1,-1,-1,-1,-1,-1,0,0,none,#ffffff,17.69813636,3.08,61.93838294,0.36,234.070122,954.85,720.4716833
-1313,90231,23,"Developed, Medium Intensity","15% trees, 35% grass, and 50% buildings",90,Extractive/Mining,,-1,-1,-1,-1,-1,-1,-1,-1,1,0.15,low,#e5f5e0,29.21041333,2.618,68.21561405,1.906,234.070122,954.85,720.4716833
-1314,90232,23,"Developed, Medium Intensity","15% trees, 35% grass, and 50% buildings",90,Extractive/Mining,,-1,-1,-1,-1,-1,-1,-1,-1,2,0.4,medium,#a1d99b,48.39754162,1.848,78.67766589,4.482666667,234.070122,954.85,720.4716833
-1315,90233,23,"Developed, Medium Intensity","15% trees, 35% grass, and 50% buildings",90,Extractive/Mining,,-1,-1,-1,-1,-1,-1,-1,-1,3,0.66,high,#31a354,68.35215504,1.0472,89.55819981,7.1624,234.070122,954.85,720.4716833
-1316,90240,24,"Developed, High Intensity","10% trees, 20% grass, and 70% buildings",90,Extractive/Mining,,-1,-1,-1,-1,-1,-1,-1,-1,0,0,none,#ffffff,10.98142029,1.76,44.78642515,0.245,267.9065041,3418.485,1805.616283
-1317,90241,24,"Developed, High Intensity","10% trees, 20% grass, and 70% buildings",90,Extractive/Mining,,-1,-1,-1,-1,-1,-1,-1,-1,1,0.15,low,#e5f5e0,23.50120467,1.496,53.63644993,1.80825,267.9065041,3418.485,1805.616283
-1318,90242,24,"Developed, High Intensity","10% trees, 20% grass, and 70% buildings",90,Extractive/Mining,,-1,-1,-1,-1,-1,-1,-1,-1,2,0.4,medium,#a1d99b,44.36751198,1.056,68.38649122,4.413666667,267.9065041,3418.485,1805.616283
-1319,90243,24,"Developed, High Intensity","10% trees, 20% grass, and 70% buildings",90,Extractive/Mining,,-1,-1,-1,-1,-1,-1,-1,-1,3,0.66,high,#31a354,66.06847158,0.5984,83.72653416,7.1233,267.9065041,3418.485,1805.616283
-1320,90310,31,Barren Land,,90,Extractive/Mining,,-1,-1,-1,-1,-1,0,-1,-1,0,0,none,#ffffff,6.8,0,25.5,0,0,0,0
-1321,90311,31,Barren Land,,90,Extractive/Mining,,-1,-1,-1,-1,-1,0,-1,-1,1,0.15,low,#e5f5e0,19.94699743,0,37.24298855,1.6,0,0,0
-1322,90312,31,Barren Land,,90,Extractive/Mining,,-1,-1,-1,-1,-1,0,-1,-1,2,0.4,medium,#a1d99b,41.8586598,0,56.81463613,4.266666667,0,0,0
-1323,90313,31,Barren Land,,90,Extractive/Mining,,-1,-1,-1,-1,-1,0,-1,-1,3,0.66,high,#31a354,64.64678868,0,77.16914961,7.04,0,0,0
-1324,90410,41,Deciduous Forest,,90,Extractive/Mining,,-1,-1,-1,-1,-1,0,-1,-1,0,0,none,#ffffff,85.88498714,0,96.08994273,8.8,0,0,0
-1325,90411,41,Deciduous Forest,,90,Extractive/Mining,,-1,-1,-1,-1,-1,0,-1,-1,1,0.15,low,#e5f5e0,85.88498714,0,96.08994273,8.8,0,0,0
-1326,90412,41,Deciduous Forest,,90,Extractive/Mining,,-1,-1,-1,-1,-1,0,-1,-1,2,0.4,medium,#a1d99b,85.88498714,0,96.08994273,8.8,0,0,0
-1327,90413,41,Deciduous Forest,,90,Extractive/Mining,,-1,-1,-1,-1,-1,0,-1,-1,3,0.66,high,#31a354,85.88498714,0,96.08994273,8.8,0,0,0
-1328,90420,42,Evergreen Forest,,90,Extractive/Mining,,-1,-1,-1,-1,-1,0,-1,-1,0,0,none,#ffffff,105.6849871,0,96.08994273,14.4,0,0,0
-1329,90421,42,Evergreen Forest,,90,Extractive/Mining,,-1,-1,-1,-1,-1,0,-1,-1,1,0.15,low,#e5f5e0,105.6849871,0,96.08994273,14.4,0,0,0
-1330,90422,42,Evergreen Forest,,90,Extractive/Mining,,-1,-1,-1,-1,-1,0,-1,-1,2,0.4,medium,#a1d99b,105.6849871,0,96.08994273,14.4,0,0,0
-1331,90423,42,Evergreen Forest,,90,Extractive/Mining,,-1,-1,-1,-1,-1,0,-1,-1,3,0.66,high,#31a354,105.6849871,0,96.08994273,14.4,0,0,0
-1332,90430,43,Mixed Forest,,90,Extractive/Mining,,-1,-1,-1,-1,-1,0,-1,-1,0,0,none,#ffffff,91.76997429,0,119.1798855,8.8,0,0,0
-1333,90431,43,Mixed Forest,,90,Extractive/Mining,,-1,-1,-1,-1,-1,0,-1,-1,1,0.15,low,#e5f5e0,91.76997429,0,119.1798855,8.8,0,0,0
-1334,90432,43,Mixed Forest,,90,Extractive/Mining,,-1,-1,-1,-1,-1,0,-1,-1,2,0.4,medium,#a1d99b,91.76997429,0,119.1798855,8.8,0,0,0
-1335,90433,43,Mixed Forest,,90,Extractive/Mining,,-1,-1,-1,-1,-1,0,-1,-1,3,0.66,high,#31a354,91.76997429,0,119.1798855,8.8,0,0,0
-1336,90520,52,Shrub/Scrub,,90,Extractive/Mining,,-1,-1,-1,-1,-1,0,-1,-1,0,0,none,#ffffff,47.875,0,68.15477645,0,0,0,0
-1337,90521,52,Shrub/Scrub,,90,Extractive/Mining,,-1,-1,-1,-1,-1,0,-1,-1,1,0.15,low,#e5f5e0,54.86074743,0,73.49954853,1.6,0,0,0
-1338,90522,52,Shrub/Scrub,,90,Extractive/Mining,,-1,-1,-1,-1,-1,0,-1,-1,2,0.4,medium,#a1d99b,66.5036598,0,82.407502,4.266666667,0,0,0
-1339,90523,52,Shrub/Scrub,,90,Extractive/Mining,,-1,-1,-1,-1,-1,0,-1,-1,3,0.66,high,#31a354,78.61228868,0,91.6717736,7.04,0,0,0
-1340,90710,71,Herbaceuous,,90,Extractive/Mining,,-1,-1,-1,-1,-1,0,-1,-1,0,0,none,#ffffff,10.10660117,8,98.79264417,0,0,0,0
-1341,90711,71,Herbaceuous,,90,Extractive/Mining,,-1,-1,-1,-1,-1,0,-1,-1,1,0.15,low,#e5f5e0,22.75760842,6.8,99.54173609,1.6,0,0,0
-1342,90712,71,Herbaceuous,,90,Extractive/Mining,,-1,-1,-1,-1,-1,0,-1,-1,2,0.4,medium,#a1d99b,43.84262051,4.8,100.7902226,4.266666667,0,0,0
-1343,90713,71,Herbaceuous,,90,Extractive/Mining,,-1,-1,-1,-1,-1,0,-1,-1,3,0.66,high,#31a354,65.77103307,2.72,102.0886486,7.04,0,0,0
-1344,90810,81,Hay/Pasture,,90,Extractive/Mining,,-1,-1,-1,-1,-1,0,-1,-1,0,0,none,#ffffff,10.10660117,8,98.79264417,0,0,0,0
-1345,90811,81,Hay/Pasture,,90,Extractive/Mining,,-1,-1,-1,-1,-1,0,-1,-1,1,0.15,low,#e5f5e0,22.75760842,6.8,99.54173609,1.6,0,0,0
-1346,90812,81,Hay/Pasture,,90,Extractive/Mining,,-1,-1,-1,-1,-1,0,-1,-1,2,0.4,medium,#a1d99b,43.84262051,4.8,100.7902226,4.266666667,0,0,0
-1347,90813,81,Hay/Pasture,,90,Extractive/Mining,,-1,-1,-1,-1,-1,0,-1,-1,3,0.66,high,#31a354,65.77103307,2.72,102.0886486,7.04,0,0,0
-1348,90820,82,Cultivated Crops,,90,Extractive/Mining,,-1,-1,-1,-1,-1,0,-1,-1,0,0,none,#ffffff,4.793840162,0,65.75263422,0,0,0,0
-1349,90821,82,Cultivated Crops,,90,Extractive/Mining,,-1,-1,-1,-1,-1,0,-1,-1,1,0.15,low,#e5f5e0,18.24176156,0,71.45772764,1.6,0,0,0
-1350,90822,82,Cultivated Crops,,90,Extractive/Mining,,-1,-1,-1,-1,-1,0,-1,-1,2,0.4,medium,#a1d99b,40.6549639,0,80.96621666,4.266666667,0,0,0
-1351,90823,82,Cultivated Crops,,90,Extractive/Mining,,-1,-1,-1,-1,-1,0,-1,-1,3,0.66,high,#31a354,63.96469433,0,90.85504525,7.04,0,0,0
-1352,90900,90,Woody Wetlands,,90,Extractive/Mining,,-1,-1,-1,-1,-1,0,-1,-1,0,0,none,#ffffff,33.5,0,259,0,0,0,0
-1353,90901,90,Woody Wetlands,,90,Extractive/Mining,,-1,-1,-1,-1,-1,0,-1,-1,1,0.15,low,#e5f5e0,42.64199743,0,235.7179885,1.6,0,0,0
-1354,90902,90,Woody Wetlands,,90,Extractive/Mining,,-1,-1,-1,-1,-1,0,-1,-1,2,0.4,medium,#a1d99b,57.8786598,0,196.9146361,4.266666667,0,0,0
-1355,90903,90,Woody Wetlands,,90,Extractive/Mining,,-1,-1,-1,-1,-1,0,-1,-1,3,0.66,high,#31a354,73.72478868,0,156.5591496,7.04,0,0,0
-1356,90950,95,Emergent Herbaceuous Wetlands,,90,Extractive/Mining,,-1,-1,-1,-1,-1,0,-1,-1,0,0,none,#ffffff,33.5,0,259,0,0,0,0
-1357,90951,95,Emergent Herbaceuous Wetlands,,90,Extractive/Mining,,-1,-1,-1,-1,-1,0,-1,-1,1,0.15,low,#e5f5e0,42.64199743,0,235.7179885,1.6,0,0,0
-1358,90952,95,Emergent Herbaceuous Wetlands,,90,Extractive/Mining,,-1,-1,-1,-1,-1,0,-1,-1,2,0.4,medium,#a1d99b,57.8786598,0,196.9146361,4.266666667,0,0,0
-1359,90953,95,Emergent Herbaceuous Wetlands,,90,Extractive/Mining,,-1,-1,-1,-1,-1,0,-1,-1,3,0.66,high,#31a354,73.72478868,0,156.5591496,7.04,0,0,0
-1360,100000,0,Background,,100,Timber,,-1,-1,-1,-1,-1,-1,-1,-1,0,0,none,#ffffff,0,0,0,0,0,0,0
-1361,100001,0,Background,,100,Timber,,-1,-1,-1,-1,-1,-1,-1,-1,1,0.15,low,#e5f5e0,14.16699743,0,15.56798855,1.6,0,0,0
-1362,100002,0,Background,,100,Timber,,-1,-1,-1,-1,-1,-1,-1,-1,2,0.4,medium,#a1d99b,37.7786598,0,41.51463613,4.266666667,0,0,0
-1363,100003,0,Background,,100,Timber,,-1,-1,-1,-1,-1,-1,-1,-1,3,0.66,high,#31a354,62.33478868,0,68.49914961,7.04,0,0,0
-1364,100110,11,Open Water,,100,Timber,,-1,-1,-1,-1,-1,0,1,-1,0,0,none,#ffffff,0,0,0,0,0,0,0
-1365,100111,11,Open Water,,100,Timber,,-1,-1,-1,-1,-1,0,1,-1,1,0.15,low,#e5f5e0,14.16699743,0,15.56798855,1.6,0,0,0
-1366,100112,11,Open Water,,100,Timber,,-1,-1,-1,-1,-1,0,1,-1,2,0.4,medium,#a1d99b,37.7786598,0,41.51463613,4.266666667,0,0,0
-1367,100113,11,Open Water,,100,Timber,,-1,-1,-1,-1,-1,0,1,-1,3,0.66,high,#31a354,62.33478868,0,68.49914961,7.04,0,0,0
-1368,100120,12,Perennial Ice/Snow,,100,Timber,,-1,-1,-1,-1,-1,-1,-1,-1,0,0,none,#ffffff,0,0,0,0,0,0,0
-1369,100121,12,Perennial Ice/Snow,,100,Timber,,-1,-1,-1,-1,-1,-1,-1,-1,1,0.15,low,#e5f5e0,14.16699743,0,15.56798855,1.6,0,0,0
-1370,100122,12,Perennial Ice/Snow,,100,Timber,,-1,-1,-1,-1,-1,-1,-1,-1,2,0.4,medium,#a1d99b,37.7786598,0,41.51463613,4.266666667,0,0,0
-1371,100123,12,Perennial Ice/Snow,,100,Timber,,-1,-1,-1,-1,-1,-1,-1,-1,3,0.66,high,#31a354,62.33478868,0,68.49914961,7.04,0,0,0
-1372,100210,21,"Developed, Open Space","20% trees, 60% grass, and 10% buildings and 10% bare soil",100,Timber,,-1,-1,-1,-1,0.3,0,1,-1,0,0,none,#ffffff,25.49986095,4.08,79.01411479,1.76,51.81402439,212.31,37.03522039
-1373,100211,21,"Developed, Open Space","20% trees, 60% grass, and 10% buildings and 10% bare soil",100,Timber,,-1,-1,-1,-1,0.3,0,1,-1,1,0.15,low,#e5f5e0,35.84187923,3.468,82.72998612,3.096,51.81402439,212.31,37.03522039
-1374,100212,21,"Developed, Open Space","20% trees, 60% grass, and 10% buildings and 10% bare soil",100,Timber,,-1,-1,-1,-1,0.3,0,1,-1,2,0.4,medium,#a1d99b,53.07857637,2.448,88.923105,5.322666667,51.81402439,212.31,37.03522039
-1375,100213,21,"Developed, Open Space","20% trees, 60% grass, and 10% buildings and 10% bare soil",100,Timber,,-1,-1,-1,-1,0.3,0,1,-1,3,0.66,high,#31a354,71.0047414,1.3872,95.36394864,7.6384,51.81402439,212.31,37.03522039
-1376,100220,22,"Developed, Low Intensity","20% trees, 40% grass, and 40% buildings",100,Timber,,-1,-1,-1,-1,0.3,-1,1,-1,0,0,none,#ffffff,20.90844667,3.52,72.06732319,0.61,207.2560976,849.24,147.1338816
-1377,100221,22,"Developed, Low Intensity","20% trees, 40% grass, and 40% buildings",100,Timber,,-1,-1,-1,-1,0.3,-1,1,-1,1,0.15,low,#e5f5e0,31.9391771,2.992,76.82521326,2.1185,207.2560976,849.24,147.1338816
-1378,100222,22,"Developed, Low Intensity","20% trees, 40% grass, and 40% buildings",100,Timber,,-1,-1,-1,-1,0.3,-1,1,-1,2,0.4,medium,#a1d99b,50.32372781,2.112,84.75503004,4.632666667,207.2560976,849.24,147.1338816
-1379,100223,22,"Developed, Low Intensity","20% trees, 40% grass, and 40% buildings",100,Timber,,-1,-1,-1,-1,0.3,-1,1,-1,3,0.66,high,#31a354,69.44366054,1.1968,93.0020395,7.2474,207.2560976,849.24,147.1338816
-1380,100230,23,"Developed, Medium Intensity","15% trees, 35% grass, and 50% buildings",100,Timber,,-1,-1,-1,-1,0.3,-1,1,-1,0,0,none,#ffffff,17.69813636,3.08,61.93838294,0.36,234.070122,954.85,720.4716833
-1381,100231,23,"Developed, Medium Intensity","15% trees, 35% grass, and 50% buildings",100,Timber,,-1,-1,-1,-1,0.3,-1,1,-1,1,0.15,low,#e5f5e0,29.21041333,2.618,68.21561405,1.906,234.070122,954.85,720.4716833
-1382,100232,23,"Developed, Medium Intensity","15% trees, 35% grass, and 50% buildings",100,Timber,,-1,-1,-1,-1,0.3,-1,1,-1,2,0.4,medium,#a1d99b,48.39754162,1.848,78.67766589,4.482666667,234.070122,954.85,720.4716833
-1383,100233,23,"Developed, Medium Intensity","15% trees, 35% grass, and 50% buildings",100,Timber,,-1,-1,-1,-1,0.3,-1,1,-1,3,0.66,high,#31a354,68.35215504,1.0472,89.55819981,7.1624,234.070122,954.85,720.4716833
-1384,100240,24,"Developed, High Intensity","10% trees, 20% grass, and 70% buildings",100,Timber,,-1,-1,-1,-1,0.3,-1,1,-1,0,0,none,#ffffff,10.98142029,1.76,44.78642515,0.245,267.9065041,3418.485,1805.616283
-1385,100241,24,"Developed, High Intensity","10% trees, 20% grass, and 70% buildings",100,Timber,,-1,-1,-1,-1,0.3,-1,1,-1,1,0.15,low,#e5f5e0,23.50120467,1.496,53.63644993,1.80825,267.9065041,3418.485,1805.616283
-1386,100242,24,"Developed, High Intensity","10% trees, 20% grass, and 70% buildings",100,Timber,,-1,-1,-1,-1,0.3,-1,1,-1,2,0.4,medium,#a1d99b,44.36751198,1.056,68.38649122,4.413666667,267.9065041,3418.485,1805.616283
-1387,100243,24,"Developed, High Intensity","10% trees, 20% grass, and 70% buildings",100,Timber,,-1,-1,-1,-1,0.3,-1,1,-1,3,0.66,high,#31a354,66.06847158,0.5984,83.72653416,7.1233,267.9065041,3418.485,1805.616283
-1388,100310,31,Barren Land,,100,Timber,,-1,-1,-1,-1,0.3,0,1,-1,0,0,none,#ffffff,6.8,0,25.5,0,0,0,0
-1389,100311,31,Barren Land,,100,Timber,,-1,-1,-1,-1,0.3,0,1,-1,1,0.15,low,#e5f5e0,19.94699743,0,37.24298855,1.6,0,0,0
-1390,100312,31,Barren Land,,100,Timber,,-1,-1,-1,-1,0.3,0,1,-1,2,0.4,medium,#a1d99b,41.8586598,0,56.81463613,4.266666667,0,0,0
-1391,100313,31,Barren Land,,100,Timber,,-1,-1,-1,-1,0.3,0,1,-1,3,0.66,high,#31a354,64.64678868,0,77.16914961,7.04,0,0,0
-1392,100410,41,Deciduous Forest,,100,Timber,,-1,-1,-1,-1,0.3,0,1,-1,0,0,none,#ffffff,85.88498714,0,96.08994273,8.8,0,0,0
-1393,100411,41,Deciduous Forest,,100,Timber,,-1,-1,-1,-1,0.3,0,1,-1,1,0.15,low,#e5f5e0,85.88498714,0,96.08994273,8.8,0,0,0
-1394,100412,41,Deciduous Forest,,100,Timber,,-1,-1,-1,-1,0.3,0,1,-1,2,0.4,medium,#a1d99b,85.88498714,0,96.08994273,8.8,0,0,0
-1395,100413,41,Deciduous Forest,,100,Timber,,-1,-1,-1,-1,0.3,0,1,-1,3,0.66,high,#31a354,85.88498714,0,96.08994273,8.8,0,0,0
-1396,100420,42,Evergreen Forest,,100,Timber,,-1,-1,-1,-1,0.3,0,1,-1,0,0,none,#ffffff,105.6849871,0,96.08994273,14.4,0,0,0
-1397,100421,42,Evergreen Forest,,100,Timber,,-1,-1,-1,-1,0.3,0,1,-1,1,0.15,low,#e5f5e0,105.6849871,0,96.08994273,14.4,0,0,0
-1398,100422,42,Evergreen Forest,,100,Timber,,-1,-1,-1,-1,0.3,0,1,-1,2,0.4,medium,#a1d99b,105.6849871,0,96.08994273,14.4,0,0,0
-1399,100423,42,Evergreen Forest,,100,Timber,,-1,-1,-1,-1,0.3,0,1,-1,3,0.66,high,#31a354,105.6849871,0,96.08994273,14.4,0,0,0
-1400,100430,43,Mixed Forest,,100,Timber,,-1,-1,-1,-1,0.3,0,1,-1,0,0,none,#ffffff,91.76997429,0,119.1798855,8.8,0,0,0
-1401,100431,43,Mixed Forest,,100,Timber,,-1,-1,-1,-1,0.3,0,1,-1,1,0.15,low,#e5f5e0,91.76997429,0,119.1798855,8.8,0,0,0
-1402,100432,43,Mixed Forest,,100,Timber,,-1,-1,-1,-1,0.3,0,1,-1,2,0.4,medium,#a1d99b,91.76997429,0,119.1798855,8.8,0,0,0
-1403,100433,43,Mixed Forest,,100,Timber,,-1,-1,-1,-1,0.3,0,1,-1,3,0.66,high,#31a354,91.76997429,0,119.1798855,8.8,0,0,0
-1404,100520,52,Shrub/Scrub,,100,Timber,,-1,-1,-1,-1,0.3,0,1,-1,0,0,none,#ffffff,47.875,0,68.15477645,0,0,0,0
-1405,100521,52,Shrub/Scrub,,100,Timber,,-1,-1,-1,-1,0.3,0,1,-1,1,0.15,low,#e5f5e0,54.86074743,0,73.49954853,1.6,0,0,0
-1406,100522,52,Shrub/Scrub,,100,Timber,,-1,-1,-1,-1,0.3,0,1,-1,2,0.4,medium,#a1d99b,66.5036598,0,82.407502,4.266666667,0,0,0
-1407,100523,52,Shrub/Scrub,,100,Timber,,-1,-1,-1,-1,0.3,0,1,-1,3,0.66,high,#31a354,78.61228868,0,91.6717736,7.04,0,0,0
-1408,100710,71,Herbaceuous,,100,Timber,,-1,-1,-1,-1,0.3,0,1,-1,0,0,none,#ffffff,10.10660117,8,98.79264417,0,0,0,0
-1409,100711,71,Herbaceuous,,100,Timber,,-1,-1,-1,-1,0.3,0,1,-1,1,0.15,low,#e5f5e0,22.75760842,6.8,99.54173609,1.6,0,0,0
-1410,100712,71,Herbaceuous,,100,Timber,,-1,-1,-1,-1,0.3,0,1,-1,2,0.4,medium,#a1d99b,43.84262051,4.8,100.7902226,4.266666667,0,0,0
-1411,100713,71,Herbaceuous,,100,Timber,,-1,-1,-1,-1,0.3,0,1,-1,3,0.66,high,#31a354,65.77103307,2.72,102.0886486,7.04,0,0,0
-1412,100810,81,Hay/Pasture,,100,Timber,,-1,-1,-1,-1,0.3,0,1,-1,0,0,none,#ffffff,10.10660117,8,98.79264417,0,0,0,0
-1413,100811,81,Hay/Pasture,,100,Timber,,-1,-1,-1,-1,0.3,0,1,-1,1,0.15,low,#e5f5e0,22.75760842,6.8,99.54173609,1.6,0,0,0
-1414,100812,81,Hay/Pasture,,100,Timber,,-1,-1,-1,-1,0.3,0,1,-1,2,0.4,medium,#a1d99b,43.84262051,4.8,100.7902226,4.266666667,0,0,0
-1415,100813,81,Hay/Pasture,,100,Timber,,-1,-1,-1,-1,0.3,0,1,-1,3,0.66,high,#31a354,65.77103307,2.72,102.0886486,7.04,0,0,0
-1416,100820,82,Cultivated Crops,,100,Timber,,-1,-1,-1,-1,-1,0,1,-1,0,0,none,#ffffff,4.793840162,0,65.75263422,0,0,0,0
-1417,100821,82,Cultivated Crops,,100,Timber,,-1,-1,-1,-1,-1,0,1,-1,1,0.15,low,#e5f5e0,18.24176156,0,71.45772764,1.6,0,0,0
-1418,100822,82,Cultivated Crops,,100,Timber,,-1,-1,-1,-1,-1,0,1,-1,2,0.4,medium,#a1d99b,40.6549639,0,80.96621666,4.266666667,0,0,0
-1419,100823,82,Cultivated Crops,,100,Timber,,-1,-1,-1,-1,-1,0,1,-1,3,0.66,high,#31a354,63.96469433,0,90.85504525,7.04,0,0,0
-1420,100900,90,Woody Wetlands,,100,Timber,,-1,-1,-1,-1,0.3,0,1,-1,0,0,none,#ffffff,33.5,0,259,0,0,0,0
-1421,100901,90,Woody Wetlands,,100,Timber,,-1,-1,-1,-1,0.3,0,1,-1,1,0.15,low,#e5f5e0,42.64199743,0,235.7179885,1.6,0,0,0
-1422,100902,90,Woody Wetlands,,100,Timber,,-1,-1,-1,-1,0.3,0,1,-1,2,0.4,medium,#a1d99b,57.8786598,0,196.9146361,4.266666667,0,0,0
-1423,100903,90,Woody Wetlands,,100,Timber,,-1,-1,-1,-1,0.3,0,1,-1,3,0.66,high,#31a354,73.72478868,0,156.5591496,7.04,0,0,0
-1424,100950,95,Emergent Herbaceuous Wetlands,,100,Timber,,-1,-1,-1,-1,0.3,0,1,-1,0,0,none,#ffffff,33.5,0,259,0,0,0,0
-1425,100951,95,Emergent Herbaceuous Wetlands,,100,Timber,,-1,-1,-1,-1,0.3,0,1,-1,1,0.15,low,#e5f5e0,42.64199743,0,235.7179885,1.6,0,0,0
-1426,100952,95,Emergent Herbaceuous Wetlands,,100,Timber,,-1,-1,-1,-1,0.3,0,1,-1,2,0.4,medium,#a1d99b,57.8786598,0,196.9146361,4.266666667,0,0,0
-1427,100953,95,Emergent Herbaceuous Wetlands,,100,Timber,,-1,-1,-1,-1,0.3,0,1,-1,3,0.66,high,#31a354,73.72478868,0,156.5591496,7.04,0,0,0
-1428,110000,0,Background,,110,Barren,,-1,-1,-1,-1,-1,-1,-1,-1,0,0,none,#ffffff,0,0,0,0,0,0,0
-1429,110001,0,Background,,110,Barren,,-1,-1,-1,-1,-1,-1,-1,-1,1,0.15,low,#e5f5e0,14.16699743,0,15.56798855,1.6,0,0,0
-1430,110002,0,Background,,110,Barren,,-1,-1,-1,-1,-1,-1,-1,-1,2,0.4,medium,#a1d99b,37.7786598,0,41.51463613,4.266666667,0,0,0
-1431,110003,0,Background,,110,Barren,,-1,-1,-1,-1,-1,-1,-1,-1,3,0.66,high,#31a354,62.33478868,0,68.49914961,7.04,0,0,0
-1432,110110,11,Open Water,,110,Barren,,-1,-1,-1,-1,-1,0,-1,-1,0,0,none,#ffffff,0,0,0,0,0,0,0
-1433,110111,11,Open Water,,110,Barren,,-1,-1,-1,-1,-1,0,-1,-1,1,0.15,low,#e5f5e0,14.16699743,0,15.56798855,1.6,0,0,0
-1434,110112,11,Open Water,,110,Barren,,-1,-1,-1,-1,-1,0,-1,-1,2,0.4,medium,#a1d99b,37.7786598,0,41.51463613,4.266666667,0,0,0
-1435,110113,11,Open Water,,110,Barren,,-1,-1,-1,-1,-1,0,-1,-1,3,0.66,high,#31a354,62.33478868,0,68.49914961,7.04,0,0,0
-1436,110120,12,Perennial Ice/Snow,,110,Barren,,-1,-1,-1,-1,-1,-1,-1,-1,0,0,none,#ffffff,0,0,0,0,0,0,0
-1437,110121,12,Perennial Ice/Snow,,110,Barren,,-1,-1,-1,-1,-1,-1,-1,-1,1,0.15,low,#e5f5e0,14.16699743,0,15.56798855,1.6,0,0,0
-1438,110122,12,Perennial Ice/Snow,,110,Barren,,-1,-1,-1,-1,-1,-1,-1,-1,2,0.4,medium,#a1d99b,37.7786598,0,41.51463613,4.266666667,0,0,0
-1439,110123,12,Perennial Ice/Snow,,110,Barren,,-1,-1,-1,-1,-1,-1,-1,-1,3,0.66,high,#31a354,62.33478868,0,68.49914961,7.04,0,0,0
-1440,110210,21,"Developed, Open Space","20% trees, 60% grass, and 10% buildings and 10% bare soil",110,Barren,,-1,-1,-1,-1,-1,0,-1,-1,0,0,none,#ffffff,25.49986095,4.08,79.01411479,1.76,51.81402439,212.31,37.03522039
-1441,110211,21,"Developed, Open Space","20% trees, 60% grass, and 10% buildings and 10% bare soil",110,Barren,,-1,-1,-1,-1,-1,0,-1,-1,1,0.15,low,#e5f5e0,35.84187923,3.468,82.72998612,3.096,51.81402439,212.31,37.03522039
-1442,110212,21,"Developed, Open Space","20% trees, 60% grass, and 10% buildings and 10% bare soil",110,Barren,,-1,-1,-1,-1,-1,0,-1,-1,2,0.4,medium,#a1d99b,53.07857637,2.448,88.923105,5.322666667,51.81402439,212.31,37.03522039
-1443,110213,21,"Developed, Open Space","20% trees, 60% grass, and 10% buildings and 10% bare soil",110,Barren,,-1,-1,-1,-1,-1,0,-1,-1,3,0.66,high,#31a354,71.0047414,1.3872,95.36394864,7.6384,51.81402439,212.31,37.03522039
-1444,110220,22,"Developed, Low Intensity","20% trees, 40% grass, and 40% buildings",110,Barren,,-1,-1,-1,-1,-1,-1,-1,-1,0,0,none,#ffffff,20.90844667,3.52,72.06732319,0.61,207.2560976,849.24,147.1338816
-1445,110221,22,"Developed, Low Intensity","20% trees, 40% grass, and 40% buildings",110,Barren,,-1,-1,-1,-1,-1,-1,-1,-1,1,0.15,low,#e5f5e0,31.9391771,2.992,76.82521326,2.1185,207.2560976,849.24,147.1338816
-1446,110222,22,"Developed, Low Intensity","20% trees, 40% grass, and 40% buildings",110,Barren,,-1,-1,-1,-1,-1,-1,-1,-1,2,0.4,medium,#a1d99b,50.32372781,2.112,84.75503004,4.632666667,207.2560976,849.24,147.1338816
-1447,110223,22,"Developed, Low Intensity","20% trees, 40% grass, and 40% buildings",110,Barren,,-1,-1,-1,-1,-1,-1,-1,-1,3,0.66,high,#31a354,69.44366054,1.1968,93.0020395,7.2474,207.2560976,849.24,147.1338816
-1448,110230,23,"Developed, Medium Intensity","15% trees, 35% grass, and 50% buildings",110,Barren,,-1,-1,-1,-1,-1,-1,-1,-1,0,0,none,#ffffff,17.69813636,3.08,61.93838294,0.36,234.070122,954.85,720.4716833
-1449,110231,23,"Developed, Medium Intensity","15% trees, 35% grass, and 50% buildings",110,Barren,,-1,-1,-1,-1,-1,-1,-1,-1,1,0.15,low,#e5f5e0,29.21041333,2.618,68.21561405,1.906,234.070122,954.85,720.4716833
-1450,110232,23,"Developed, Medium Intensity","15% trees, 35% grass, and 50% buildings",110,Barren,,-1,-1,-1,-1,-1,-1,-1,-1,2,0.4,medium,#a1d99b,48.39754162,1.848,78.67766589,4.482666667,234.070122,954.85,720.4716833
-1451,110233,23,"Developed, Medium Intensity","15% trees, 35% grass, and 50% buildings",110,Barren,,-1,-1,-1,-1,-1,-1,-1,-1,3,0.66,high,#31a354,68.35215504,1.0472,89.55819981,7.1624,234.070122,954.85,720.4716833
-1452,110240,24,"Developed, High Intensity","10% trees, 20% grass, and 70% buildings",110,Barren,,-1,-1,-1,-1,-1,-1,-1,-1,0,0,none,#ffffff,10.98142029,1.76,44.78642515,0.245,267.9065041,3418.485,1805.616283
-1453,110241,24,"Developed, High Intensity","10% trees, 20% grass, and 70% buildings",110,Barren,,-1,-1,-1,-1,-1,-1,-1,-1,1,0.15,low,#e5f5e0,23.50120467,1.496,53.63644993,1.80825,267.9065041,3418.485,1805.616283
-1454,110242,24,"Developed, High Intensity","10% trees, 20% grass, and 70% buildings",110,Barren,,-1,-1,-1,-1,-1,-1,-1,-1,2,0.4,medium,#a1d99b,44.36751198,1.056,68.38649122,4.413666667,267.9065041,3418.485,1805.616283
-1455,110243,24,"Developed, High Intensity","10% trees, 20% grass, and 70% buildings",110,Barren,,-1,-1,-1,-1,-1,-1,-1,-1,3,0.66,high,#31a354,66.06847158,0.5984,83.72653416,7.1233,267.9065041,3418.485,1805.616283
-1456,110310,31,Barren Land,,110,Barren,,-1,-1,-1,-1,-1,0,-1,-1,0,0,none,#ffffff,6.8,0,25.5,0,0,0,0
-1457,110311,31,Barren Land,,110,Barren,,-1,-1,-1,-1,-1,0,-1,-1,1,0.15,low,#e5f5e0,19.94699743,0,37.24298855,1.6,0,0,0
-1458,110312,31,Barren Land,,110,Barren,,-1,-1,-1,-1,-1,0,-1,-1,2,0.4,medium,#a1d99b,41.8586598,0,56.81463613,4.266666667,0,0,0
-1459,110313,31,Barren Land,,110,Barren,,-1,-1,-1,-1,-1,0,-1,-1,3,0.66,high,#31a354,64.64678868,0,77.16914961,7.04,0,0,0
-1460,110410,41,Deciduous Forest,,110,Barren,,-1,-1,-1,-1,-1,0,-1,-1,0,0,none,#ffffff,85.88498714,0,96.08994273,8.8,0,0,0
-1461,110411,41,Deciduous Forest,,110,Barren,,-1,-1,-1,-1,-1,0,-1,-1,1,0.15,low,#e5f5e0,85.88498714,0,96.08994273,8.8,0,0,0
-1462,110412,41,Deciduous Forest,,110,Barren,,-1,-1,-1,-1,-1,0,-1,-1,2,0.4,medium,#a1d99b,85.88498714,0,96.08994273,8.8,0,0,0
-1463,110413,41,Deciduous Forest,,110,Barren,,-1,-1,-1,-1,-1,0,-1,-1,3,0.66,high,#31a354,85.88498714,0,96.08994273,8.8,0,0,0
-1464,110420,42,Evergreen Forest,,110,Barren,,-1,-1,-1,-1,-1,0,-1,-1,0,0,none,#ffffff,105.6849871,0,96.08994273,14.4,0,0,0
-1465,110421,42,Evergreen Forest,,110,Barren,,-1,-1,-1,-1,-1,0,-1,-1,1,0.15,low,#e5f5e0,105.6849871,0,96.08994273,14.4,0,0,0
-1466,110422,42,Evergreen Forest,,110,Barren,,-1,-1,-1,-1,-1,0,-1,-1,2,0.4,medium,#a1d99b,105.6849871,0,96.08994273,14.4,0,0,0
-1467,110423,42,Evergreen Forest,,110,Barren,,-1,-1,-1,-1,-1,0,-1,-1,3,0.66,high,#31a354,105.6849871,0,96.08994273,14.4,0,0,0
-1468,110430,43,Mixed Forest,,110,Barren,,-1,-1,-1,-1,-1,0,-1,-1,0,0,none,#ffffff,91.76997429,0,119.1798855,8.8,0,0,0
-1469,110431,43,Mixed Forest,,110,Barren,,-1,-1,-1,-1,-1,0,-1,-1,1,0.15,low,#e5f5e0,91.76997429,0,119.1798855,8.8,0,0,0
-1470,110432,43,Mixed Forest,,110,Barren,,-1,-1,-1,-1,-1,0,-1,-1,2,0.4,medium,#a1d99b,91.76997429,0,119.1798855,8.8,0,0,0
-1471,110433,43,Mixed Forest,,110,Barren,,-1,-1,-1,-1,-1,0,-1,-1,3,0.66,high,#31a354,91.76997429,0,119.1798855,8.8,0,0,0
-1472,110520,52,Shrub/Scrub,,110,Barren,,-1,-1,-1,-1,-1,0,-1,-1,0,0,none,#ffffff,47.875,0,68.15477645,0,0,0,0
-1473,110521,52,Shrub/Scrub,,110,Barren,,-1,-1,-1,-1,-1,0,-1,-1,1,0.15,low,#e5f5e0,54.86074743,0,73.49954853,1.6,0,0,0
-1474,110522,52,Shrub/Scrub,,110,Barren,,-1,-1,-1,-1,-1,0,-1,-1,2,0.4,medium,#a1d99b,66.5036598,0,82.407502,4.266666667,0,0,0
-1475,110523,52,Shrub/Scrub,,110,Barren,,-1,-1,-1,-1,-1,0,-1,-1,3,0.66,high,#31a354,78.61228868,0,91.6717736,7.04,0,0,0
-1476,110710,71,Herbaceuous,,110,Barren,,-1,-1,-1,-1,-1,0,-1,-1,0,0,none,#ffffff,10.10660117,8,98.79264417,0,0,0,0
-1477,110711,71,Herbaceuous,,110,Barren,,-1,-1,-1,-1,-1,0,-1,-1,1,0.15,low,#e5f5e0,22.75760842,6.8,99.54173609,1.6,0,0,0
-1478,110712,71,Herbaceuous,,110,Barren,,-1,-1,-1,-1,-1,0,-1,-1,2,0.4,medium,#a1d99b,43.84262051,4.8,100.7902226,4.266666667,0,0,0
-1479,110713,71,Herbaceuous,,110,Barren,,-1,-1,-1,-1,-1,0,-1,-1,3,0.66,high,#31a354,65.77103307,2.72,102.0886486,7.04,0,0,0
-1480,110810,81,Hay/Pasture,,110,Barren,,-1,-1,-1,-1,-1,0,-1,-1,0,0,none,#ffffff,10.10660117,8,98.79264417,0,0,0,0
-1481,110811,81,Hay/Pasture,,110,Barren,,-1,-1,-1,-1,-1,0,-1,-1,1,0.15,low,#e5f5e0,22.75760842,6.8,99.54173609,1.6,0,0,0
-1482,110812,81,Hay/Pasture,,110,Barren,,-1,-1,-1,-1,-1,0,-1,-1,2,0.4,medium,#a1d99b,43.84262051,4.8,100.7902226,4.266666667,0,0,0
-1483,110813,81,Hay/Pasture,,110,Barren,,-1,-1,-1,-1,-1,0,-1,-1,3,0.66,high,#31a354,65.77103307,2.72,102.0886486,7.04,0,0,0
-1484,110820,82,Cultivated Crops,,110,Barren,,-1,-1,-1,-1,-1,0,-1,-1,0,0,none,#ffffff,4.793840162,0,65.75263422,0,0,0,0
-1485,110821,82,Cultivated Crops,,110,Barren,,-1,-1,-1,-1,-1,0,-1,-1,1,0.15,low,#e5f5e0,18.24176156,0,71.45772764,1.6,0,0,0
-1486,110822,82,Cultivated Crops,,110,Barren,,-1,-1,-1,-1,-1,0,-1,-1,2,0.4,medium,#a1d99b,40.6549639,0,80.96621666,4.266666667,0,0,0
-1487,110823,82,Cultivated Crops,,110,Barren,,-1,-1,-1,-1,-1,0,-1,-1,3,0.66,high,#31a354,63.96469433,0,90.85504525,7.04,0,0,0
-1488,110900,90,Woody Wetlands,,110,Barren,,-1,-1,-1,-1,-1,0,-1,-1,0,0,none,#ffffff,33.5,0,259,0,0,0,0
-1489,110901,90,Woody Wetlands,,110,Barren,,-1,-1,-1,-1,-1,0,-1,-1,1,0.15,low,#e5f5e0,42.64199743,0,235.7179885,1.6,0,0,0
-1490,110902,90,Woody Wetlands,,110,Barren,,-1,-1,-1,-1,-1,0,-1,-1,2,0.4,medium,#a1d99b,57.8786598,0,196.9146361,4.266666667,0,0,0
-1491,110903,90,Woody Wetlands,,110,Barren,,-1,-1,-1,-1,-1,0,-1,-1,3,0.66,high,#31a354,73.72478868,0,156.5591496,7.04,0,0,0
-1492,110950,95,Emergent Herbaceuous Wetlands,,110,Barren,,-1,-1,-1,-1,-1,0,-1,-1,0,0,none,#ffffff,33.5,0,259,0,0,0,0
-1493,110951,95,Emergent Herbaceuous Wetlands,,110,Barren,,-1,-1,-1,-1,-1,0,-1,-1,1,0.15,low,#e5f5e0,42.64199743,0,235.7179885,1.6,0,0,0
-1494,110952,95,Emergent Herbaceuous Wetlands,,110,Barren,,-1,-1,-1,-1,-1,0,-1,-1,2,0.4,medium,#a1d99b,57.8786598,0,196.9146361,4.266666667,0,0,0
-1495,110953,95,Emergent Herbaceuous Wetlands,,110,Barren,,-1,-1,-1,-1,-1,0,-1,-1,3,0.66,high,#31a354,73.72478868,0,156.5591496,7.04,0,0,0
-1496,120000,0,Background,,120,Undifferentiated park,,-1,-1,-1,-1,-1,-1,-1,-1,0,0,none,#ffffff,0,0,0,0,0,0,0
-1497,120001,0,Background,,120,Undifferentiated park,,-1,-1,-1,-1,-1,-1,-1,-1,1,0.15,low,#e5f5e0,14.16699743,0,15.56798855,1.6,0,0,0
-1498,120002,0,Background,,120,Undifferentiated park,,-1,-1,-1,-1,-1,-1,-1,-1,2,0.4,medium,#a1d99b,37.7786598,0,41.51463613,4.266666667,0,0,0
-1499,120003,0,Background,,120,Undifferentiated park,,-1,-1,-1,-1,-1,-1,-1,-1,3,0.66,high,#31a354,62.33478868,0,68.49914961,7.04,0,0,0
-1500,120110,11,Open Water,,120,Undifferentiated park,,-1,-1,-1,-1,-1,-1,1,-1,0,0,none,#ffffff,0,0,0,0,0,0,0
-1501,120111,11,Open Water,,120,Undifferentiated park,,-1,-1,-1,-1,-1,-1,1,-1,1,0.15,low,#e5f5e0,14.16699743,0,15.56798855,1.6,0,0,0
-1502,120112,11,Open Water,,120,Undifferentiated park,,-1,-1,-1,-1,-1,-1,1,-1,2,0.4,medium,#a1d99b,37.7786598,0,41.51463613,4.266666667,0,0,0
-1503,120113,11,Open Water,,120,Undifferentiated park,,-1,-1,-1,-1,-1,-1,1,-1,3,0.66,high,#31a354,62.33478868,0,68.49914961,7.04,0,0,0
-1504,120120,12,Perennial Ice/Snow,,120,Undifferentiated park,,-1,-1,-1,-1,-1,-1,-1,-1,0,0,none,#ffffff,0,0,0,0,0,0,0
-1505,120121,12,Perennial Ice/Snow,,120,Undifferentiated park,,-1,-1,-1,-1,-1,-1,-1,-1,1,0.15,low,#e5f5e0,14.16699743,0,15.56798855,1.6,0,0,0
-1506,120122,12,Perennial Ice/Snow,,120,Undifferentiated park,,-1,-1,-1,-1,-1,-1,-1,-1,2,0.4,medium,#a1d99b,37.7786598,0,41.51463613,4.266666667,0,0,0
-1507,120123,12,Perennial Ice/Snow,,120,Undifferentiated park,,-1,-1,-1,-1,-1,-1,-1,-1,3,0.66,high,#31a354,62.33478868,0,68.49914961,7.04,0,0,0
-1508,120210,21,"Developed, Open Space","20% trees, 60% grass, and 10% buildings and 10% bare soil",120,Undifferentiated park,,-1,-1,-1,0.4,0.4,-1,1,-1,0,0,none,#ffffff,25.49986095,4.08,79.01411479,1.76,51.81402439,212.31,37.03522039
-1509,120211,21,"Developed, Open Space","20% trees, 60% grass, and 10% buildings and 10% bare soil",120,Undifferentiated park,,-1,-1,-1,0.4,0.4,-1,1,-1,1,0.15,low,#e5f5e0,35.84187923,3.468,82.72998612,3.096,51.81402439,212.31,37.03522039
-1510,120212,21,"Developed, Open Space","20% trees, 60% grass, and 10% buildings and 10% bare soil",120,Undifferentiated park,,-1,-1,-1,0.4,0.4,-1,1,-1,2,0.4,medium,#a1d99b,53.07857637,2.448,88.923105,5.322666667,51.81402439,212.31,37.03522039
-1511,120213,21,"Developed, Open Space","20% trees, 60% grass, and 10% buildings and 10% bare soil",120,Undifferentiated park,,-1,-1,-1,0.4,0.4,-1,1,-1,3,0.66,high,#31a354,71.0047414,1.3872,95.36394864,7.6384,51.81402439,212.31,37.03522039
-1512,120220,22,"Developed, Low Intensity","20% trees, 40% grass, and 40% buildings",120,Undifferentiated park,,-1,-1,-1,0.4,0.4,-1,1,-1,0,0,none,#ffffff,20.90844667,3.52,72.06732319,0.61,207.2560976,849.24,147.1338816
-1513,120221,22,"Developed, Low Intensity","20% trees, 40% grass, and 40% buildings",120,Undifferentiated park,,-1,-1,-1,0.4,0.4,-1,1,-1,1,0.15,low,#e5f5e0,31.9391771,2.992,76.82521326,2.1185,207.2560976,849.24,147.1338816
-1514,120222,22,"Developed, Low Intensity","20% trees, 40% grass, and 40% buildings",120,Undifferentiated park,,-1,-1,-1,0.4,0.4,-1,1,-1,2,0.4,medium,#a1d99b,50.32372781,2.112,84.75503004,4.632666667,207.2560976,849.24,147.1338816
-1515,120223,22,"Developed, Low Intensity","20% trees, 40% grass, and 40% buildings",120,Undifferentiated park,,-1,-1,-1,0.4,0.4,-1,1,-1,3,0.66,high,#31a354,69.44366054,1.1968,93.0020395,7.2474,207.2560976,849.24,147.1338816
-1516,120230,23,"Developed, Medium Intensity","15% trees, 35% grass, and 50% buildings",120,Undifferentiated park,,-1,-1,-1,0.4,0.4,-1,1,-1,0,0,none,#ffffff,17.69813636,3.08,61.93838294,0.36,234.070122,954.85,720.4716833
-1517,120231,23,"Developed, Medium Intensity","15% trees, 35% grass, and 50% buildings",120,Undifferentiated park,,-1,-1,-1,0.4,0.4,-1,1,-1,1,0.15,low,#e5f5e0,29.21041333,2.618,68.21561405,1.906,234.070122,954.85,720.4716833
-1518,120232,23,"Developed, Medium Intensity","15% trees, 35% grass, and 50% buildings",120,Undifferentiated park,,-1,-1,-1,0.4,0.4,-1,1,-1,2,0.4,medium,#a1d99b,48.39754162,1.848,78.67766589,4.482666667,234.070122,954.85,720.4716833
-1519,120233,23,"Developed, Medium Intensity","15% trees, 35% grass, and 50% buildings",120,Undifferentiated park,,-1,-1,-1,0.4,0.4,-1,1,-1,3,0.66,high,#31a354,68.35215504,1.0472,89.55819981,7.1624,234.070122,954.85,720.4716833
-1520,120240,24,"Developed, High Intensity","10% trees, 20% grass, and 70% buildings",120,Undifferentiated park,,-1,-1,-1,0.4,0.4,-1,1,-1,0,0,none,#ffffff,10.98142029,1.76,44.78642515,0.245,267.9065041,3418.485,1805.616283
-1521,120241,24,"Developed, High Intensity","10% trees, 20% grass, and 70% buildings",120,Undifferentiated park,,-1,-1,-1,0.4,0.4,-1,1,-1,1,0.15,low,#e5f5e0,23.50120467,1.496,53.63644993,1.80825,267.9065041,3418.485,1805.616283
-1522,120242,24,"Developed, High Intensity","10% trees, 20% grass, and 70% buildings",120,Undifferentiated park,,-1,-1,-1,0.4,0.4,-1,1,-1,2,0.4,medium,#a1d99b,44.36751198,1.056,68.38649122,4.413666667,267.9065041,3418.485,1805.616283
-1523,120243,24,"Developed, High Intensity","10% trees, 20% grass, and 70% buildings",120,Undifferentiated park,,-1,-1,-1,0.4,0.4,-1,1,-1,3,0.66,high,#31a354,66.06847158,0.5984,83.72653416,7.1233,267.9065041,3418.485,1805.616283
-1524,120310,31,Barren Land,,120,Undifferentiated park,,-1,-1,-1,0.4,0.4,-1,1,-1,0,0,none,#ffffff,6.8,0,25.5,0,0,0,0
-1525,120311,31,Barren Land,,120,Undifferentiated park,,-1,-1,-1,0.4,0.4,-1,1,-1,1,0.15,low,#e5f5e0,19.94699743,0,37.24298855,1.6,0,0,0
-1526,120312,31,Barren Land,,120,Undifferentiated park,,-1,-1,-1,0.4,0.4,-1,1,-1,2,0.4,medium,#a1d99b,41.8586598,0,56.81463613,4.266666667,0,0,0
-1527,120313,31,Barren Land,,120,Undifferentiated park,,-1,-1,-1,0.4,0.4,-1,1,-1,3,0.66,high,#31a354,64.64678868,0,77.16914961,7.04,0,0,0
-1528,120410,41,Deciduous Forest,,120,Undifferentiated park,,-1,-1,-1,-1,0.4,-1,1,-1,0,0,none,#ffffff,85.88498714,0,96.08994273,8.8,0,0,0
-1529,120411,41,Deciduous Forest,,120,Undifferentiated park,,-1,-1,-1,-1,0.4,-1,1,-1,1,0.15,low,#e5f5e0,85.88498714,0,96.08994273,8.8,0,0,0
-1530,120412,41,Deciduous Forest,,120,Undifferentiated park,,-1,-1,-1,-1,0.4,-1,1,-1,2,0.4,medium,#a1d99b,85.88498714,0,96.08994273,8.8,0,0,0
-1531,120413,41,Deciduous Forest,,120,Undifferentiated park,,-1,-1,-1,-1,0.4,-1,1,-1,3,0.66,high,#31a354,85.88498714,0,96.08994273,8.8,0,0,0
-1532,120420,42,Evergreen Forest,,120,Undifferentiated park,,-1,-1,-1,-1,0.4,-1,1,-1,0,0,none,#ffffff,105.6849871,0,96.08994273,14.4,0,0,0
-1533,120421,42,Evergreen Forest,,120,Undifferentiated park,,-1,-1,-1,-1,0.4,-1,1,-1,1,0.15,low,#e5f5e0,105.6849871,0,96.08994273,14.4,0,0,0
-1534,120422,42,Evergreen Forest,,120,Undifferentiated park,,-1,-1,-1,-1,0.4,-1,1,-1,2,0.4,medium,#a1d99b,105.6849871,0,96.08994273,14.4,0,0,0
-1535,120423,42,Evergreen Forest,,120,Undifferentiated park,,-1,-1,-1,-1,0.4,-1,1,-1,3,0.66,high,#31a354,105.6849871,0,96.08994273,14.4,0,0,0
-1536,120430,43,Mixed Forest,,120,Undifferentiated park,,-1,-1,-1,-1,0.4,-1,1,-1,0,0,none,#ffffff,91.76997429,0,119.1798855,8.8,0,0,0
-1537,120431,43,Mixed Forest,,120,Undifferentiated park,,-1,-1,-1,-1,0.4,-1,1,-1,1,0.15,low,#e5f5e0,91.76997429,0,119.1798855,8.8,0,0,0
-1538,120432,43,Mixed Forest,,120,Undifferentiated park,,-1,-1,-1,-1,0.4,-1,1,-1,2,0.4,medium,#a1d99b,91.76997429,0,119.1798855,8.8,0,0,0
-1539,120433,43,Mixed Forest,,120,Undifferentiated park,,-1,-1,-1,-1,0.4,-1,1,-1,3,0.66,high,#31a354,91.76997429,0,119.1798855,8.8,0,0,0
-1540,120520,52,Shrub/Scrub,,120,Undifferentiated park,,-1,-1,-1,0.4,0.4,-1,1,-1,0,0,none,#ffffff,47.875,0,68.15477645,0,0,0,0
-1541,120521,52,Shrub/Scrub,,120,Undifferentiated park,,-1,-1,-1,0.4,0.4,-1,1,-1,1,0.15,low,#e5f5e0,54.86074743,0,73.49954853,1.6,0,0,0
-1542,120522,52,Shrub/Scrub,,120,Undifferentiated park,,-1,-1,-1,0.4,0.4,-1,1,-1,2,0.4,medium,#a1d99b,66.5036598,0,82.407502,4.266666667,0,0,0
-1543,120523,52,Shrub/Scrub,,120,Undifferentiated park,,-1,-1,-1,0.4,0.4,-1,1,-1,3,0.66,high,#31a354,78.61228868,0,91.6717736,7.04,0,0,0
-1544,120710,71,Herbaceuous,,120,Undifferentiated park,,-1,-1,-1,0.4,0.4,-1,1,-1,0,0,none,#ffffff,10.10660117,8,98.79264417,0,0,0,0
-1545,120711,71,Herbaceuous,,120,Undifferentiated park,,-1,-1,-1,0.4,0.4,-1,1,-1,1,0.15,low,#e5f5e0,22.75760842,6.8,99.54173609,1.6,0,0,0
-1546,120712,71,Herbaceuous,,120,Undifferentiated park,,-1,-1,-1,0.4,0.4,-1,1,-1,2,0.4,medium,#a1d99b,43.84262051,4.8,100.7902226,4.266666667,0,0,0
-1547,120713,71,Herbaceuous,,120,Undifferentiated park,,-1,-1,-1,0.4,0.4,-1,1,-1,3,0.66,high,#31a354,65.77103307,2.72,102.0886486,7.04,0,0,0
-1548,120810,81,Hay/Pasture,,120,Undifferentiated park,,-1,-1,-1,0.4,0.4,-1,1,-1,0,0,none,#ffffff,10.10660117,8,98.79264417,0,0,0,0
-1549,120811,81,Hay/Pasture,,120,Undifferentiated park,,-1,-1,-1,0.4,0.4,-1,1,-1,1,0.15,low,#e5f5e0,22.75760842,6.8,99.54173609,1.6,0,0,0
-1550,120812,81,Hay/Pasture,,120,Undifferentiated park,,-1,-1,-1,0.4,0.4,-1,1,-1,2,0.4,medium,#a1d99b,43.84262051,4.8,100.7902226,4.266666667,0,0,0
-1551,120813,81,Hay/Pasture,,120,Undifferentiated park,,-1,-1,-1,0.4,0.4,-1,1,-1,3,0.66,high,#31a354,65.77103307,2.72,102.0886486,7.04,0,0,0
-1552,120820,82,Cultivated Crops,,120,Undifferentiated park,,-1,-1,-1,-1,-1,-1,1,-1,0,0,none,#ffffff,4.793840162,0,65.75263422,0,0,0,0
-1553,120821,82,Cultivated Crops,,120,Undifferentiated park,,-1,-1,-1,-1,-1,-1,1,-1,1,0.15,low,#e5f5e0,18.24176156,0,71.45772764,1.6,0,0,0
-1554,120822,82,Cultivated Crops,,120,Undifferentiated park,,-1,-1,-1,-1,-1,-1,1,-1,2,0.4,medium,#a1d99b,40.6549639,0,80.96621666,4.266666667,0,0,0
-1555,120823,82,Cultivated Crops,,120,Undifferentiated park,,-1,-1,-1,-1,-1,-1,1,-1,3,0.66,high,#31a354,63.96469433,0,90.85504525,7.04,0,0,0
-1556,120900,90,Woody Wetlands,,120,Undifferentiated park,,-1,-1,-1,-1,0.4,-1,1,-1,0,0,none,#ffffff,33.5,0,259,0,0,0,0
-1557,120901,90,Woody Wetlands,,120,Undifferentiated park,,-1,-1,-1,-1,0.4,-1,1,-1,1,0.15,low,#e5f5e0,42.64199743,0,235.7179885,1.6,0,0,0
-1558,120902,90,Woody Wetlands,,120,Undifferentiated park,,-1,-1,-1,-1,0.4,-1,1,-1,2,0.4,medium,#a1d99b,57.8786598,0,196.9146361,4.266666667,0,0,0
-1559,120903,90,Woody Wetlands,,120,Undifferentiated park,,-1,-1,-1,-1,0.4,-1,1,-1,3,0.66,high,#31a354,73.72478868,0,156.5591496,7.04,0,0,0
-1560,120950,95,Emergent Herbaceuous Wetlands,,120,Undifferentiated park,,-1,-1,-1,-1,0.4,-1,1,-1,0,0,none,#ffffff,33.5,0,259,0,0,0,0
-1561,120951,95,Emergent Herbaceuous Wetlands,,120,Undifferentiated park,,-1,-1,-1,-1,0.4,-1,1,-1,1,0.15,low,#e5f5e0,42.64199743,0,235.7179885,1.6,0,0,0
-1562,120952,95,Emergent Herbaceuous Wetlands,,120,Undifferentiated park,,-1,-1,-1,-1,0.4,-1,1,-1,2,0.4,medium,#a1d99b,57.8786598,0,196.9146361,4.266666667,0,0,0
-1563,120953,95,Emergent Herbaceuous Wetlands,,120,Undifferentiated park,,-1,-1,-1,-1,0.4,-1,1,-1,3,0.66,high,#31a354,73.72478868,0,156.5591496,7.04,0,0,0
-1564,131000,0,Background,,131,Developed park,Urban park,-1,-1,-1,-1,-1,-1,-1,-1,0,0,none,#ffffff,0,0,0,0,0,0,0
-1565,131001,0,Background,,131,Developed park,Urban park,-1,-1,-1,-1,-1,-1,-1,-1,1,0.15,low,#e5f5e0,14.16699743,0,15.56798855,1.6,0,0,0
-1566,131002,0,Background,,131,Developed park,Urban park,-1,-1,-1,-1,-1,-1,-1,-1,2,0.4,medium,#a1d99b,37.7786598,0,41.51463613,4.266666667,0,0,0
-1567,131003,0,Background,,131,Developed park,Urban park,-1,-1,-1,-1,-1,-1,-1,-1,3,0.66,high,#31a354,62.33478868,0,68.49914961,7.04,0,0,0
-1568,131110,11,Open Water,,131,Developed park,Urban park,-1,-1,-1,-1,-1,1,1,-1,0,0,none,#ffffff,0,0,0,0,0,0,0
-1569,131111,11,Open Water,,131,Developed park,Urban park,-1,-1,-1,-1,-1,1,1,-1,1,0.15,low,#e5f5e0,14.16699743,0,15.56798855,1.6,0,0,0
-1570,131112,11,Open Water,,131,Developed park,Urban park,-1,-1,-1,-1,-1,1,1,-1,2,0.4,medium,#a1d99b,37.7786598,0,41.51463613,4.266666667,0,0,0
-1571,131113,11,Open Water,,131,Developed park,Urban park,-1,-1,-1,-1,-1,1,1,-1,3,0.66,high,#31a354,62.33478868,0,68.49914961,7.04,0,0,0
-1572,131120,12,Perennial Ice/Snow,,131,Developed park,Urban park,-1,-1,-1,-1,-1,-1,-1,-1,0,0,none,#ffffff,0,0,0,0,0,0,0
-1573,131121,12,Perennial Ice/Snow,,131,Developed park,Urban park,-1,-1,-1,-1,-1,-1,-1,-1,1,0.15,low,#e5f5e0,14.16699743,0,15.56798855,1.6,0,0,0
-1574,131122,12,Perennial Ice/Snow,,131,Developed park,Urban park,-1,-1,-1,-1,-1,-1,-1,-1,2,0.4,medium,#a1d99b,37.7786598,0,41.51463613,4.266666667,0,0,0
-1575,131123,12,Perennial Ice/Snow,,131,Developed park,Urban park,-1,-1,-1,-1,-1,-1,-1,-1,3,0.66,high,#31a354,62.33478868,0,68.49914961,7.04,0,0,0
-1576,131210,21,"Developed, Open Space","20% trees, 60% grass, and 10% buildings and 10% bare soil",131,Developed park,Urban park,0.2,0.1,0.2,0.5,0.5,1,1,-1,0,0,none,#ffffff,25.49986095,4.08,79.01411479,1.76,51.81402439,212.31,37.03522039
-1577,131211,21,"Developed, Open Space","20% trees, 60% grass, and 10% buildings and 10% bare soil",131,Developed park,Urban park,0.2,0.1,0.2,0.5,0.5,1,1,-1,1,0.15,low,#e5f5e0,35.84187923,3.468,82.72998612,3.096,51.81402439,212.31,37.03522039
-1578,131212,21,"Developed, Open Space","20% trees, 60% grass, and 10% buildings and 10% bare soil",131,Developed park,Urban park,0.2,0.1,0.2,0.5,0.5,1,1,-1,2,0.4,medium,#a1d99b,53.07857637,2.448,88.923105,5.322666667,51.81402439,212.31,37.03522039
-1579,131213,21,"Developed, Open Space","20% trees, 60% grass, and 10% buildings and 10% bare soil",131,Developed park,Urban park,0.2,0.1,0.2,0.5,0.5,1,1,-1,3,0.66,high,#31a354,71.0047414,1.3872,95.36394864,7.6384,51.81402439,212.31,37.03522039
-1580,131220,22,"Developed, Low Intensity","20% trees, 40% grass, and 40% buildings",131,Developed park,Urban park,0.2,0.1,0.2,0.5,0.5,-1,1,-1,0,0,none,#ffffff,20.90844667,3.52,72.06732319,0.61,207.2560976,849.24,147.1338816
-1581,131221,22,"Developed, Low Intensity","20% trees, 40% grass, and 40% buildings",131,Developed park,Urban park,0.2,0.1,0.2,0.5,0.5,-1,1,-1,1,0.15,low,#e5f5e0,31.9391771,2.992,76.82521326,2.1185,207.2560976,849.24,147.1338816
-1582,131222,22,"Developed, Low Intensity","20% trees, 40% grass, and 40% buildings",131,Developed park,Urban park,0.2,0.1,0.2,0.5,0.5,-1,1,-1,2,0.4,medium,#a1d99b,50.32372781,2.112,84.75503004,4.632666667,207.2560976,849.24,147.1338816
-1583,131223,22,"Developed, Low Intensity","20% trees, 40% grass, and 40% buildings",131,Developed park,Urban park,0.2,0.1,0.2,0.5,0.5,-1,1,-1,3,0.66,high,#31a354,69.44366054,1.1968,93.0020395,7.2474,207.2560976,849.24,147.1338816
-1584,131230,23,"Developed, Medium Intensity","15% trees, 35% grass, and 50% buildings",131,Developed park,Urban park,0.2,0.1,0.2,0.5,0.5,-1,1,-1,0,0,none,#ffffff,17.69813636,3.08,61.93838294,0.36,234.070122,954.85,720.4716833
-1585,131231,23,"Developed, Medium Intensity","15% trees, 35% grass, and 50% buildings",131,Developed park,Urban park,0.2,0.1,0.2,0.5,0.5,-1,1,-1,1,0.15,low,#e5f5e0,29.21041333,2.618,68.21561405,1.906,234.070122,954.85,720.4716833
-1586,131232,23,"Developed, Medium Intensity","15% trees, 35% grass, and 50% buildings",131,Developed park,Urban park,0.2,0.1,0.2,0.5,0.5,-1,1,-1,2,0.4,medium,#a1d99b,48.39754162,1.848,78.67766589,4.482666667,234.070122,954.85,720.4716833
-1587,131233,23,"Developed, Medium Intensity","15% trees, 35% grass, and 50% buildings",131,Developed park,Urban park,0.2,0.1,0.2,0.5,0.5,-1,1,-1,3,0.66,high,#31a354,68.35215504,1.0472,89.55819981,7.1624,234.070122,954.85,720.4716833
-1588,131240,24,"Developed, High Intensity","10% trees, 20% grass, and 70% buildings",131,Developed park,Urban park,0.2,0.1,0.2,0.5,0.5,-1,1,-1,0,0,none,#ffffff,10.98142029,1.76,44.78642515,0.245,267.9065041,3418.485,1805.616283
-1589,131241,24,"Developed, High Intensity","10% trees, 20% grass, and 70% buildings",131,Developed park,Urban park,0.2,0.1,0.2,0.5,0.5,-1,1,-1,1,0.15,low,#e5f5e0,23.50120467,1.496,53.63644993,1.80825,267.9065041,3418.485,1805.616283
-1590,131242,24,"Developed, High Intensity","10% trees, 20% grass, and 70% buildings",131,Developed park,Urban park,0.2,0.1,0.2,0.5,0.5,-1,1,-1,2,0.4,medium,#a1d99b,44.36751198,1.056,68.38649122,4.413666667,267.9065041,3418.485,1805.616283
-1591,131243,24,"Developed, High Intensity","10% trees, 20% grass, and 70% buildings",131,Developed park,Urban park,0.2,0.1,0.2,0.5,0.5,-1,1,-1,3,0.66,high,#31a354,66.06847158,0.5984,83.72653416,7.1233,267.9065041,3418.485,1805.616283
-1592,131310,31,Barren Land,,131,Developed park,Urban park,0.2,0.1,0.2,0.5,0.5,1,1,-1,0,0,none,#ffffff,6.8,0,25.5,0,0,0,0
-1593,131311,31,Barren Land,,131,Developed park,Urban park,0.2,0.1,0.2,0.5,0.5,1,1,-1,1,0.15,low,#e5f5e0,19.94699743,0,37.24298855,1.6,0,0,0
-1594,131312,31,Barren Land,,131,Developed park,Urban park,0.2,0.1,0.2,0.5,0.5,1,1,-1,2,0.4,medium,#a1d99b,41.8586598,0,56.81463613,4.266666667,0,0,0
-1595,131313,31,Barren Land,,131,Developed park,Urban park,0.2,0.1,0.2,0.5,0.5,1,1,-1,3,0.66,high,#31a354,64.64678868,0,77.16914961,7.04,0,0,0
-1596,131410,41,Deciduous Forest,,131,Developed park,Urban park,-1,0.1,-1,-1,0.5,1,1,-1,0,0,none,#ffffff,85.88498714,0,96.08994273,8.8,0,0,0
-1597,131411,41,Deciduous Forest,,131,Developed park,Urban park,-1,0.1,-1,-1,0.5,1,1,-1,1,0.15,low,#e5f5e0,85.88498714,0,96.08994273,8.8,0,0,0
-1598,131412,41,Deciduous Forest,,131,Developed park,Urban park,-1,0.1,-1,-1,0.5,1,1,-1,2,0.4,medium,#a1d99b,85.88498714,0,96.08994273,8.8,0,0,0
-1599,131413,41,Deciduous Forest,,131,Developed park,Urban park,-1,0.1,-1,-1,0.5,1,1,-1,3,0.66,high,#31a354,85.88498714,0,96.08994273,8.8,0,0,0
-1600,131420,42,Evergreen Forest,,131,Developed park,Urban park,-1,0.1,-1,-1,0.5,1,1,-1,0,0,none,#ffffff,105.6849871,0,96.08994273,14.4,0,0,0
-1601,131421,42,Evergreen Forest,,131,Developed park,Urban park,-1,0.1,-1,-1,0.5,1,1,-1,1,0.15,low,#e5f5e0,105.6849871,0,96.08994273,14.4,0,0,0
-1602,131422,42,Evergreen Forest,,131,Developed park,Urban park,-1,0.1,-1,-1,0.5,1,1,-1,2,0.4,medium,#a1d99b,105.6849871,0,96.08994273,14.4,0,0,0
-1603,131423,42,Evergreen Forest,,131,Developed park,Urban park,-1,0.1,-1,-1,0.5,1,1,-1,3,0.66,high,#31a354,105.6849871,0,96.08994273,14.4,0,0,0
-1604,131430,43,Mixed Forest,,131,Developed park,Urban park,-1,0.1,-1,-1,0.5,1,1,-1,0,0,none,#ffffff,91.76997429,0,119.1798855,8.8,0,0,0
-1605,131431,43,Mixed Forest,,131,Developed park,Urban park,-1,0.1,-1,-1,0.5,1,1,-1,1,0.15,low,#e5f5e0,91.76997429,0,119.1798855,8.8,0,0,0
-1606,131432,43,Mixed Forest,,131,Developed park,Urban park,-1,0.1,-1,-1,0.5,1,1,-1,2,0.4,medium,#a1d99b,91.76997429,0,119.1798855,8.8,0,0,0
-1607,131433,43,Mixed Forest,,131,Developed park,Urban park,-1,0.1,-1,-1,0.5,1,1,-1,3,0.66,high,#31a354,91.76997429,0,119.1798855,8.8,0,0,0
-1608,131520,52,Shrub/Scrub,,131,Developed park,Urban park,0.2,0.1,0.2,0.5,0.5,1,1,-1,0,0,none,#ffffff,47.875,0,68.15477645,0,0,0,0
-1609,131521,52,Shrub/Scrub,,131,Developed park,Urban park,0.2,0.1,0.2,0.5,0.5,1,1,-1,1,0.15,low,#e5f5e0,54.86074743,0,73.49954853,1.6,0,0,0
-1610,131522,52,Shrub/Scrub,,131,Developed park,Urban park,0.2,0.1,0.2,0.5,0.5,1,1,-1,2,0.4,medium,#a1d99b,66.5036598,0,82.407502,4.266666667,0,0,0
-1611,131523,52,Shrub/Scrub,,131,Developed park,Urban park,0.2,0.1,0.2,0.5,0.5,1,1,-1,3,0.66,high,#31a354,78.61228868,0,91.6717736,7.04,0,0,0
-1612,131710,71,Herbaceuous,,131,Developed park,Urban park,0.2,0.1,0.2,0.5,0.5,1,1,-1,0,0,none,#ffffff,10.10660117,8,98.79264417,0,0,0,0
-1613,131711,71,Herbaceuous,,131,Developed park,Urban park,0.2,0.1,0.2,0.5,0.5,1,1,-1,1,0.15,low,#e5f5e0,22.75760842,6.8,99.54173609,1.6,0,0,0
-1614,131712,71,Herbaceuous,,131,Developed park,Urban park,0.2,0.1,0.2,0.5,0.5,1,1,-1,2,0.4,medium,#a1d99b,43.84262051,4.8,100.7902226,4.266666667,0,0,0
-1615,131713,71,Herbaceuous,,131,Developed park,Urban park,0.2,0.1,0.2,0.5,0.5,1,1,-1,3,0.66,high,#31a354,65.77103307,2.72,102.0886486,7.04,0,0,0
-1616,131810,81,Hay/Pasture,,131,Developed park,Urban park,0.2,0.1,0.2,0.5,0.5,1,1,-1,0,0,none,#ffffff,10.10660117,8,98.79264417,0,0,0,0
-1617,131811,81,Hay/Pasture,,131,Developed park,Urban park,0.2,0.1,0.2,0.5,0.5,1,1,-1,1,0.15,low,#e5f5e0,22.75760842,6.8,99.54173609,1.6,0,0,0
-1618,131812,81,Hay/Pasture,,131,Developed park,Urban park,0.2,0.1,0.2,0.5,0.5,1,1,-1,2,0.4,medium,#a1d99b,43.84262051,4.8,100.7902226,4.266666667,0,0,0
-1619,131813,81,Hay/Pasture,,131,Developed park,Urban park,0.2,0.1,0.2,0.5,0.5,1,1,-1,3,0.66,high,#31a354,65.77103307,2.72,102.0886486,7.04,0,0,0
-1620,131820,82,Cultivated Crops,,131,Developed park,Urban park,0.2,0.1,0.2,-1,-1,1,1,-1,0,0,none,#ffffff,4.793840162,0,65.75263422,0,0,0,0
-1621,131821,82,Cultivated Crops,,131,Developed park,Urban park,0.2,0.1,0.2,-1,-1,1,1,-1,1,0.15,low,#e5f5e0,18.24176156,0,71.45772764,1.6,0,0,0
-1622,131822,82,Cultivated Crops,,131,Developed park,Urban park,0.2,0.1,0.2,-1,-1,1,1,-1,2,0.4,medium,#a1d99b,40.6549639,0,80.96621666,4.266666667,0,0,0
-1623,131823,82,Cultivated Crops,,131,Developed park,Urban park,0.2,0.1,0.2,-1,-1,1,1,-1,3,0.66,high,#31a354,63.96469433,0,90.85504525,7.04,0,0,0
-1624,131900,90,Woody Wetlands,,131,Developed park,Urban park,0.2,0.1,-1,-1,0.5,1,1,-1,0,0,none,#ffffff,33.5,0,259,0,0,0,0
-1625,131901,90,Woody Wetlands,,131,Developed park,Urban park,0.2,0.1,-1,-1,0.5,1,1,-1,1,0.15,low,#e5f5e0,42.64199743,0,235.7179885,1.6,0,0,0
-1626,131902,90,Woody Wetlands,,131,Developed park,Urban park,0.2,0.1,-1,-1,0.5,1,1,-1,2,0.4,medium,#a1d99b,57.8786598,0,196.9146361,4.266666667,0,0,0
-1627,131903,90,Woody Wetlands,,131,Developed park,Urban park,0.2,0.1,-1,-1,0.5,1,1,-1,3,0.66,high,#31a354,73.72478868,0,156.5591496,7.04,0,0,0
-1628,131950,95,Emergent Herbaceuous Wetlands,,131,Developed park,Urban park,0.2,0.1,-1,-1,0.5,1,1,-1,0,0,none,#ffffff,33.5,0,259,0,0,0,0
-1629,131951,95,Emergent Herbaceuous Wetlands,,131,Developed park,Urban park,0.2,0.1,-1,-1,0.5,1,1,-1,1,0.15,low,#e5f5e0,42.64199743,0,235.7179885,1.6,0,0,0
-1630,131952,95,Emergent Herbaceuous Wetlands,,131,Developed park,Urban park,0.2,0.1,-1,-1,0.5,1,1,-1,2,0.4,medium,#a1d99b,57.8786598,0,196.9146361,4.266666667,0,0,0
-1631,131953,95,Emergent Herbaceuous Wetlands,,131,Developed park,Urban park,0.2,0.1,-1,-1,0.5,1,1,-1,3,0.66,high,#31a354,73.72478868,0,156.5591496,7.04,0,0,0
-1632,132000,0,Background,,132,Developed park,Golf course,-1,-1,-1,-1,-1,-1,-1,-1,0,0,none,#ffffff,0,0,0,0,0,0,0
-1633,132001,0,Background,,132,Developed park,Golf course,-1,-1,-1,-1,-1,-1,-1,-1,1,0.15,low,#e5f5e0,14.16699743,0,15.56798855,1.6,0,0,0
-1634,132002,0,Background,,132,Developed park,Golf course,-1,-1,-1,-1,-1,-1,-1,-1,2,0.4,medium,#a1d99b,37.7786598,0,41.51463613,4.266666667,0,0,0
-1635,132003,0,Background,,132,Developed park,Golf course,-1,-1,-1,-1,-1,-1,-1,-1,3,0.66,high,#31a354,62.33478868,0,68.49914961,7.04,0,0,0
-1636,132110,11,Open Water,,132,Developed park,Golf course,-1,-1,-1,-1,-1,-1,1,-1,0,0,none,#ffffff,0,0,0,0,0,0,0
-1637,132111,11,Open Water,,132,Developed park,Golf course,-1,-1,-1,-1,-1,-1,1,-1,1,0.15,low,#e5f5e0,14.16699743,0,15.56798855,1.6,0,0,0
-1638,132112,11,Open Water,,132,Developed park,Golf course,-1,-1,-1,-1,-1,-1,1,-1,2,0.4,medium,#a1d99b,37.7786598,0,41.51463613,4.266666667,0,0,0
-1639,132113,11,Open Water,,132,Developed park,Golf course,-1,-1,-1,-1,-1,-1,1,-1,3,0.66,high,#31a354,62.33478868,0,68.49914961,7.04,0,0,0
-1640,132120,12,Perennial Ice/Snow,,132,Developed park,Golf course,-1,-1,-1,-1,-1,-1,-1,-1,0,0,none,#ffffff,0,0,0,0,0,0,0
-1641,132121,12,Perennial Ice/Snow,,132,Developed park,Golf course,-1,-1,-1,-1,-1,-1,-1,-1,1,0.15,low,#e5f5e0,14.16699743,0,15.56798855,1.6,0,0,0
-1642,132122,12,Perennial Ice/Snow,,132,Developed park,Golf course,-1,-1,-1,-1,-1,-1,-1,-1,2,0.4,medium,#a1d99b,37.7786598,0,41.51463613,4.266666667,0,0,0
-1643,132123,12,Perennial Ice/Snow,,132,Developed park,Golf course,-1,-1,-1,-1,-1,-1,-1,-1,3,0.66,high,#31a354,62.33478868,0,68.49914961,7.04,0,0,0
-1644,132210,21,"Developed, Open Space","20% trees, 60% grass, and 10% buildings and 10% bare soil",132,Developed park,Golf course,1,1,1,0.2,1,-1,1,-1,0,0,none,#ffffff,25.49986095,4.08,79.01411479,1.76,51.81402439,212.31,37.03522039
-1645,132211,21,"Developed, Open Space","20% trees, 60% grass, and 10% buildings and 10% bare soil",132,Developed park,Golf course,1,1,1,0.2,1,-1,1,-1,1,0.15,low,#e5f5e0,35.84187923,3.468,82.72998612,3.096,51.81402439,212.31,37.03522039
-1646,132212,21,"Developed, Open Space","20% trees, 60% grass, and 10% buildings and 10% bare soil",132,Developed park,Golf course,1,1,1,0.2,1,-1,1,-1,2,0.4,medium,#a1d99b,53.07857637,2.448,88.923105,5.322666667,51.81402439,212.31,37.03522039
-1647,132213,21,"Developed, Open Space","20% trees, 60% grass, and 10% buildings and 10% bare soil",132,Developed park,Golf course,1,1,1,0.2,1,-1,1,-1,3,0.66,high,#31a354,71.0047414,1.3872,95.36394864,7.6384,51.81402439,212.31,37.03522039
-1648,132220,22,"Developed, Low Intensity","20% trees, 40% grass, and 40% buildings",132,Developed park,Golf course,1,1,1,0.2,1,-1,1,-1,0,0,none,#ffffff,20.90844667,3.52,72.06732319,0.61,207.2560976,849.24,147.1338816
-1649,132221,22,"Developed, Low Intensity","20% trees, 40% grass, and 40% buildings",132,Developed park,Golf course,1,1,1,0.2,1,-1,1,-1,1,0.15,low,#e5f5e0,31.9391771,2.992,76.82521326,2.1185,207.2560976,849.24,147.1338816
-1650,132222,22,"Developed, Low Intensity","20% trees, 40% grass, and 40% buildings",132,Developed park,Golf course,1,1,1,0.2,1,-1,1,-1,2,0.4,medium,#a1d99b,50.32372781,2.112,84.75503004,4.632666667,207.2560976,849.24,147.1338816
-1651,132223,22,"Developed, Low Intensity","20% trees, 40% grass, and 40% buildings",132,Developed park,Golf course,1,1,1,0.2,1,-1,1,-1,3,0.66,high,#31a354,69.44366054,1.1968,93.0020395,7.2474,207.2560976,849.24,147.1338816
-1652,132230,23,"Developed, Medium Intensity","15% trees, 35% grass, and 50% buildings",132,Developed park,Golf course,1,1,1,0.2,1,-1,1,-1,0,0,none,#ffffff,17.69813636,3.08,61.93838294,0.36,234.070122,954.85,720.4716833
-1653,132231,23,"Developed, Medium Intensity","15% trees, 35% grass, and 50% buildings",132,Developed park,Golf course,1,1,1,0.2,1,-1,1,-1,1,0.15,low,#e5f5e0,29.21041333,2.618,68.21561405,1.906,234.070122,954.85,720.4716833
-1654,132232,23,"Developed, Medium Intensity","15% trees, 35% grass, and 50% buildings",132,Developed park,Golf course,1,1,1,0.2,1,-1,1,-1,2,0.4,medium,#a1d99b,48.39754162,1.848,78.67766589,4.482666667,234.070122,954.85,720.4716833
-1655,132233,23,"Developed, Medium Intensity","15% trees, 35% grass, and 50% buildings",132,Developed park,Golf course,1,1,1,0.2,1,-1,1,-1,3,0.66,high,#31a354,68.35215504,1.0472,89.55819981,7.1624,234.070122,954.85,720.4716833
-1656,132240,24,"Developed, High Intensity","10% trees, 20% grass, and 70% buildings",132,Developed park,Golf course,1,1,1,0.2,1,-1,1,-1,0,0,none,#ffffff,10.98142029,1.76,44.78642515,0.245,267.9065041,3418.485,1805.616283
-1657,132241,24,"Developed, High Intensity","10% trees, 20% grass, and 70% buildings",132,Developed park,Golf course,1,1,1,0.2,1,-1,1,-1,1,0.15,low,#e5f5e0,23.50120467,1.496,53.63644993,1.80825,267.9065041,3418.485,1805.616283
-1658,132242,24,"Developed, High Intensity","10% trees, 20% grass, and 70% buildings",132,Developed park,Golf course,1,1,1,0.2,1,-1,1,-1,2,0.4,medium,#a1d99b,44.36751198,1.056,68.38649122,4.413666667,267.9065041,3418.485,1805.616283
-1659,132243,24,"Developed, High Intensity","10% trees, 20% grass, and 70% buildings",132,Developed park,Golf course,1,1,1,0.2,1,-1,1,-1,3,0.66,high,#31a354,66.06847158,0.5984,83.72653416,7.1233,267.9065041,3418.485,1805.616283
-1660,132310,31,Barren Land,,132,Developed park,Golf course,1,1,1,0.2,1,-1,1,-1,0,0,none,#ffffff,6.8,0,25.5,0,0,0,0
-1661,132311,31,Barren Land,,132,Developed park,Golf course,1,1,1,0.2,1,-1,1,-1,1,0.15,low,#e5f5e0,19.94699743,0,37.24298855,1.6,0,0,0
-1662,132312,31,Barren Land,,132,Developed park,Golf course,1,1,1,0.2,1,-1,1,-1,2,0.4,medium,#a1d99b,41.8586598,0,56.81463613,4.266666667,0,0,0
-1663,132313,31,Barren Land,,132,Developed park,Golf course,1,1,1,0.2,1,-1,1,-1,3,0.66,high,#31a354,64.64678868,0,77.16914961,7.04,0,0,0
-1664,132410,41,Deciduous Forest,,132,Developed park,Golf course,-1,1,-1,-1,1,-1,1,-1,0,0,none,#ffffff,85.88498714,0,96.08994273,8.8,0,0,0
-1665,132411,41,Deciduous Forest,,132,Developed park,Golf course,-1,1,-1,-1,1,-1,1,-1,1,0.15,low,#e5f5e0,85.88498714,0,96.08994273,8.8,0,0,0
-1666,132412,41,Deciduous Forest,,132,Developed park,Golf course,-1,1,-1,-1,1,-1,1,-1,2,0.4,medium,#a1d99b,85.88498714,0,96.08994273,8.8,0,0,0
-1667,132413,41,Deciduous Forest,,132,Developed park,Golf course,-1,1,-1,-1,1,-1,1,-1,3,0.66,high,#31a354,85.88498714,0,96.08994273,8.8,0,0,0
-1668,132420,42,Evergreen Forest,,132,Developed park,Golf course,-1,1,-1,-1,1,-1,1,-1,0,0,none,#ffffff,105.6849871,0,96.08994273,14.4,0,0,0
-1669,132421,42,Evergreen Forest,,132,Developed park,Golf course,-1,1,-1,-1,1,-1,1,-1,1,0.15,low,#e5f5e0,105.6849871,0,96.08994273,14.4,0,0,0
-1670,132422,42,Evergreen Forest,,132,Developed park,Golf course,-1,1,-1,-1,1,-1,1,-1,2,0.4,medium,#a1d99b,105.6849871,0,96.08994273,14.4,0,0,0
-1671,132423,42,Evergreen Forest,,132,Developed park,Golf course,-1,1,-1,-1,1,-1,1,-1,3,0.66,high,#31a354,105.6849871,0,96.08994273,14.4,0,0,0
-1672,132430,43,Mixed Forest,,132,Developed park,Golf course,-1,1,-1,-1,1,-1,1,-1,0,0,none,#ffffff,91.76997429,0,119.1798855,8.8,0,0,0
-1673,132431,43,Mixed Forest,,132,Developed park,Golf course,-1,1,-1,-1,1,-1,1,-1,1,0.15,low,#e5f5e0,91.76997429,0,119.1798855,8.8,0,0,0
-1674,132432,43,Mixed Forest,,132,Developed park,Golf course,-1,1,-1,-1,1,-1,1,-1,2,0.4,medium,#a1d99b,91.76997429,0,119.1798855,8.8,0,0,0
-1675,132433,43,Mixed Forest,,132,Developed park,Golf course,-1,1,-1,-1,1,-1,1,-1,3,0.66,high,#31a354,91.76997429,0,119.1798855,8.8,0,0,0
-1676,132520,52,Shrub/Scrub,,132,Developed park,Golf course,1,1,1,0.2,1,-1,1,-1,0,0,none,#ffffff,47.875,0,68.15477645,0,0,0,0
-1677,132521,52,Shrub/Scrub,,132,Developed park,Golf course,1,1,1,0.2,1,-1,1,-1,1,0.15,low,#e5f5e0,54.86074743,0,73.49954853,1.6,0,0,0
-1678,132522,52,Shrub/Scrub,,132,Developed park,Golf course,1,1,1,0.2,1,-1,1,-1,2,0.4,medium,#a1d99b,66.5036598,0,82.407502,4.266666667,0,0,0
-1679,132523,52,Shrub/Scrub,,132,Developed park,Golf course,1,1,1,0.2,1,-1,1,-1,3,0.66,high,#31a354,78.61228868,0,91.6717736,7.04,0,0,0
-1680,132710,71,Herbaceuous,,132,Developed park,Golf course,1,1,1,0.2,1,-1,1,-1,0,0,none,#ffffff,10.10660117,8,98.79264417,0,0,0,0
-1681,132711,71,Herbaceuous,,132,Developed park,Golf course,1,1,1,0.2,1,-1,1,-1,1,0.15,low,#e5f5e0,22.75760842,6.8,99.54173609,1.6,0,0,0
-1682,132712,71,Herbaceuous,,132,Developed park,Golf course,1,1,1,0.2,1,-1,1,-1,2,0.4,medium,#a1d99b,43.84262051,4.8,100.7902226,4.266666667,0,0,0
-1683,132713,71,Herbaceuous,,132,Developed park,Golf course,1,1,1,0.2,1,-1,1,-1,3,0.66,high,#31a354,65.77103307,2.72,102.0886486,7.04,0,0,0
-1684,132810,81,Hay/Pasture,,132,Developed park,Golf course,1,1,1,0.2,1,-1,1,-1,0,0,none,#ffffff,10.10660117,8,98.79264417,0,0,0,0
-1685,132811,81,Hay/Pasture,,132,Developed park,Golf course,1,1,1,0.2,1,-1,1,-1,1,0.15,low,#e5f5e0,22.75760842,6.8,99.54173609,1.6,0,0,0
-1686,132812,81,Hay/Pasture,,132,Developed park,Golf course,1,1,1,0.2,1,-1,1,-1,2,0.4,medium,#a1d99b,43.84262051,4.8,100.7902226,4.266666667,0,0,0
-1687,132813,81,Hay/Pasture,,132,Developed park,Golf course,1,1,1,0.2,1,-1,1,-1,3,0.66,high,#31a354,65.77103307,2.72,102.0886486,7.04,0,0,0
-1688,132820,82,Cultivated Crops,,132,Developed park,Golf course,1,1,1,-1,-1,-1,1,-1,0,0,none,#ffffff,4.793840162,0,65.75263422,0,0,0,0
-1689,132821,82,Cultivated Crops,,132,Developed park,Golf course,1,1,1,-1,-1,-1,1,-1,1,0.15,low,#e5f5e0,18.24176156,0,71.45772764,1.6,0,0,0
-1690,132822,82,Cultivated Crops,,132,Developed park,Golf course,1,1,1,-1,-1,-1,1,-1,2,0.4,medium,#a1d99b,40.6549639,0,80.96621666,4.266666667,0,0,0
-1691,132823,82,Cultivated Crops,,132,Developed park,Golf course,1,1,1,-1,-1,-1,1,-1,3,0.66,high,#31a354,63.96469433,0,90.85504525,7.04,0,0,0
-1692,132900,90,Woody Wetlands,,132,Developed park,Golf course,1,1,-1,-1,1,-1,1,-1,0,0,none,#ffffff,33.5,0,259,0,0,0,0
-1693,132901,90,Woody Wetlands,,132,Developed park,Golf course,1,1,-1,-1,1,-1,1,-1,1,0.15,low,#e5f5e0,42.64199743,0,235.7179885,1.6,0,0,0
-1694,132902,90,Woody Wetlands,,132,Developed park,Golf course,1,1,-1,-1,1,-1,1,-1,2,0.4,medium,#a1d99b,57.8786598,0,196.9146361,4.266666667,0,0,0
-1695,132903,90,Woody Wetlands,,132,Developed park,Golf course,1,1,-1,-1,1,-1,1,-1,3,0.66,high,#31a354,73.72478868,0,156.5591496,7.04,0,0,0
-1696,132950,95,Emergent Herbaceuous Wetlands,,132,Developed park,Golf course,1,1,-1,-1,1,-1,1,-1,0,0,none,#ffffff,33.5,0,259,0,0,0,0
-1697,132951,95,Emergent Herbaceuous Wetlands,,132,Developed park,Golf course,1,1,-1,-1,1,-1,1,-1,1,0.15,low,#e5f5e0,42.64199743,0,235.7179885,1.6,0,0,0
-1698,132952,95,Emergent Herbaceuous Wetlands,,132,Developed park,Golf course,1,1,-1,-1,1,-1,1,-1,2,0.4,medium,#a1d99b,57.8786598,0,196.9146361,4.266666667,0,0,0
-1699,132953,95,Emergent Herbaceuous Wetlands,,132,Developed park,Golf course,1,1,-1,-1,1,-1,1,-1,3,0.66,high,#31a354,73.72478868,0,156.5591496,7.04,0,0,0
-1700,133000,0,Background,,133,Developed park,Resort/ski area,-1,-1,-1,-1,-1,-1,-1,-1,0,0,none,#ffffff,0,0,0,0,0,0,0
-1701,133001,0,Background,,133,Developed park,Resort/ski area,-1,-1,-1,-1,-1,-1,-1,-1,1,0.15,low,#e5f5e0,14.16699743,0,15.56798855,1.6,0,0,0
-1702,133002,0,Background,,133,Developed park,Resort/ski area,-1,-1,-1,-1,-1,-1,-1,-1,2,0.4,medium,#a1d99b,37.7786598,0,41.51463613,4.266666667,0,0,0
-1703,133003,0,Background,,133,Developed park,Resort/ski area,-1,-1,-1,-1,-1,-1,-1,-1,3,0.66,high,#31a354,62.33478868,0,68.49914961,7.04,0,0,0
-1704,133110,11,Open Water,,133,Developed park,Resort/ski area,-1,-1,-1,-1,-1,-1,1,-1,0,0,none,#ffffff,0,0,0,0,0,0,0
-1705,133111,11,Open Water,,133,Developed park,Resort/ski area,-1,-1,-1,-1,-1,-1,1,-1,1,0.15,low,#e5f5e0,14.16699743,0,15.56798855,1.6,0,0,0
-1706,133112,11,Open Water,,133,Developed park,Resort/ski area,-1,-1,-1,-1,-1,-1,1,-1,2,0.4,medium,#a1d99b,37.7786598,0,41.51463613,4.266666667,0,0,0
-1707,133113,11,Open Water,,133,Developed park,Resort/ski area,-1,-1,-1,-1,-1,-1,1,-1,3,0.66,high,#31a354,62.33478868,0,68.49914961,7.04,0,0,0
-1708,133120,12,Perennial Ice/Snow,,133,Developed park,Resort/ski area,-1,-1,-1,-1,-1,-1,-1,-1,0,0,none,#ffffff,0,0,0,0,0,0,0
-1709,133121,12,Perennial Ice/Snow,,133,Developed park,Resort/ski area,-1,-1,-1,-1,-1,-1,-1,-1,1,0.15,low,#e5f5e0,14.16699743,0,15.56798855,1.6,0,0,0
-1710,133122,12,Perennial Ice/Snow,,133,Developed park,Resort/ski area,-1,-1,-1,-1,-1,-1,-1,-1,2,0.4,medium,#a1d99b,37.7786598,0,41.51463613,4.266666667,0,0,0
-1711,133123,12,Perennial Ice/Snow,,133,Developed park,Resort/ski area,-1,-1,-1,-1,-1,-1,-1,-1,3,0.66,high,#31a354,62.33478868,0,68.49914961,7.04,0,0,0
-1712,133210,21,"Developed, Open Space","20% trees, 60% grass, and 10% buildings and 10% bare soil",133,Developed park,Resort/ski area,-1,-1,-1,-1,-1,-1,1,-1,0,0,none,#ffffff,25.49986095,4.08,79.01411479,1.76,51.81402439,212.31,37.03522039
-1713,133211,21,"Developed, Open Space","20% trees, 60% grass, and 10% buildings and 10% bare soil",133,Developed park,Resort/ski area,-1,-1,-1,-1,-1,-1,1,-1,1,0.15,low,#e5f5e0,35.84187923,3.468,82.72998612,3.096,51.81402439,212.31,37.03522039
-1714,133212,21,"Developed, Open Space","20% trees, 60% grass, and 10% buildings and 10% bare soil",133,Developed park,Resort/ski area,-1,-1,-1,-1,-1,-1,1,-1,2,0.4,medium,#a1d99b,53.07857637,2.448,88.923105,5.322666667,51.81402439,212.31,37.03522039
-1715,133213,21,"Developed, Open Space","20% trees, 60% grass, and 10% buildings and 10% bare soil",133,Developed park,Resort/ski area,-1,-1,-1,-1,-1,-1,1,-1,3,0.66,high,#31a354,71.0047414,1.3872,95.36394864,7.6384,51.81402439,212.31,37.03522039
-1716,133220,22,"Developed, Low Intensity","20% trees, 40% grass, and 40% buildings",133,Developed park,Resort/ski area,-1,-1,-1,-1,-1,-1,1,-1,0,0,none,#ffffff,20.90844667,3.52,72.06732319,0.61,207.2560976,849.24,147.1338816
-1717,133221,22,"Developed, Low Intensity","20% trees, 40% grass, and 40% buildings",133,Developed park,Resort/ski area,-1,-1,-1,-1,-1,-1,1,-1,1,0.15,low,#e5f5e0,31.9391771,2.992,76.82521326,2.1185,207.2560976,849.24,147.1338816
-1718,133222,22,"Developed, Low Intensity","20% trees, 40% grass, and 40% buildings",133,Developed park,Resort/ski area,-1,-1,-1,-1,-1,-1,1,-1,2,0.4,medium,#a1d99b,50.32372781,2.112,84.75503004,4.632666667,207.2560976,849.24,147.1338816
-1719,133223,22,"Developed, Low Intensity","20% trees, 40% grass, and 40% buildings",133,Developed park,Resort/ski area,-1,-1,-1,-1,-1,-1,1,-1,3,0.66,high,#31a354,69.44366054,1.1968,93.0020395,7.2474,207.2560976,849.24,147.1338816
-1720,133230,23,"Developed, Medium Intensity","15% trees, 35% grass, and 50% buildings",133,Developed park,Resort/ski area,-1,-1,-1,-1,-1,-1,1,-1,0,0,none,#ffffff,17.69813636,3.08,61.93838294,0.36,234.070122,954.85,720.4716833
-1721,133231,23,"Developed, Medium Intensity","15% trees, 35% grass, and 50% buildings",133,Developed park,Resort/ski area,-1,-1,-1,-1,-1,-1,1,-1,1,0.15,low,#e5f5e0,29.21041333,2.618,68.21561405,1.906,234.070122,954.85,720.4716833
-1722,133232,23,"Developed, Medium Intensity","15% trees, 35% grass, and 50% buildings",133,Developed park,Resort/ski area,-1,-1,-1,-1,-1,-1,1,-1,2,0.4,medium,#a1d99b,48.39754162,1.848,78.67766589,4.482666667,234.070122,954.85,720.4716833
-1723,133233,23,"Developed, Medium Intensity","15% trees, 35% grass, and 50% buildings",133,Developed park,Resort/ski area,-1,-1,-1,-1,-1,-1,1,-1,3,0.66,high,#31a354,68.35215504,1.0472,89.55819981,7.1624,234.070122,954.85,720.4716833
-1724,133240,24,"Developed, High Intensity","10% trees, 20% grass, and 70% buildings",133,Developed park,Resort/ski area,-1,-1,-1,-1,-1,-1,1,-1,0,0,none,#ffffff,10.98142029,1.76,44.78642515,0.245,267.9065041,3418.485,1805.616283
-1725,133241,24,"Developed, High Intensity","10% trees, 20% grass, and 70% buildings",133,Developed park,Resort/ski area,-1,-1,-1,-1,-1,-1,1,-1,1,0.15,low,#e5f5e0,23.50120467,1.496,53.63644993,1.80825,267.9065041,3418.485,1805.616283
-1726,133242,24,"Developed, High Intensity","10% trees, 20% grass, and 70% buildings",133,Developed park,Resort/ski area,-1,-1,-1,-1,-1,-1,1,-1,2,0.4,medium,#a1d99b,44.36751198,1.056,68.38649122,4.413666667,267.9065041,3418.485,1805.616283
-1727,133243,24,"Developed, High Intensity","10% trees, 20% grass, and 70% buildings",133,Developed park,Resort/ski area,-1,-1,-1,-1,-1,-1,1,-1,3,0.66,high,#31a354,66.06847158,0.5984,83.72653416,7.1233,267.9065041,3418.485,1805.616283
-1728,133310,31,Barren Land,,133,Developed park,Resort/ski area,-1,-1,-1,-1,-1,-1,1,-1,0,0,none,#ffffff,6.8,0,25.5,0,0,0,0
-1729,133311,31,Barren Land,,133,Developed park,Resort/ski area,-1,-1,-1,-1,-1,-1,1,-1,1,0.15,low,#e5f5e0,19.94699743,0,37.24298855,1.6,0,0,0
-1730,133312,31,Barren Land,,133,Developed park,Resort/ski area,-1,-1,-1,-1,-1,-1,1,-1,2,0.4,medium,#a1d99b,41.8586598,0,56.81463613,4.266666667,0,0,0
-1731,133313,31,Barren Land,,133,Developed park,Resort/ski area,-1,-1,-1,-1,-1,-1,1,-1,3,0.66,high,#31a354,64.64678868,0,77.16914961,7.04,0,0,0
-1732,133410,41,Deciduous Forest,,133,Developed park,Resort/ski area,-1,-1,-1,-1,-1,-1,1,-1,0,0,none,#ffffff,85.88498714,0,96.08994273,8.8,0,0,0
-1733,133411,41,Deciduous Forest,,133,Developed park,Resort/ski area,-1,-1,-1,-1,-1,-1,1,-1,1,0.15,low,#e5f5e0,85.88498714,0,96.08994273,8.8,0,0,0
-1734,133412,41,Deciduous Forest,,133,Developed park,Resort/ski area,-1,-1,-1,-1,-1,-1,1,-1,2,0.4,medium,#a1d99b,85.88498714,0,96.08994273,8.8,0,0,0
-1735,133413,41,Deciduous Forest,,133,Developed park,Resort/ski area,-1,-1,-1,-1,-1,-1,1,-1,3,0.66,high,#31a354,85.88498714,0,96.08994273,8.8,0,0,0
-1736,133420,42,Evergreen Forest,,133,Developed park,Resort/ski area,-1,-1,-1,-1,-1,-1,1,-1,0,0,none,#ffffff,105.6849871,0,96.08994273,14.4,0,0,0
-1737,133421,42,Evergreen Forest,,133,Developed park,Resort/ski area,-1,-1,-1,-1,-1,-1,1,-1,1,0.15,low,#e5f5e0,105.6849871,0,96.08994273,14.4,0,0,0
-1738,133422,42,Evergreen Forest,,133,Developed park,Resort/ski area,-1,-1,-1,-1,-1,-1,1,-1,2,0.4,medium,#a1d99b,105.6849871,0,96.08994273,14.4,0,0,0
-1739,133423,42,Evergreen Forest,,133,Developed park,Resort/ski area,-1,-1,-1,-1,-1,-1,1,-1,3,0.66,high,#31a354,105.6849871,0,96.08994273,14.4,0,0,0
-1740,133430,43,Mixed Forest,,133,Developed park,Resort/ski area,-1,-1,-1,-1,-1,-1,1,-1,0,0,none,#ffffff,91.76997429,0,119.1798855,8.8,0,0,0
-1741,133431,43,Mixed Forest,,133,Developed park,Resort/ski area,-1,-1,-1,-1,-1,-1,1,-1,1,0.15,low,#e5f5e0,91.76997429,0,119.1798855,8.8,0,0,0
-1742,133432,43,Mixed Forest,,133,Developed park,Resort/ski area,-1,-1,-1,-1,-1,-1,1,-1,2,0.4,medium,#a1d99b,91.76997429,0,119.1798855,8.8,0,0,0
-1743,133433,43,Mixed Forest,,133,Developed park,Resort/ski area,-1,-1,-1,-1,-1,-1,1,-1,3,0.66,high,#31a354,91.76997429,0,119.1798855,8.8,0,0,0
-1744,133520,52,Shrub/Scrub,,133,Developed park,Resort/ski area,-1,-1,-1,-1,-1,-1,1,-1,0,0,none,#ffffff,47.875,0,68.15477645,0,0,0,0
-1745,133521,52,Shrub/Scrub,,133,Developed park,Resort/ski area,-1,-1,-1,-1,-1,-1,1,-1,1,0.15,low,#e5f5e0,54.86074743,0,73.49954853,1.6,0,0,0
-1746,133522,52,Shrub/Scrub,,133,Developed park,Resort/ski area,-1,-1,-1,-1,-1,-1,1,-1,2,0.4,medium,#a1d99b,66.5036598,0,82.407502,4.266666667,0,0,0
-1747,133523,52,Shrub/Scrub,,133,Developed park,Resort/ski area,-1,-1,-1,-1,-1,-1,1,-1,3,0.66,high,#31a354,78.61228868,0,91.6717736,7.04,0,0,0
-1748,133710,71,Herbaceuous,,133,Developed park,Resort/ski area,-1,-1,-1,-1,-1,-1,1,-1,0,0,none,#ffffff,10.10660117,8,98.79264417,0,0,0,0
-1749,133711,71,Herbaceuous,,133,Developed park,Resort/ski area,-1,-1,-1,-1,-1,-1,1,-1,1,0.15,low,#e5f5e0,22.75760842,6.8,99.54173609,1.6,0,0,0
-1750,133712,71,Herbaceuous,,133,Developed park,Resort/ski area,-1,-1,-1,-1,-1,-1,1,-1,2,0.4,medium,#a1d99b,43.84262051,4.8,100.7902226,4.266666667,0,0,0
-1751,133713,71,Herbaceuous,,133,Developed park,Resort/ski area,-1,-1,-1,-1,-1,-1,1,-1,3,0.66,high,#31a354,65.77103307,2.72,102.0886486,7.04,0,0,0
-1752,133810,81,Hay/Pasture,,133,Developed park,Resort/ski area,-1,-1,-1,-1,-1,-1,1,-1,0,0,none,#ffffff,10.10660117,8,98.79264417,0,0,0,0
-1753,133811,81,Hay/Pasture,,133,Developed park,Resort/ski area,-1,-1,-1,-1,-1,-1,1,-1,1,0.15,low,#e5f5e0,22.75760842,6.8,99.54173609,1.6,0,0,0
-1754,133812,81,Hay/Pasture,,133,Developed park,Resort/ski area,-1,-1,-1,-1,-1,-1,1,-1,2,0.4,medium,#a1d99b,43.84262051,4.8,100.7902226,4.266666667,0,0,0
-1755,133813,81,Hay/Pasture,,133,Developed park,Resort/ski area,-1,-1,-1,-1,-1,-1,1,-1,3,0.66,high,#31a354,65.77103307,2.72,102.0886486,7.04,0,0,0
-1756,133820,82,Cultivated Crops,,133,Developed park,Resort/ski area,-1,-1,-1,-1,-1,-1,1,-1,0,0,none,#ffffff,4.793840162,0,65.75263422,0,0,0,0
-1757,133821,82,Cultivated Crops,,133,Developed park,Resort/ski area,-1,-1,-1,-1,-1,-1,1,-1,1,0.15,low,#e5f5e0,18.24176156,0,71.45772764,1.6,0,0,0
-1758,133822,82,Cultivated Crops,,133,Developed park,Resort/ski area,-1,-1,-1,-1,-1,-1,1,-1,2,0.4,medium,#a1d99b,40.6549639,0,80.96621666,4.266666667,0,0,0
-1759,133823,82,Cultivated Crops,,133,Developed park,Resort/ski area,-1,-1,-1,-1,-1,-1,1,-1,3,0.66,high,#31a354,63.96469433,0,90.85504525,7.04,0,0,0
-1760,133900,90,Woody Wetlands,,133,Developed park,Resort/ski area,-1,-1,-1,-1,-1,-1,1,-1,0,0,none,#ffffff,33.5,0,259,0,0,0,0
-1761,133901,90,Woody Wetlands,,133,Developed park,Resort/ski area,-1,-1,-1,-1,-1,-1,1,-1,1,0.15,low,#e5f5e0,42.64199743,0,235.7179885,1.6,0,0,0
-1762,133902,90,Woody Wetlands,,133,Developed park,Resort/ski area,-1,-1,-1,-1,-1,-1,1,-1,2,0.4,medium,#a1d99b,57.8786598,0,196.9146361,4.266666667,0,0,0
-1763,133903,90,Woody Wetlands,,133,Developed park,Resort/ski area,-1,-1,-1,-1,-1,-1,1,-1,3,0.66,high,#31a354,73.72478868,0,156.5591496,7.04,0,0,0
-1764,133950,95,Emergent Herbaceuous Wetlands,,133,Developed park,Resort/ski area,-1,-1,-1,-1,-1,-1,1,-1,0,0,none,#ffffff,33.5,0,259,0,0,0,0
-1765,133951,95,Emergent Herbaceuous Wetlands,,133,Developed park,Resort/ski area,-1,-1,-1,-1,-1,-1,1,-1,1,0.15,low,#e5f5e0,42.64199743,0,235.7179885,1.6,0,0,0
-1766,133952,95,Emergent Herbaceuous Wetlands,,133,Developed park,Resort/ski area,-1,-1,-1,-1,-1,-1,1,-1,2,0.4,medium,#a1d99b,57.8786598,0,196.9146361,4.266666667,0,0,0
-1767,133953,95,Emergent Herbaceuous Wetlands,,133,Developed park,Resort/ski area,-1,-1,-1,-1,-1,-1,1,-1,3,0.66,high,#31a354,73.72478868,0,156.5591496,7.04,0,0,0
-1768,134000,0,Background,,134,Developed park,Other,-1,-1,-1,-1,-1,-1,-1,-1,0,0,none,#ffffff,0,0,0,0,0,0,0
-1769,134001,0,Background,,134,Developed park,Other,-1,-1,-1,-1,-1,-1,-1,-1,1,0.15,low,#e5f5e0,14.16699743,0,15.56798855,1.6,0,0,0
-1770,134002,0,Background,,134,Developed park,Other,-1,-1,-1,-1,-1,-1,-1,-1,2,0.4,medium,#a1d99b,37.7786598,0,41.51463613,4.266666667,0,0,0
-1771,134003,0,Background,,134,Developed park,Other,-1,-1,-1,-1,-1,-1,-1,-1,3,0.66,high,#31a354,62.33478868,0,68.49914961,7.04,0,0,0
-1772,134110,11,Open Water,,134,Developed park,Other,-1,-1,-1,-1,-1,-1,1,-1,0,0,none,#ffffff,0,0,0,0,0,0,0
-1773,134111,11,Open Water,,134,Developed park,Other,-1,-1,-1,-1,-1,-1,1,-1,1,0.15,low,#e5f5e0,14.16699743,0,15.56798855,1.6,0,0,0
-1774,134112,11,Open Water,,134,Developed park,Other,-1,-1,-1,-1,-1,-1,1,-1,2,0.4,medium,#a1d99b,37.7786598,0,41.51463613,4.266666667,0,0,0
-1775,134113,11,Open Water,,134,Developed park,Other,-1,-1,-1,-1,-1,-1,1,-1,3,0.66,high,#31a354,62.33478868,0,68.49914961,7.04,0,0,0
-1776,134120,12,Perennial Ice/Snow,,134,Developed park,Other,-1,-1,-1,-1,-1,-1,-1,-1,0,0,none,#ffffff,0,0,0,0,0,0,0
-1777,134121,12,Perennial Ice/Snow,,134,Developed park,Other,-1,-1,-1,-1,-1,-1,-1,-1,1,0.15,low,#e5f5e0,14.16699743,0,15.56798855,1.6,0,0,0
-1778,134122,12,Perennial Ice/Snow,,134,Developed park,Other,-1,-1,-1,-1,-1,-1,-1,-1,2,0.4,medium,#a1d99b,37.7786598,0,41.51463613,4.266666667,0,0,0
-1779,134123,12,Perennial Ice/Snow,,134,Developed park,Other,-1,-1,-1,-1,-1,-1,-1,-1,3,0.66,high,#31a354,62.33478868,0,68.49914961,7.04,0,0,0
-1780,134210,21,"Developed, Open Space","20% trees, 60% grass, and 10% buildings and 10% bare soil",134,Developed park,Other,-1,-1,-1,-1,-1,-1,1,-1,0,0,none,#ffffff,25.49986095,4.08,79.01411479,1.76,51.81402439,212.31,37.03522039
-1781,134211,21,"Developed, Open Space","20% trees, 60% grass, and 10% buildings and 10% bare soil",134,Developed park,Other,-1,-1,-1,-1,-1,-1,1,-1,1,0.15,low,#e5f5e0,35.84187923,3.468,82.72998612,3.096,51.81402439,212.31,37.03522039
-1782,134212,21,"Developed, Open Space","20% trees, 60% grass, and 10% buildings and 10% bare soil",134,Developed park,Other,-1,-1,-1,-1,-1,-1,1,-1,2,0.4,medium,#a1d99b,53.07857637,2.448,88.923105,5.322666667,51.81402439,212.31,37.03522039
-1783,134213,21,"Developed, Open Space","20% trees, 60% grass, and 10% buildings and 10% bare soil",134,Developed park,Other,-1,-1,-1,-1,-1,-1,1,-1,3,0.66,high,#31a354,71.0047414,1.3872,95.36394864,7.6384,51.81402439,212.31,37.03522039
-1784,134220,22,"Developed, Low Intensity","20% trees, 40% grass, and 40% buildings",134,Developed park,Other,-1,-1,-1,-1,-1,-1,1,-1,0,0,none,#ffffff,20.90844667,3.52,72.06732319,0.61,207.2560976,849.24,147.1338816
-1785,134221,22,"Developed, Low Intensity","20% trees, 40% grass, and 40% buildings",134,Developed park,Other,-1,-1,-1,-1,-1,-1,1,-1,1,0.15,low,#e5f5e0,31.9391771,2.992,76.82521326,2.1185,207.2560976,849.24,147.1338816
-1786,134222,22,"Developed, Low Intensity","20% trees, 40% grass, and 40% buildings",134,Developed park,Other,-1,-1,-1,-1,-1,-1,1,-1,2,0.4,medium,#a1d99b,50.32372781,2.112,84.75503004,4.632666667,207.2560976,849.24,147.1338816
-1787,134223,22,"Developed, Low Intensity","20% trees, 40% grass, and 40% buildings",134,Developed park,Other,-1,-1,-1,-1,-1,-1,1,-1,3,0.66,high,#31a354,69.44366054,1.1968,93.0020395,7.2474,207.2560976,849.24,147.1338816
-1788,134230,23,"Developed, Medium Intensity","15% trees, 35% grass, and 50% buildings",134,Developed park,Other,-1,-1,-1,-1,-1,-1,1,-1,0,0,none,#ffffff,17.69813636,3.08,61.93838294,0.36,234.070122,954.85,720.4716833
-1789,134231,23,"Developed, Medium Intensity","15% trees, 35% grass, and 50% buildings",134,Developed park,Other,-1,-1,-1,-1,-1,-1,1,-1,1,0.15,low,#e5f5e0,29.21041333,2.618,68.21561405,1.906,234.070122,954.85,720.4716833
-1790,134232,23,"Developed, Medium Intensity","15% trees, 35% grass, and 50% buildings",134,Developed park,Other,-1,-1,-1,-1,-1,-1,1,-1,2,0.4,medium,#a1d99b,48.39754162,1.848,78.67766589,4.482666667,234.070122,954.85,720.4716833
-1791,134233,23,"Developed, Medium Intensity","15% trees, 35% grass, and 50% buildings",134,Developed park,Other,-1,-1,-1,-1,-1,-1,1,-1,3,0.66,high,#31a354,68.35215504,1.0472,89.55819981,7.1624,234.070122,954.85,720.4716833
-1792,134240,24,"Developed, High Intensity","10% trees, 20% grass, and 70% buildings",134,Developed park,Other,-1,-1,-1,-1,-1,-1,1,-1,0,0,none,#ffffff,10.98142029,1.76,44.78642515,0.245,267.9065041,3418.485,1805.616283
-1793,134241,24,"Developed, High Intensity","10% trees, 20% grass, and 70% buildings",134,Developed park,Other,-1,-1,-1,-1,-1,-1,1,-1,1,0.15,low,#e5f5e0,23.50120467,1.496,53.63644993,1.80825,267.9065041,3418.485,1805.616283
-1794,134242,24,"Developed, High Intensity","10% trees, 20% grass, and 70% buildings",134,Developed park,Other,-1,-1,-1,-1,-1,-1,1,-1,2,0.4,medium,#a1d99b,44.36751198,1.056,68.38649122,4.413666667,267.9065041,3418.485,1805.616283
-1795,134243,24,"Developed, High Intensity","10% trees, 20% grass, and 70% buildings",134,Developed park,Other,-1,-1,-1,-1,-1,-1,1,-1,3,0.66,high,#31a354,66.06847158,0.5984,83.72653416,7.1233,267.9065041,3418.485,1805.616283
-1796,134310,31,Barren Land,,134,Developed park,Other,-1,-1,-1,-1,-1,-1,1,-1,0,0,none,#ffffff,6.8,0,25.5,0,0,0,0
-1797,134311,31,Barren Land,,134,Developed park,Other,-1,-1,-1,-1,-1,-1,1,-1,1,0.15,low,#e5f5e0,19.94699743,0,37.24298855,1.6,0,0,0
-1798,134312,31,Barren Land,,134,Developed park,Other,-1,-1,-1,-1,-1,-1,1,-1,2,0.4,medium,#a1d99b,41.8586598,0,56.81463613,4.266666667,0,0,0
-1799,134313,31,Barren Land,,134,Developed park,Other,-1,-1,-1,-1,-1,-1,1,-1,3,0.66,high,#31a354,64.64678868,0,77.16914961,7.04,0,0,0
-1800,134410,41,Deciduous Forest,,134,Developed park,Other,-1,-1,-1,-1,-1,-1,1,-1,0,0,none,#ffffff,85.88498714,0,96.08994273,8.8,0,0,0
-1801,134411,41,Deciduous Forest,,134,Developed park,Other,-1,-1,-1,-1,-1,-1,1,-1,1,0.15,low,#e5f5e0,85.88498714,0,96.08994273,8.8,0,0,0
-1802,134412,41,Deciduous Forest,,134,Developed park,Other,-1,-1,-1,-1,-1,-1,1,-1,2,0.4,medium,#a1d99b,85.88498714,0,96.08994273,8.8,0,0,0
-1803,134413,41,Deciduous Forest,,134,Developed park,Other,-1,-1,-1,-1,-1,-1,1,-1,3,0.66,high,#31a354,85.88498714,0,96.08994273,8.8,0,0,0
-1804,134420,42,Evergreen Forest,,134,Developed park,Other,-1,-1,-1,-1,-1,-1,1,-1,0,0,none,#ffffff,105.6849871,0,96.08994273,14.4,0,0,0
-1805,134421,42,Evergreen Forest,,134,Developed park,Other,-1,-1,-1,-1,-1,-1,1,-1,1,0.15,low,#e5f5e0,105.6849871,0,96.08994273,14.4,0,0,0
-1806,134422,42,Evergreen Forest,,134,Developed park,Other,-1,-1,-1,-1,-1,-1,1,-1,2,0.4,medium,#a1d99b,105.6849871,0,96.08994273,14.4,0,0,0
-1807,134423,42,Evergreen Forest,,134,Developed park,Other,-1,-1,-1,-1,-1,-1,1,-1,3,0.66,high,#31a354,105.6849871,0,96.08994273,14.4,0,0,0
-1808,134430,43,Mixed Forest,,134,Developed park,Other,-1,-1,-1,-1,-1,-1,1,-1,0,0,none,#ffffff,91.76997429,0,119.1798855,8.8,0,0,0
-1809,134431,43,Mixed Forest,,134,Developed park,Other,-1,-1,-1,-1,-1,-1,1,-1,1,0.15,low,#e5f5e0,91.76997429,0,119.1798855,8.8,0,0,0
-1810,134432,43,Mixed Forest,,134,Developed park,Other,-1,-1,-1,-1,-1,-1,1,-1,2,0.4,medium,#a1d99b,91.76997429,0,119.1798855,8.8,0,0,0
-1811,134433,43,Mixed Forest,,134,Developed park,Other,-1,-1,-1,-1,-1,-1,1,-1,3,0.66,high,#31a354,91.76997429,0,119.1798855,8.8,0,0,0
-1812,134520,52,Shrub/Scrub,,134,Developed park,Other,-1,-1,-1,-1,-1,-1,1,-1,0,0,none,#ffffff,47.875,0,68.15477645,0,0,0,0
-1813,134521,52,Shrub/Scrub,,134,Developed park,Other,-1,-1,-1,-1,-1,-1,1,-1,1,0.15,low,#e5f5e0,54.86074743,0,73.49954853,1.6,0,0,0
-1814,134522,52,Shrub/Scrub,,134,Developed park,Other,-1,-1,-1,-1,-1,-1,1,-1,2,0.4,medium,#a1d99b,66.5036598,0,82.407502,4.266666667,0,0,0
-1815,134523,52,Shrub/Scrub,,134,Developed park,Other,-1,-1,-1,-1,-1,-1,1,-1,3,0.66,high,#31a354,78.61228868,0,91.6717736,7.04,0,0,0
-1816,134710,71,Herbaceuous,,134,Developed park,Other,-1,-1,-1,-1,-1,-1,1,-1,0,0,none,#ffffff,10.10660117,8,98.79264417,0,0,0,0
-1817,134711,71,Herbaceuous,,134,Developed park,Other,-1,-1,-1,-1,-1,-1,1,-1,1,0.15,low,#e5f5e0,22.75760842,6.8,99.54173609,1.6,0,0,0
-1818,134712,71,Herbaceuous,,134,Developed park,Other,-1,-1,-1,-1,-1,-1,1,-1,2,0.4,medium,#a1d99b,43.84262051,4.8,100.7902226,4.266666667,0,0,0
-1819,134713,71,Herbaceuous,,134,Developed park,Other,-1,-1,-1,-1,-1,-1,1,-1,3,0.66,high,#31a354,65.77103307,2.72,102.0886486,7.04,0,0,0
-1820,134810,81,Hay/Pasture,,134,Developed park,Other,-1,-1,-1,-1,-1,-1,1,-1,0,0,none,#ffffff,10.10660117,8,98.79264417,0,0,0,0
-1821,134811,81,Hay/Pasture,,134,Developed park,Other,-1,-1,-1,-1,-1,-1,1,-1,1,0.15,low,#e5f5e0,22.75760842,6.8,99.54173609,1.6,0,0,0
-1822,134812,81,Hay/Pasture,,134,Developed park,Other,-1,-1,-1,-1,-1,-1,1,-1,2,0.4,medium,#a1d99b,43.84262051,4.8,100.7902226,4.266666667,0,0,0
-1823,134813,81,Hay/Pasture,,134,Developed park,Other,-1,-1,-1,-1,-1,-1,1,-1,3,0.66,high,#31a354,65.77103307,2.72,102.0886486,7.04,0,0,0
-1824,134820,82,Cultivated Crops,,134,Developed park,Other,-1,-1,-1,-1,-1,-1,1,-1,0,0,none,#ffffff,4.793840162,0,65.75263422,0,0,0,0
-1825,134821,82,Cultivated Crops,,134,Developed park,Other,-1,-1,-1,-1,-1,-1,1,-1,1,0.15,low,#e5f5e0,18.24176156,0,71.45772764,1.6,0,0,0
-1826,134822,82,Cultivated Crops,,134,Developed park,Other,-1,-1,-1,-1,-1,-1,1,-1,2,0.4,medium,#a1d99b,40.6549639,0,80.96621666,4.266666667,0,0,0
-1827,134823,82,Cultivated Crops,,134,Developed park,Other,-1,-1,-1,-1,-1,-1,1,-1,3,0.66,high,#31a354,63.96469433,0,90.85504525,7.04,0,0,0
-1828,134900,90,Woody Wetlands,,134,Developed park,Other,-1,-1,-1,-1,-1,-1,1,-1,0,0,none,#ffffff,33.5,0,259,0,0,0,0
-1829,134901,90,Woody Wetlands,,134,Developed park,Other,-1,-1,-1,-1,-1,-1,1,-1,1,0.15,low,#e5f5e0,42.64199743,0,235.7179885,1.6,0,0,0
-1830,134902,90,Woody Wetlands,,134,Developed park,Other,-1,-1,-1,-1,-1,-1,1,-1,2,0.4,medium,#a1d99b,57.8786598,0,196.9146361,4.266666667,0,0,0
-1831,134903,90,Woody Wetlands,,134,Developed park,Other,-1,-1,-1,-1,-1,-1,1,-1,3,0.66,high,#31a354,73.72478868,0,156.5591496,7.04,0,0,0
-1832,134950,95,Emergent Herbaceuous Wetlands,,134,Developed park,Other,-1,-1,-1,-1,-1,-1,1,-1,0,0,none,#ffffff,33.5,0,259,0,0,0,0
-1833,134951,95,Emergent Herbaceuous Wetlands,,134,Developed park,Other,-1,-1,-1,-1,-1,-1,1,-1,1,0.15,low,#e5f5e0,42.64199743,0,235.7179885,1.6,0,0,0
-1834,134952,95,Emergent Herbaceuous Wetlands,,134,Developed park,Other,-1,-1,-1,-1,-1,-1,1,-1,2,0.4,medium,#a1d99b,57.8786598,0,196.9146361,4.266666667,0,0,0
-1835,134953,95,Emergent Herbaceuous Wetlands,,134,Developed park,Other,-1,-1,-1,-1,-1,-1,1,-1,3,0.66,high,#31a354,73.72478868,0,156.5591496,7.04,0,0,0
-1836,140000,0,Background,,140,Natural park,,-1,-1,-1,-1,-1,-1,-1,-1,0,0,none,#ffffff,0,0,0,0,0,0,0
-1837,140001,0,Background,,140,Natural park,,-1,-1,-1,-1,-1,-1,-1,-1,1,0.15,low,#e5f5e0,14.16699743,0,15.56798855,1.6,0,0,0
-1838,140002,0,Background,,140,Natural park,,-1,-1,-1,-1,-1,-1,-1,-1,2,0.4,medium,#a1d99b,37.7786598,0,41.51463613,4.266666667,0,0,0
-1839,140003,0,Background,,140,Natural park,,-1,-1,-1,-1,-1,-1,-1,-1,3,0.66,high,#31a354,62.33478868,0,68.49914961,7.04,0,0,0
-1840,140110,11,Open Water,,140,Natural park,,-1,-1,-1,-1,-1,-1,1,-1,0,0,none,#ffffff,0,0,0,0,0,0,0
-1841,140111,11,Open Water,,140,Natural park,,-1,-1,-1,-1,-1,-1,1,-1,1,0.15,low,#e5f5e0,14.16699743,0,15.56798855,1.6,0,0,0
-1842,140112,11,Open Water,,140,Natural park,,-1,-1,-1,-1,-1,-1,1,-1,2,0.4,medium,#a1d99b,37.7786598,0,41.51463613,4.266666667,0,0,0
-1843,140113,11,Open Water,,140,Natural park,,-1,-1,-1,-1,-1,-1,1,-1,3,0.66,high,#31a354,62.33478868,0,68.49914961,7.04,0,0,0
-1844,140120,12,Perennial Ice/Snow,,140,Natural park,,-1,-1,-1,-1,-1,-1,-1,-1,0,0,none,#ffffff,0,0,0,0,0,0,0
-1845,140121,12,Perennial Ice/Snow,,140,Natural park,,-1,-1,-1,-1,-1,-1,-1,-1,1,0.15,low,#e5f5e0,14.16699743,0,15.56798855,1.6,0,0,0
-1846,140122,12,Perennial Ice/Snow,,140,Natural park,,-1,-1,-1,-1,-1,-1,-1,-1,2,0.4,medium,#a1d99b,37.7786598,0,41.51463613,4.266666667,0,0,0
-1847,140123,12,Perennial Ice/Snow,,140,Natural park,,-1,-1,-1,-1,-1,-1,-1,-1,3,0.66,high,#31a354,62.33478868,0,68.49914961,7.04,0,0,0
-1848,140210,21,"Developed, Open Space","20% trees, 60% grass, and 10% buildings and 10% bare soil",140,Natural park,,-1,-1,-1,1,-1,-1,1,-1,0,0,none,#ffffff,25.49986095,4.08,79.01411479,1.76,51.81402439,212.31,37.03522039
-1849,140211,21,"Developed, Open Space","20% trees, 60% grass, and 10% buildings and 10% bare soil",140,Natural park,,-1,-1,-1,1,-1,-1,1,-1,1,0.15,low,#e5f5e0,35.84187923,3.468,82.72998612,3.096,51.81402439,212.31,37.03522039
-1850,140212,21,"Developed, Open Space","20% trees, 60% grass, and 10% buildings and 10% bare soil",140,Natural park,,-1,-1,-1,1,-1,-1,1,-1,2,0.4,medium,#a1d99b,53.07857637,2.448,88.923105,5.322666667,51.81402439,212.31,37.03522039
-1851,140213,21,"Developed, Open Space","20% trees, 60% grass, and 10% buildings and 10% bare soil",140,Natural park,,-1,-1,-1,1,-1,-1,1,-1,3,0.66,high,#31a354,71.0047414,1.3872,95.36394864,7.6384,51.81402439,212.31,37.03522039
-1852,140220,22,"Developed, Low Intensity","20% trees, 40% grass, and 40% buildings",140,Natural park,,-1,-1,-1,1,-1,-1,1,-1,0,0,none,#ffffff,20.90844667,3.52,72.06732319,0.61,207.2560976,849.24,147.1338816
-1853,140221,22,"Developed, Low Intensity","20% trees, 40% grass, and 40% buildings",140,Natural park,,-1,-1,-1,1,-1,-1,1,-1,1,0.15,low,#e5f5e0,31.9391771,2.992,76.82521326,2.1185,207.2560976,849.24,147.1338816
-1854,140222,22,"Developed, Low Intensity","20% trees, 40% grass, and 40% buildings",140,Natural park,,-1,-1,-1,1,-1,-1,1,-1,2,0.4,medium,#a1d99b,50.32372781,2.112,84.75503004,4.632666667,207.2560976,849.24,147.1338816
-1855,140223,22,"Developed, Low Intensity","20% trees, 40% grass, and 40% buildings",140,Natural park,,-1,-1,-1,1,-1,-1,1,-1,3,0.66,high,#31a354,69.44366054,1.1968,93.0020395,7.2474,207.2560976,849.24,147.1338816
-1856,140230,23,"Developed, Medium Intensity","15% trees, 35% grass, and 50% buildings",140,Natural park,,-1,-1,-1,1,-1,-1,1,-1,0,0,none,#ffffff,17.69813636,3.08,61.93838294,0.36,234.070122,954.85,720.4716833
-1857,140231,23,"Developed, Medium Intensity","15% trees, 35% grass, and 50% buildings",140,Natural park,,-1,-1,-1,1,-1,-1,1,-1,1,0.15,low,#e5f5e0,29.21041333,2.618,68.21561405,1.906,234.070122,954.85,720.4716833
-1858,140232,23,"Developed, Medium Intensity","15% trees, 35% grass, and 50% buildings",140,Natural park,,-1,-1,-1,1,-1,-1,1,-1,2,0.4,medium,#a1d99b,48.39754162,1.848,78.67766589,4.482666667,234.070122,954.85,720.4716833
-1859,140233,23,"Developed, Medium Intensity","15% trees, 35% grass, and 50% buildings",140,Natural park,,-1,-1,-1,1,-1,-1,1,-1,3,0.66,high,#31a354,68.35215504,1.0472,89.55819981,7.1624,234.070122,954.85,720.4716833
-1860,140240,24,"Developed, High Intensity","10% trees, 20% grass, and 70% buildings",140,Natural park,,-1,-1,-1,1,-1,-1,1,-1,0,0,none,#ffffff,10.98142029,1.76,44.78642515,0.245,267.9065041,3418.485,1805.616283
-1861,140241,24,"Developed, High Intensity","10% trees, 20% grass, and 70% buildings",140,Natural park,,-1,-1,-1,1,-1,-1,1,-1,1,0.15,low,#e5f5e0,23.50120467,1.496,53.63644993,1.80825,267.9065041,3418.485,1805.616283
-1862,140242,24,"Developed, High Intensity","10% trees, 20% grass, and 70% buildings",140,Natural park,,-1,-1,-1,1,-1,-1,1,-1,2,0.4,medium,#a1d99b,44.36751198,1.056,68.38649122,4.413666667,267.9065041,3418.485,1805.616283
-1863,140243,24,"Developed, High Intensity","10% trees, 20% grass, and 70% buildings",140,Natural park,,-1,-1,-1,1,-1,-1,1,-1,3,0.66,high,#31a354,66.06847158,0.5984,83.72653416,7.1233,267.9065041,3418.485,1805.616283
-1864,140310,31,Barren Land,,140,Natural park,,-1,-1,-1,1,-1,-1,1,-1,0,0,none,#ffffff,6.8,0,25.5,0,0,0,0
-1865,140311,31,Barren Land,,140,Natural park,,-1,-1,-1,1,-1,-1,1,-1,1,0.15,low,#e5f5e0,19.94699743,0,37.24298855,1.6,0,0,0
-1866,140312,31,Barren Land,,140,Natural park,,-1,-1,-1,1,-1,-1,1,-1,2,0.4,medium,#a1d99b,41.8586598,0,56.81463613,4.266666667,0,0,0
-1867,140313,31,Barren Land,,140,Natural park,,-1,-1,-1,1,-1,-1,1,-1,3,0.66,high,#31a354,64.64678868,0,77.16914961,7.04,0,0,0
-1868,140410,41,Deciduous Forest,,140,Natural park,,-1,-1,-1,-1,-1,-1,1,-1,0,0,none,#ffffff,85.88498714,0,96.08994273,8.8,0,0,0
-1869,140411,41,Deciduous Forest,,140,Natural park,,-1,-1,-1,-1,-1,-1,1,-1,1,0.15,low,#e5f5e0,85.88498714,0,96.08994273,8.8,0,0,0
-1870,140412,41,Deciduous Forest,,140,Natural park,,-1,-1,-1,-1,-1,-1,1,-1,2,0.4,medium,#a1d99b,85.88498714,0,96.08994273,8.8,0,0,0
-1871,140413,41,Deciduous Forest,,140,Natural park,,-1,-1,-1,-1,-1,-1,1,-1,3,0.66,high,#31a354,85.88498714,0,96.08994273,8.8,0,0,0
-1872,140420,42,Evergreen Forest,,140,Natural park,,-1,-1,-1,-1,-1,-1,1,-1,0,0,none,#ffffff,105.6849871,0,96.08994273,14.4,0,0,0
-1873,140421,42,Evergreen Forest,,140,Natural park,,-1,-1,-1,-1,-1,-1,1,-1,1,0.15,low,#e5f5e0,105.6849871,0,96.08994273,14.4,0,0,0
-1874,140422,42,Evergreen Forest,,140,Natural park,,-1,-1,-1,-1,-1,-1,1,-1,2,0.4,medium,#a1d99b,105.6849871,0,96.08994273,14.4,0,0,0
-1875,140423,42,Evergreen Forest,,140,Natural park,,-1,-1,-1,-1,-1,-1,1,-1,3,0.66,high,#31a354,105.6849871,0,96.08994273,14.4,0,0,0
-1876,140430,43,Mixed Forest,,140,Natural park,,-1,-1,-1,-1,-1,-1,1,-1,0,0,none,#ffffff,91.76997429,0,119.1798855,8.8,0,0,0
-1877,140431,43,Mixed Forest,,140,Natural park,,-1,-1,-1,-1,-1,-1,1,-1,1,0.15,low,#e5f5e0,91.76997429,0,119.1798855,8.8,0,0,0
-1878,140432,43,Mixed Forest,,140,Natural park,,-1,-1,-1,-1,-1,-1,1,-1,2,0.4,medium,#a1d99b,91.76997429,0,119.1798855,8.8,0,0,0
-1879,140433,43,Mixed Forest,,140,Natural park,,-1,-1,-1,-1,-1,-1,1,-1,3,0.66,high,#31a354,91.76997429,0,119.1798855,8.8,0,0,0
-1880,140520,52,Shrub/Scrub,,140,Natural park,,-1,-1,-1,1,-1,-1,1,-1,0,0,none,#ffffff,47.875,0,68.15477645,0,0,0,0
-1881,140521,52,Shrub/Scrub,,140,Natural park,,-1,-1,-1,1,-1,-1,1,-1,1,0.15,low,#e5f5e0,54.86074743,0,73.49954853,1.6,0,0,0
-1882,140522,52,Shrub/Scrub,,140,Natural park,,-1,-1,-1,1,-1,-1,1,-1,2,0.4,medium,#a1d99b,66.5036598,0,82.407502,4.266666667,0,0,0
-1883,140523,52,Shrub/Scrub,,140,Natural park,,-1,-1,-1,1,-1,-1,1,-1,3,0.66,high,#31a354,78.61228868,0,91.6717736,7.04,0,0,0
-1884,140710,71,Herbaceuous,,140,Natural park,,-1,-1,-1,1,-1,-1,1,-1,0,0,none,#ffffff,10.10660117,8,98.79264417,0,0,0,0
-1885,140711,71,Herbaceuous,,140,Natural park,,-1,-1,-1,1,-1,-1,1,-1,1,0.15,low,#e5f5e0,22.75760842,6.8,99.54173609,1.6,0,0,0
-1886,140712,71,Herbaceuous,,140,Natural park,,-1,-1,-1,1,-1,-1,1,-1,2,0.4,medium,#a1d99b,43.84262051,4.8,100.7902226,4.266666667,0,0,0
-1887,140713,71,Herbaceuous,,140,Natural park,,-1,-1,-1,1,-1,-1,1,-1,3,0.66,high,#31a354,65.77103307,2.72,102.0886486,7.04,0,0,0
-1888,140810,81,Hay/Pasture,,140,Natural park,,-1,-1,-1,1,-1,-1,1,-1,0,0,none,#ffffff,10.10660117,8,98.79264417,0,0,0,0
-1889,140811,81,Hay/Pasture,,140,Natural park,,-1,-1,-1,1,-1,-1,1,-1,1,0.15,low,#e5f5e0,22.75760842,6.8,99.54173609,1.6,0,0,0
-1890,140812,81,Hay/Pasture,,140,Natural park,,-1,-1,-1,1,-1,-1,1,-1,2,0.4,medium,#a1d99b,43.84262051,4.8,100.7902226,4.266666667,0,0,0
-1891,140813,81,Hay/Pasture,,140,Natural park,,-1,-1,-1,1,-1,-1,1,-1,3,0.66,high,#31a354,65.77103307,2.72,102.0886486,7.04,0,0,0
-1892,140820,82,Cultivated Crops,,140,Natural park,,-1,-1,-1,-1,-1,-1,1,-1,0,0,none,#ffffff,4.793840162,0,65.75263422,0,0,0,0
-1893,140821,82,Cultivated Crops,,140,Natural park,,-1,-1,-1,-1,-1,-1,1,-1,1,0.15,low,#e5f5e0,18.24176156,0,71.45772764,1.6,0,0,0
-1894,140822,82,Cultivated Crops,,140,Natural park,,-1,-1,-1,-1,-1,-1,1,-1,2,0.4,medium,#a1d99b,40.6549639,0,80.96621666,4.266666667,0,0,0
-1895,140823,82,Cultivated Crops,,140,Natural park,,-1,-1,-1,-1,-1,-1,1,-1,3,0.66,high,#31a354,63.96469433,0,90.85504525,7.04,0,0,0
-1896,140900,90,Woody Wetlands,,140,Natural park,,-1,-1,-1,-1,-1,-1,1,-1,0,0,none,#ffffff,33.5,0,259,0,0,0,0
-1897,140901,90,Woody Wetlands,,140,Natural park,,-1,-1,-1,-1,-1,-1,1,-1,1,0.15,low,#e5f5e0,42.64199743,0,235.7179885,1.6,0,0,0
-1898,140902,90,Woody Wetlands,,140,Natural park,,-1,-1,-1,-1,-1,-1,1,-1,2,0.4,medium,#a1d99b,57.8786598,0,196.9146361,4.266666667,0,0,0
-1899,140903,90,Woody Wetlands,,140,Natural park,,-1,-1,-1,-1,-1,-1,1,-1,3,0.66,high,#31a354,73.72478868,0,156.5591496,7.04,0,0,0
-1900,140950,95,Emergent Herbaceuous Wetlands,,140,Natural park,,-1,-1,-1,-1,-1,-1,1,-1,0,0,none,#ffffff,33.5,0,259,0,0,0,0
-1901,140951,95,Emergent Herbaceuous Wetlands,,140,Natural park,,-1,-1,-1,-1,-1,-1,1,-1,1,0.15,low,#e5f5e0,42.64199743,0,235.7179885,1.6,0,0,0
-1902,140952,95,Emergent Herbaceuous Wetlands,,140,Natural park,,-1,-1,-1,-1,-1,-1,1,-1,2,0.4,medium,#a1d99b,57.8786598,0,196.9146361,4.266666667,0,0,0
-1903,140953,95,Emergent Herbaceuous Wetlands,,140,Natural park,,-1,-1,-1,-1,-1,-1,1,-1,3,0.66,high,#31a354,73.72478868,0,156.5591496,7.04,0,0,0
-1904,151000,0,Background,,151,Conservation,Public,-1,-1,-1,-1,-1,-1,-1,-1,0,0,none,#ffffff,0,0,0,0,0,0,0
-1905,151001,0,Background,,151,Conservation,Public,-1,-1,-1,-1,-1,-1,-1,-1,1,0.15,low,#e5f5e0,14.16699743,0,15.56798855,1.6,0,0,0
-1906,151002,0,Background,,151,Conservation,Public,-1,-1,-1,-1,-1,-1,-1,-1,2,0.4,medium,#a1d99b,37.7786598,0,41.51463613,4.266666667,0,0,0
-1907,151003,0,Background,,151,Conservation,Public,-1,-1,-1,-1,-1,-1,-1,-1,3,0.66,high,#31a354,62.33478868,0,68.49914961,7.04,0,0,0
-1908,151110,11,Open Water,,151,Conservation,Public,-1,-1,-1,-1,-1,-1,1,-1,0,0,none,#ffffff,0,0,0,0,0,0,0
-1909,151111,11,Open Water,,151,Conservation,Public,-1,-1,-1,-1,-1,-1,1,-1,1,0.15,low,#e5f5e0,14.16699743,0,15.56798855,1.6,0,0,0
-1910,151112,11,Open Water,,151,Conservation,Public,-1,-1,-1,-1,-1,-1,1,-1,2,0.4,medium,#a1d99b,37.7786598,0,41.51463613,4.266666667,0,0,0
-1911,151113,11,Open Water,,151,Conservation,Public,-1,-1,-1,-1,-1,-1,1,-1,3,0.66,high,#31a354,62.33478868,0,68.49914961,7.04,0,0,0
-1912,151120,12,Perennial Ice/Snow,,151,Conservation,Public,-1,-1,-1,-1,-1,-1,-1,-1,0,0,none,#ffffff,0,0,0,0,0,0,0
-1913,151121,12,Perennial Ice/Snow,,151,Conservation,Public,-1,-1,-1,-1,-1,-1,-1,-1,1,0.15,low,#e5f5e0,14.16699743,0,15.56798855,1.6,0,0,0
-1914,151122,12,Perennial Ice/Snow,,151,Conservation,Public,-1,-1,-1,-1,-1,-1,-1,-1,2,0.4,medium,#a1d99b,37.7786598,0,41.51463613,4.266666667,0,0,0
-1915,151123,12,Perennial Ice/Snow,,151,Conservation,Public,-1,-1,-1,-1,-1,-1,-1,-1,3,0.66,high,#31a354,62.33478868,0,68.49914961,7.04,0,0,0
-1916,151210,21,"Developed, Open Space","20% trees, 60% grass, and 10% buildings and 10% bare soil",151,Conservation,Public,-1,-1,-1,1,-1,-1,1,-1,0,0,none,#ffffff,25.49986095,4.08,79.01411479,1.76,51.81402439,212.31,37.03522039
-1917,151211,21,"Developed, Open Space","20% trees, 60% grass, and 10% buildings and 10% bare soil",151,Conservation,Public,-1,-1,-1,1,-1,-1,1,-1,1,0.15,low,#e5f5e0,35.84187923,3.468,82.72998612,3.096,51.81402439,212.31,37.03522039
-1918,151212,21,"Developed, Open Space","20% trees, 60% grass, and 10% buildings and 10% bare soil",151,Conservation,Public,-1,-1,-1,1,-1,-1,1,-1,2,0.4,medium,#a1d99b,53.07857637,2.448,88.923105,5.322666667,51.81402439,212.31,37.03522039
-1919,151213,21,"Developed, Open Space","20% trees, 60% grass, and 10% buildings and 10% bare soil",151,Conservation,Public,-1,-1,-1,1,-1,-1,1,-1,3,0.66,high,#31a354,71.0047414,1.3872,95.36394864,7.6384,51.81402439,212.31,37.03522039
-1920,151220,22,"Developed, Low Intensity","20% trees, 40% grass, and 40% buildings",151,Conservation,Public,-1,-1,-1,1,-1,-1,1,-1,0,0,none,#ffffff,20.90844667,3.52,72.06732319,0.61,207.2560976,849.24,147.1338816
-1921,151221,22,"Developed, Low Intensity","20% trees, 40% grass, and 40% buildings",151,Conservation,Public,-1,-1,-1,1,-1,-1,1,-1,1,0.15,low,#e5f5e0,31.9391771,2.992,76.82521326,2.1185,207.2560976,849.24,147.1338816
-1922,151222,22,"Developed, Low Intensity","20% trees, 40% grass, and 40% buildings",151,Conservation,Public,-1,-1,-1,1,-1,-1,1,-1,2,0.4,medium,#a1d99b,50.32372781,2.112,84.75503004,4.632666667,207.2560976,849.24,147.1338816
-1923,151223,22,"Developed, Low Intensity","20% trees, 40% grass, and 40% buildings",151,Conservation,Public,-1,-1,-1,1,-1,-1,1,-1,3,0.66,high,#31a354,69.44366054,1.1968,93.0020395,7.2474,207.2560976,849.24,147.1338816
-1924,151230,23,"Developed, Medium Intensity","15% trees, 35% grass, and 50% buildings",151,Conservation,Public,-1,-1,-1,1,-1,-1,1,-1,0,0,none,#ffffff,17.69813636,3.08,61.93838294,0.36,234.070122,954.85,720.4716833
-1925,151231,23,"Developed, Medium Intensity","15% trees, 35% grass, and 50% buildings",151,Conservation,Public,-1,-1,-1,1,-1,-1,1,-1,1,0.15,low,#e5f5e0,29.21041333,2.618,68.21561405,1.906,234.070122,954.85,720.4716833
-1926,151232,23,"Developed, Medium Intensity","15% trees, 35% grass, and 50% buildings",151,Conservation,Public,-1,-1,-1,1,-1,-1,1,-1,2,0.4,medium,#a1d99b,48.39754162,1.848,78.67766589,4.482666667,234.070122,954.85,720.4716833
-1927,151233,23,"Developed, Medium Intensity","15% trees, 35% grass, and 50% buildings",151,Conservation,Public,-1,-1,-1,1,-1,-1,1,-1,3,0.66,high,#31a354,68.35215504,1.0472,89.55819981,7.1624,234.070122,954.85,720.4716833
-1928,151240,24,"Developed, High Intensity","10% trees, 20% grass, and 70% buildings",151,Conservation,Public,-1,-1,-1,1,-1,-1,1,-1,0,0,none,#ffffff,10.98142029,1.76,44.78642515,0.245,267.9065041,3418.485,1805.616283
-1929,151241,24,"Developed, High Intensity","10% trees, 20% grass, and 70% buildings",151,Conservation,Public,-1,-1,-1,1,-1,-1,1,-1,1,0.15,low,#e5f5e0,23.50120467,1.496,53.63644993,1.80825,267.9065041,3418.485,1805.616283
-1930,151242,24,"Developed, High Intensity","10% trees, 20% grass, and 70% buildings",151,Conservation,Public,-1,-1,-1,1,-1,-1,1,-1,2,0.4,medium,#a1d99b,44.36751198,1.056,68.38649122,4.413666667,267.9065041,3418.485,1805.616283
-1931,151243,24,"Developed, High Intensity","10% trees, 20% grass, and 70% buildings",151,Conservation,Public,-1,-1,-1,1,-1,-1,1,-1,3,0.66,high,#31a354,66.06847158,0.5984,83.72653416,7.1233,267.9065041,3418.485,1805.616283
-1932,151310,31,Barren Land,,151,Conservation,Public,-1,-1,-1,1,-1,-1,1,-1,0,0,none,#ffffff,6.8,0,25.5,0,0,0,0
-1933,151311,31,Barren Land,,151,Conservation,Public,-1,-1,-1,1,-1,-1,1,-1,1,0.15,low,#e5f5e0,19.94699743,0,37.24298855,1.6,0,0,0
-1934,151312,31,Barren Land,,151,Conservation,Public,-1,-1,-1,1,-1,-1,1,-1,2,0.4,medium,#a1d99b,41.8586598,0,56.81463613,4.266666667,0,0,0
-1935,151313,31,Barren Land,,151,Conservation,Public,-1,-1,-1,1,-1,-1,1,-1,3,0.66,high,#31a354,64.64678868,0,77.16914961,7.04,0,0,0
-1936,151410,41,Deciduous Forest,,151,Conservation,Public,-1,-1,-1,-1,-1,-1,1,-1,0,0,none,#ffffff,85.88498714,0,96.08994273,8.8,0,0,0
-1937,151411,41,Deciduous Forest,,151,Conservation,Public,-1,-1,-1,-1,-1,-1,1,-1,1,0.15,low,#e5f5e0,85.88498714,0,96.08994273,8.8,0,0,0
-1938,151412,41,Deciduous Forest,,151,Conservation,Public,-1,-1,-1,-1,-1,-1,1,-1,2,0.4,medium,#a1d99b,85.88498714,0,96.08994273,8.8,0,0,0
-1939,151413,41,Deciduous Forest,,151,Conservation,Public,-1,-1,-1,-1,-1,-1,1,-1,3,0.66,high,#31a354,85.88498714,0,96.08994273,8.8,0,0,0
-1940,151420,42,Evergreen Forest,,151,Conservation,Public,-1,-1,-1,-1,-1,-1,1,-1,0,0,none,#ffffff,105.6849871,0,96.08994273,14.4,0,0,0
-1941,151421,42,Evergreen Forest,,151,Conservation,Public,-1,-1,-1,-1,-1,-1,1,-1,1,0.15,low,#e5f5e0,105.6849871,0,96.08994273,14.4,0,0,0
-1942,151422,42,Evergreen Forest,,151,Conservation,Public,-1,-1,-1,-1,-1,-1,1,-1,2,0.4,medium,#a1d99b,105.6849871,0,96.08994273,14.4,0,0,0
-1943,151423,42,Evergreen Forest,,151,Conservation,Public,-1,-1,-1,-1,-1,-1,1,-1,3,0.66,high,#31a354,105.6849871,0,96.08994273,14.4,0,0,0
-1944,151430,43,Mixed Forest,,151,Conservation,Public,-1,-1,-1,-1,-1,-1,1,-1,0,0,none,#ffffff,91.76997429,0,119.1798855,8.8,0,0,0
-1945,151431,43,Mixed Forest,,151,Conservation,Public,-1,-1,-1,-1,-1,-1,1,-1,1,0.15,low,#e5f5e0,91.76997429,0,119.1798855,8.8,0,0,0
-1946,151432,43,Mixed Forest,,151,Conservation,Public,-1,-1,-1,-1,-1,-1,1,-1,2,0.4,medium,#a1d99b,91.76997429,0,119.1798855,8.8,0,0,0
-1947,151433,43,Mixed Forest,,151,Conservation,Public,-1,-1,-1,-1,-1,-1,1,-1,3,0.66,high,#31a354,91.76997429,0,119.1798855,8.8,0,0,0
-1948,151520,52,Shrub/Scrub,,151,Conservation,Public,-1,-1,-1,1,-1,-1,1,-1,0,0,none,#ffffff,47.875,0,68.15477645,0,0,0,0
-1949,151521,52,Shrub/Scrub,,151,Conservation,Public,-1,-1,-1,1,-1,-1,1,-1,1,0.15,low,#e5f5e0,54.86074743,0,73.49954853,1.6,0,0,0
-1950,151522,52,Shrub/Scrub,,151,Conservation,Public,-1,-1,-1,1,-1,-1,1,-1,2,0.4,medium,#a1d99b,66.5036598,0,82.407502,4.266666667,0,0,0
-1951,151523,52,Shrub/Scrub,,151,Conservation,Public,-1,-1,-1,1,-1,-1,1,-1,3,0.66,high,#31a354,78.61228868,0,91.6717736,7.04,0,0,0
-1952,151710,71,Herbaceuous,,151,Conservation,Public,-1,-1,-1,1,-1,-1,1,-1,0,0,none,#ffffff,10.10660117,8,98.79264417,0,0,0,0
-1953,151711,71,Herbaceuous,,151,Conservation,Public,-1,-1,-1,1,-1,-1,1,-1,1,0.15,low,#e5f5e0,22.75760842,6.8,99.54173609,1.6,0,0,0
-1954,151712,71,Herbaceuous,,151,Conservation,Public,-1,-1,-1,1,-1,-1,1,-1,2,0.4,medium,#a1d99b,43.84262051,4.8,100.7902226,4.266666667,0,0,0
-1955,151713,71,Herbaceuous,,151,Conservation,Public,-1,-1,-1,1,-1,-1,1,-1,3,0.66,high,#31a354,65.77103307,2.72,102.0886486,7.04,0,0,0
-1956,151810,81,Hay/Pasture,,151,Conservation,Public,-1,-1,-1,1,-1,-1,1,-1,0,0,none,#ffffff,10.10660117,8,98.79264417,0,0,0,0
-1957,151811,81,Hay/Pasture,,151,Conservation,Public,-1,-1,-1,1,-1,-1,1,-1,1,0.15,low,#e5f5e0,22.75760842,6.8,99.54173609,1.6,0,0,0
-1958,151812,81,Hay/Pasture,,151,Conservation,Public,-1,-1,-1,1,-1,-1,1,-1,2,0.4,medium,#a1d99b,43.84262051,4.8,100.7902226,4.266666667,0,0,0
-1959,151813,81,Hay/Pasture,,151,Conservation,Public,-1,-1,-1,1,-1,-1,1,-1,3,0.66,high,#31a354,65.77103307,2.72,102.0886486,7.04,0,0,0
-1960,151820,82,Cultivated Crops,,151,Conservation,Public,-1,-1,-1,-1,-1,-1,1,-1,0,0,none,#ffffff,4.793840162,0,65.75263422,0,0,0,0
-1961,151821,82,Cultivated Crops,,151,Conservation,Public,-1,-1,-1,-1,-1,-1,1,-1,1,0.15,low,#e5f5e0,18.24176156,0,71.45772764,1.6,0,0,0
-1962,151822,82,Cultivated Crops,,151,Conservation,Public,-1,-1,-1,-1,-1,-1,1,-1,2,0.4,medium,#a1d99b,40.6549639,0,80.96621666,4.266666667,0,0,0
-1963,151823,82,Cultivated Crops,,151,Conservation,Public,-1,-1,-1,-1,-1,-1,1,-1,3,0.66,high,#31a354,63.96469433,0,90.85504525,7.04,0,0,0
-1964,151900,90,Woody Wetlands,,151,Conservation,Public,-1,-1,-1,-1,-1,-1,1,-1,0,0,none,#ffffff,33.5,0,259,0,0,0,0
-1965,151901,90,Woody Wetlands,,151,Conservation,Public,-1,-1,-1,-1,-1,-1,1,-1,1,0.15,low,#e5f5e0,42.64199743,0,235.7179885,1.6,0,0,0
-1966,151902,90,Woody Wetlands,,151,Conservation,Public,-1,-1,-1,-1,-1,-1,1,-1,2,0.4,medium,#a1d99b,57.8786598,0,196.9146361,4.266666667,0,0,0
-1967,151903,90,Woody Wetlands,,151,Conservation,Public,-1,-1,-1,-1,-1,-1,1,-1,3,0.66,high,#31a354,73.72478868,0,156.5591496,7.04,0,0,0
-1968,151950,95,Emergent Herbaceuous Wetlands,,151,Conservation,Public,-1,-1,-1,-1,-1,-1,1,-1,0,0,none,#ffffff,33.5,0,259,0,0,0,0
-1969,151951,95,Emergent Herbaceuous Wetlands,,151,Conservation,Public,-1,-1,-1,-1,-1,-1,1,-1,1,0.15,low,#e5f5e0,42.64199743,0,235.7179885,1.6,0,0,0
-1970,151952,95,Emergent Herbaceuous Wetlands,,151,Conservation,Public,-1,-1,-1,-1,-1,-1,1,-1,2,0.4,medium,#a1d99b,57.8786598,0,196.9146361,4.266666667,0,0,0
-1971,151953,95,Emergent Herbaceuous Wetlands,,151,Conservation,Public,-1,-1,-1,-1,-1,-1,1,-1,3,0.66,high,#31a354,73.72478868,0,156.5591496,7.04,0,0,0
-1972,152000,0,Background,,152,Conservation,Public-limited access,-1,-1,-1,-1,-1,-1,-1,-1,0,0,none,#ffffff,0,0,0,0,0,0,0
-1973,152001,0,Background,,152,Conservation,Public-limited access,-1,-1,-1,-1,-1,-1,-1,-1,1,0.15,low,#e5f5e0,14.16699743,0,15.56798855,1.6,0,0,0
-1974,152002,0,Background,,152,Conservation,Public-limited access,-1,-1,-1,-1,-1,-1,-1,-1,2,0.4,medium,#a1d99b,37.7786598,0,41.51463613,4.266666667,0,0,0
-1975,152003,0,Background,,152,Conservation,Public-limited access,-1,-1,-1,-1,-1,-1,-1,-1,3,0.66,high,#31a354,62.33478868,0,68.49914961,7.04,0,0,0
-1976,152110,11,Open Water,,152,Conservation,Public-limited access,-1,-1,-1,-1,-1,0.5,1,-1,0,0,none,#ffffff,0,0,0,0,0,0,0
-1977,152111,11,Open Water,,152,Conservation,Public-limited access,-1,-1,-1,-1,-1,0.5,1,-1,1,0.15,low,#e5f5e0,14.16699743,0,15.56798855,1.6,0,0,0
-1978,152112,11,Open Water,,152,Conservation,Public-limited access,-1,-1,-1,-1,-1,0.5,1,-1,2,0.4,medium,#a1d99b,37.7786598,0,41.51463613,4.266666667,0,0,0
-1979,152113,11,Open Water,,152,Conservation,Public-limited access,-1,-1,-1,-1,-1,0.5,1,-1,3,0.66,high,#31a354,62.33478868,0,68.49914961,7.04,0,0,0
-1980,152120,12,Perennial Ice/Snow,,152,Conservation,Public-limited access,-1,-1,-1,-1,-1,-1,-1,-1,0,0,none,#ffffff,0,0,0,0,0,0,0
-1981,152121,12,Perennial Ice/Snow,,152,Conservation,Public-limited access,-1,-1,-1,-1,-1,-1,-1,-1,1,0.15,low,#e5f5e0,14.16699743,0,15.56798855,1.6,0,0,0
-1982,152122,12,Perennial Ice/Snow,,152,Conservation,Public-limited access,-1,-1,-1,-1,-1,-1,-1,-1,2,0.4,medium,#a1d99b,37.7786598,0,41.51463613,4.266666667,0,0,0
-1983,152123,12,Perennial Ice/Snow,,152,Conservation,Public-limited access,-1,-1,-1,-1,-1,-1,-1,-1,3,0.66,high,#31a354,62.33478868,0,68.49914961,7.04,0,0,0
-1984,152210,21,"Developed, Open Space","20% trees, 60% grass, and 10% buildings and 10% bare soil",152,Conservation,Public-limited access,-1,-1,-1,1,-1,0.5,1,-1,0,0,none,#ffffff,25.49986095,4.08,79.01411479,1.76,51.81402439,212.31,37.03522039
-1985,152211,21,"Developed, Open Space","20% trees, 60% grass, and 10% buildings and 10% bare soil",152,Conservation,Public-limited access,-1,-1,-1,1,-1,0.5,1,-1,1,0.15,low,#e5f5e0,35.84187923,3.468,82.72998612,3.096,51.81402439,212.31,37.03522039
-1986,152212,21,"Developed, Open Space","20% trees, 60% grass, and 10% buildings and 10% bare soil",152,Conservation,Public-limited access,-1,-1,-1,1,-1,0.5,1,-1,2,0.4,medium,#a1d99b,53.07857637,2.448,88.923105,5.322666667,51.81402439,212.31,37.03522039
-1987,152213,21,"Developed, Open Space","20% trees, 60% grass, and 10% buildings and 10% bare soil",152,Conservation,Public-limited access,-1,-1,-1,1,-1,0.5,1,-1,3,0.66,high,#31a354,71.0047414,1.3872,95.36394864,7.6384,51.81402439,212.31,37.03522039
-1988,152220,22,"Developed, Low Intensity","20% trees, 40% grass, and 40% buildings",152,Conservation,Public-limited access,-1,-1,-1,1,-1,-1,1,-1,0,0,none,#ffffff,20.90844667,3.52,72.06732319,0.61,207.2560976,849.24,147.1338816
-1989,152221,22,"Developed, Low Intensity","20% trees, 40% grass, and 40% buildings",152,Conservation,Public-limited access,-1,-1,-1,1,-1,-1,1,-1,1,0.15,low,#e5f5e0,31.9391771,2.992,76.82521326,2.1185,207.2560976,849.24,147.1338816
-1990,152222,22,"Developed, Low Intensity","20% trees, 40% grass, and 40% buildings",152,Conservation,Public-limited access,-1,-1,-1,1,-1,-1,1,-1,2,0.4,medium,#a1d99b,50.32372781,2.112,84.75503004,4.632666667,207.2560976,849.24,147.1338816
-1991,152223,22,"Developed, Low Intensity","20% trees, 40% grass, and 40% buildings",152,Conservation,Public-limited access,-1,-1,-1,1,-1,-1,1,-1,3,0.66,high,#31a354,69.44366054,1.1968,93.0020395,7.2474,207.2560976,849.24,147.1338816
-1992,152230,23,"Developed, Medium Intensity","15% trees, 35% grass, and 50% buildings",152,Conservation,Public-limited access,-1,-1,-1,1,-1,-1,1,-1,0,0,none,#ffffff,17.69813636,3.08,61.93838294,0.36,234.070122,954.85,720.4716833
-1993,152231,23,"Developed, Medium Intensity","15% trees, 35% grass, and 50% buildings",152,Conservation,Public-limited access,-1,-1,-1,1,-1,-1,1,-1,1,0.15,low,#e5f5e0,29.21041333,2.618,68.21561405,1.906,234.070122,954.85,720.4716833
-1994,152232,23,"Developed, Medium Intensity","15% trees, 35% grass, and 50% buildings",152,Conservation,Public-limited access,-1,-1,-1,1,-1,-1,1,-1,2,0.4,medium,#a1d99b,48.39754162,1.848,78.67766589,4.482666667,234.070122,954.85,720.4716833
-1995,152233,23,"Developed, Medium Intensity","15% trees, 35% grass, and 50% buildings",152,Conservation,Public-limited access,-1,-1,-1,1,-1,-1,1,-1,3,0.66,high,#31a354,68.35215504,1.0472,89.55819981,7.1624,234.070122,954.85,720.4716833
-1996,152240,24,"Developed, High Intensity","10% trees, 20% grass, and 70% buildings",152,Conservation,Public-limited access,-1,-1,-1,1,-1,-1,1,-1,0,0,none,#ffffff,10.98142029,1.76,44.78642515,0.245,267.9065041,3418.485,1805.616283
-1997,152241,24,"Developed, High Intensity","10% trees, 20% grass, and 70% buildings",152,Conservation,Public-limited access,-1,-1,-1,1,-1,-1,1,-1,1,0.15,low,#e5f5e0,23.50120467,1.496,53.63644993,1.80825,267.9065041,3418.485,1805.616283
-1998,152242,24,"Developed, High Intensity","10% trees, 20% grass, and 70% buildings",152,Conservation,Public-limited access,-1,-1,-1,1,-1,-1,1,-1,2,0.4,medium,#a1d99b,44.36751198,1.056,68.38649122,4.413666667,267.9065041,3418.485,1805.616283
-1999,152243,24,"Developed, High Intensity","10% trees, 20% grass, and 70% buildings",152,Conservation,Public-limited access,-1,-1,-1,1,-1,-1,1,-1,3,0.66,high,#31a354,66.06847158,0.5984,83.72653416,7.1233,267.9065041,3418.485,1805.616283
-2000,152310,31,Barren Land,,152,Conservation,Public-limited access,-1,-1,-1,1,-1,0.5,1,-1,0,0,none,#ffffff,6.8,0,25.5,0,0,0,0
-2001,152311,31,Barren Land,,152,Conservation,Public-limited access,-1,-1,-1,1,-1,0.5,1,-1,1,0.15,low,#e5f5e0,19.94699743,0,37.24298855,1.6,0,0,0
-2002,152312,31,Barren Land,,152,Conservation,Public-limited access,-1,-1,-1,1,-1,0.5,1,-1,2,0.4,medium,#a1d99b,41.8586598,0,56.81463613,4.266666667,0,0,0
-2003,152313,31,Barren Land,,152,Conservation,Public-limited access,-1,-1,-1,1,-1,0.5,1,-1,3,0.66,high,#31a354,64.64678868,0,77.16914961,7.04,0,0,0
-2004,152410,41,Deciduous Forest,,152,Conservation,Public-limited access,-1,-1,-1,-1,-1,0.5,1,-1,0,0,none,#ffffff,85.88498714,0,96.08994273,8.8,0,0,0
-2005,152411,41,Deciduous Forest,,152,Conservation,Public-limited access,-1,-1,-1,-1,-1,0.5,1,-1,1,0.15,low,#e5f5e0,85.88498714,0,96.08994273,8.8,0,0,0
-2006,152412,41,Deciduous Forest,,152,Conservation,Public-limited access,-1,-1,-1,-1,-1,0.5,1,-1,2,0.4,medium,#a1d99b,85.88498714,0,96.08994273,8.8,0,0,0
-2007,152413,41,Deciduous Forest,,152,Conservation,Public-limited access,-1,-1,-1,-1,-1,0.5,1,-1,3,0.66,high,#31a354,85.88498714,0,96.08994273,8.8,0,0,0
-2008,152420,42,Evergreen Forest,,152,Conservation,Public-limited access,-1,-1,-1,-1,-1,0.5,1,-1,0,0,none,#ffffff,105.6849871,0,96.08994273,14.4,0,0,0
-2009,152421,42,Evergreen Forest,,152,Conservation,Public-limited access,-1,-1,-1,-1,-1,0.5,1,-1,1,0.15,low,#e5f5e0,105.6849871,0,96.08994273,14.4,0,0,0
-2010,152422,42,Evergreen Forest,,152,Conservation,Public-limited access,-1,-1,-1,-1,-1,0.5,1,-1,2,0.4,medium,#a1d99b,105.6849871,0,96.08994273,14.4,0,0,0
-2011,152423,42,Evergreen Forest,,152,Conservation,Public-limited access,-1,-1,-1,-1,-1,0.5,1,-1,3,0.66,high,#31a354,105.6849871,0,96.08994273,14.4,0,0,0
-2012,152430,43,Mixed Forest,,152,Conservation,Public-limited access,-1,-1,-1,-1,-1,0.5,1,-1,0,0,none,#ffffff,91.76997429,0,119.1798855,8.8,0,0,0
-2013,152431,43,Mixed Forest,,152,Conservation,Public-limited access,-1,-1,-1,-1,-1,0.5,1,-1,1,0.15,low,#e5f5e0,91.76997429,0,119.1798855,8.8,0,0,0
-2014,152432,43,Mixed Forest,,152,Conservation,Public-limited access,-1,-1,-1,-1,-1,0.5,1,-1,2,0.4,medium,#a1d99b,91.76997429,0,119.1798855,8.8,0,0,0
-2015,152433,43,Mixed Forest,,152,Conservation,Public-limited access,-1,-1,-1,-1,-1,0.5,1,-1,3,0.66,high,#31a354,91.76997429,0,119.1798855,8.8,0,0,0
-2016,152520,52,Shrub/Scrub,,152,Conservation,Public-limited access,-1,-1,-1,1,-1,0.5,1,-1,0,0,none,#ffffff,47.875,0,68.15477645,0,0,0,0
-2017,152521,52,Shrub/Scrub,,152,Conservation,Public-limited access,-1,-1,-1,1,-1,0.5,1,-1,1,0.15,low,#e5f5e0,54.86074743,0,73.49954853,1.6,0,0,0
-2018,152522,52,Shrub/Scrub,,152,Conservation,Public-limited access,-1,-1,-1,1,-1,0.5,1,-1,2,0.4,medium,#a1d99b,66.5036598,0,82.407502,4.266666667,0,0,0
-2019,152523,52,Shrub/Scrub,,152,Conservation,Public-limited access,-1,-1,-1,1,-1,0.5,1,-1,3,0.66,high,#31a354,78.61228868,0,91.6717736,7.04,0,0,0
-2020,152710,71,Herbaceuous,,152,Conservation,Public-limited access,-1,-1,-1,1,-1,0.5,1,-1,0,0,none,#ffffff,10.10660117,8,98.79264417,0,0,0,0
-2021,152711,71,Herbaceuous,,152,Conservation,Public-limited access,-1,-1,-1,1,-1,0.5,1,-1,1,0.15,low,#e5f5e0,22.75760842,6.8,99.54173609,1.6,0,0,0
-2022,152712,71,Herbaceuous,,152,Conservation,Public-limited access,-1,-1,-1,1,-1,0.5,1,-1,2,0.4,medium,#a1d99b,43.84262051,4.8,100.7902226,4.266666667,0,0,0
-2023,152713,71,Herbaceuous,,152,Conservation,Public-limited access,-1,-1,-1,1,-1,0.5,1,-1,3,0.66,high,#31a354,65.77103307,2.72,102.0886486,7.04,0,0,0
-2024,152810,81,Hay/Pasture,,152,Conservation,Public-limited access,-1,-1,-1,1,-1,0.5,1,-1,0,0,none,#ffffff,10.10660117,8,98.79264417,0,0,0,0
-2025,152811,81,Hay/Pasture,,152,Conservation,Public-limited access,-1,-1,-1,1,-1,0.5,1,-1,1,0.15,low,#e5f5e0,22.75760842,6.8,99.54173609,1.6,0,0,0
-2026,152812,81,Hay/Pasture,,152,Conservation,Public-limited access,-1,-1,-1,1,-1,0.5,1,-1,2,0.4,medium,#a1d99b,43.84262051,4.8,100.7902226,4.266666667,0,0,0
-2027,152813,81,Hay/Pasture,,152,Conservation,Public-limited access,-1,-1,-1,1,-1,0.5,1,-1,3,0.66,high,#31a354,65.77103307,2.72,102.0886486,7.04,0,0,0
-2028,152820,82,Cultivated Crops,,152,Conservation,Public-limited access,-1,-1,-1,-1,-1,0.5,1,-1,0,0,none,#ffffff,4.793840162,0,65.75263422,0,0,0,0
-2029,152821,82,Cultivated Crops,,152,Conservation,Public-limited access,-1,-1,-1,-1,-1,0.5,1,-1,1,0.15,low,#e5f5e0,18.24176156,0,71.45772764,1.6,0,0,0
-2030,152822,82,Cultivated Crops,,152,Conservation,Public-limited access,-1,-1,-1,-1,-1,0.5,1,-1,2,0.4,medium,#a1d99b,40.6549639,0,80.96621666,4.266666667,0,0,0
-2031,152823,82,Cultivated Crops,,152,Conservation,Public-limited access,-1,-1,-1,-1,-1,0.5,1,-1,3,0.66,high,#31a354,63.96469433,0,90.85504525,7.04,0,0,0
-2032,152900,90,Woody Wetlands,,152,Conservation,Public-limited access,-1,-1,-1,-1,-1,0.5,1,-1,0,0,none,#ffffff,33.5,0,259,0,0,0,0
-2033,152901,90,Woody Wetlands,,152,Conservation,Public-limited access,-1,-1,-1,-1,-1,0.5,1,-1,1,0.15,low,#e5f5e0,42.64199743,0,235.7179885,1.6,0,0,0
-2034,152902,90,Woody Wetlands,,152,Conservation,Public-limited access,-1,-1,-1,-1,-1,0.5,1,-1,2,0.4,medium,#a1d99b,57.8786598,0,196.9146361,4.266666667,0,0,0
-2035,152903,90,Woody Wetlands,,152,Conservation,Public-limited access,-1,-1,-1,-1,-1,0.5,1,-1,3,0.66,high,#31a354,73.72478868,0,156.5591496,7.04,0,0,0
-2036,152950,95,Emergent Herbaceuous Wetlands,,152,Conservation,Public-limited access,-1,-1,-1,-1,-1,0.5,1,-1,0,0,none,#ffffff,33.5,0,259,0,0,0,0
-2037,152951,95,Emergent Herbaceuous Wetlands,,152,Conservation,Public-limited access,-1,-1,-1,-1,-1,0.5,1,-1,1,0.15,low,#e5f5e0,42.64199743,0,235.7179885,1.6,0,0,0
-2038,152952,95,Emergent Herbaceuous Wetlands,,152,Conservation,Public-limited access,-1,-1,-1,-1,-1,0.5,1,-1,2,0.4,medium,#a1d99b,57.8786598,0,196.9146361,4.266666667,0,0,0
-2039,152953,95,Emergent Herbaceuous Wetlands,,152,Conservation,Public-limited access,-1,-1,-1,-1,-1,0.5,1,-1,3,0.66,high,#31a354,73.72478868,0,156.5591496,7.04,0,0,0
-2040,153000,0,Background,,153,Conservation,Private easement,-1,-1,-1,-1,-1,-1,-1,-1,0,0,none,#ffffff,0,0,0,0,0,0,0
-2041,153001,0,Background,,153,Conservation,Private easement,-1,-1,-1,-1,-1,-1,-1,-1,1,0.15,low,#e5f5e0,14.16699743,0,15.56798855,1.6,0,0,0
-2042,153002,0,Background,,153,Conservation,Private easement,-1,-1,-1,-1,-1,-1,-1,-1,2,0.4,medium,#a1d99b,37.7786598,0,41.51463613,4.266666667,0,0,0
-2043,153003,0,Background,,153,Conservation,Private easement,-1,-1,-1,-1,-1,-1,-1,-1,3,0.66,high,#31a354,62.33478868,0,68.49914961,7.04,0,0,0
-2044,153110,11,Open Water,,153,Conservation,Private easement,-1,-1,-1,-1,-1,0,1,-1,0,0,none,#ffffff,0,0,0,0,0,0,0
-2045,153111,11,Open Water,,153,Conservation,Private easement,-1,-1,-1,-1,-1,0,1,-1,1,0.15,low,#e5f5e0,14.16699743,0,15.56798855,1.6,0,0,0
-2046,153112,11,Open Water,,153,Conservation,Private easement,-1,-1,-1,-1,-1,0,1,-1,2,0.4,medium,#a1d99b,37.7786598,0,41.51463613,4.266666667,0,0,0
-2047,153113,11,Open Water,,153,Conservation,Private easement,-1,-1,-1,-1,-1,0,1,-1,3,0.66,high,#31a354,62.33478868,0,68.49914961,7.04,0,0,0
-2048,153120,12,Perennial Ice/Snow,,153,Conservation,Private easement,-1,-1,-1,-1,-1,-1,-1,-1,0,0,none,#ffffff,0,0,0,0,0,0,0
-2049,153121,12,Perennial Ice/Snow,,153,Conservation,Private easement,-1,-1,-1,-1,-1,-1,-1,-1,1,0.15,low,#e5f5e0,14.16699743,0,15.56798855,1.6,0,0,0
-2050,153122,12,Perennial Ice/Snow,,153,Conservation,Private easement,-1,-1,-1,-1,-1,-1,-1,-1,2,0.4,medium,#a1d99b,37.7786598,0,41.51463613,4.266666667,0,0,0
-2051,153123,12,Perennial Ice/Snow,,153,Conservation,Private easement,-1,-1,-1,-1,-1,-1,-1,-1,3,0.66,high,#31a354,62.33478868,0,68.49914961,7.04,0,0,0
-2052,153210,21,"Developed, Open Space","20% trees, 60% grass, and 10% buildings and 10% bare soil",153,Conservation,Private easement,-1,-1,-1,1,-1,0,1,-1,0,0,none,#ffffff,25.49986095,4.08,79.01411479,1.76,51.81402439,212.31,37.03522039
-2053,153211,21,"Developed, Open Space","20% trees, 60% grass, and 10% buildings and 10% bare soil",153,Conservation,Private easement,-1,-1,-1,1,-1,0,1,-1,1,0.15,low,#e5f5e0,35.84187923,3.468,82.72998612,3.096,51.81402439,212.31,37.03522039
-2054,153212,21,"Developed, Open Space","20% trees, 60% grass, and 10% buildings and 10% bare soil",153,Conservation,Private easement,-1,-1,-1,1,-1,0,1,-1,2,0.4,medium,#a1d99b,53.07857637,2.448,88.923105,5.322666667,51.81402439,212.31,37.03522039
-2055,153213,21,"Developed, Open Space","20% trees, 60% grass, and 10% buildings and 10% bare soil",153,Conservation,Private easement,-1,-1,-1,1,-1,0,1,-1,3,0.66,high,#31a354,71.0047414,1.3872,95.36394864,7.6384,51.81402439,212.31,37.03522039
-2056,153220,22,"Developed, Low Intensity","20% trees, 40% grass, and 40% buildings",153,Conservation,Private easement,-1,-1,-1,1,-1,-1,1,-1,0,0,none,#ffffff,20.90844667,3.52,72.06732319,0.61,207.2560976,849.24,147.1338816
-2057,153221,22,"Developed, Low Intensity","20% trees, 40% grass, and 40% buildings",153,Conservation,Private easement,-1,-1,-1,1,-1,-1,1,-1,1,0.15,low,#e5f5e0,31.9391771,2.992,76.82521326,2.1185,207.2560976,849.24,147.1338816
-2058,153222,22,"Developed, Low Intensity","20% trees, 40% grass, and 40% buildings",153,Conservation,Private easement,-1,-1,-1,1,-1,-1,1,-1,2,0.4,medium,#a1d99b,50.32372781,2.112,84.75503004,4.632666667,207.2560976,849.24,147.1338816
-2059,153223,22,"Developed, Low Intensity","20% trees, 40% grass, and 40% buildings",153,Conservation,Private easement,-1,-1,-1,1,-1,-1,1,-1,3,0.66,high,#31a354,69.44366054,1.1968,93.0020395,7.2474,207.2560976,849.24,147.1338816
-2060,153230,23,"Developed, Medium Intensity","15% trees, 35% grass, and 50% buildings",153,Conservation,Private easement,-1,-1,-1,1,-1,-1,1,-1,0,0,none,#ffffff,17.69813636,3.08,61.93838294,0.36,234.070122,954.85,720.4716833
-2061,153231,23,"Developed, Medium Intensity","15% trees, 35% grass, and 50% buildings",153,Conservation,Private easement,-1,-1,-1,1,-1,-1,1,-1,1,0.15,low,#e5f5e0,29.21041333,2.618,68.21561405,1.906,234.070122,954.85,720.4716833
-2062,153232,23,"Developed, Medium Intensity","15% trees, 35% grass, and 50% buildings",153,Conservation,Private easement,-1,-1,-1,1,-1,-1,1,-1,2,0.4,medium,#a1d99b,48.39754162,1.848,78.67766589,4.482666667,234.070122,954.85,720.4716833
-2063,153233,23,"Developed, Medium Intensity","15% trees, 35% grass, and 50% buildings",153,Conservation,Private easement,-1,-1,-1,1,-1,-1,1,-1,3,0.66,high,#31a354,68.35215504,1.0472,89.55819981,7.1624,234.070122,954.85,720.4716833
-2064,153240,24,"Developed, High Intensity","10% trees, 20% grass, and 70% buildings",153,Conservation,Private easement,-1,-1,-1,1,-1,-1,1,-1,0,0,none,#ffffff,10.98142029,1.76,44.78642515,0.245,267.9065041,3418.485,1805.616283
-2065,153241,24,"Developed, High Intensity","10% trees, 20% grass, and 70% buildings",153,Conservation,Private easement,-1,-1,-1,1,-1,-1,1,-1,1,0.15,low,#e5f5e0,23.50120467,1.496,53.63644993,1.80825,267.9065041,3418.485,1805.616283
-2066,153242,24,"Developed, High Intensity","10% trees, 20% grass, and 70% buildings",153,Conservation,Private easement,-1,-1,-1,1,-1,-1,1,-1,2,0.4,medium,#a1d99b,44.36751198,1.056,68.38649122,4.413666667,267.9065041,3418.485,1805.616283
-2067,153243,24,"Developed, High Intensity","10% trees, 20% grass, and 70% buildings",153,Conservation,Private easement,-1,-1,-1,1,-1,-1,1,-1,3,0.66,high,#31a354,66.06847158,0.5984,83.72653416,7.1233,267.9065041,3418.485,1805.616283
-2068,153310,31,Barren Land,,153,Conservation,Private easement,-1,-1,-1,1,-1,0,1,-1,0,0,none,#ffffff,6.8,0,25.5,0,0,0,0
-2069,153311,31,Barren Land,,153,Conservation,Private easement,-1,-1,-1,1,-1,0,1,-1,1,0.15,low,#e5f5e0,19.94699743,0,37.24298855,1.6,0,0,0
-2070,153312,31,Barren Land,,153,Conservation,Private easement,-1,-1,-1,1,-1,0,1,-1,2,0.4,medium,#a1d99b,41.8586598,0,56.81463613,4.266666667,0,0,0
-2071,153313,31,Barren Land,,153,Conservation,Private easement,-1,-1,-1,1,-1,0,1,-1,3,0.66,high,#31a354,64.64678868,0,77.16914961,7.04,0,0,0
-2072,153410,41,Deciduous Forest,,153,Conservation,Private easement,-1,-1,-1,-1,-1,0,1,-1,0,0,none,#ffffff,85.88498714,0,96.08994273,8.8,0,0,0
-2073,153411,41,Deciduous Forest,,153,Conservation,Private easement,-1,-1,-1,-1,-1,0,1,-1,1,0.15,low,#e5f5e0,85.88498714,0,96.08994273,8.8,0,0,0
-2074,153412,41,Deciduous Forest,,153,Conservation,Private easement,-1,-1,-1,-1,-1,0,1,-1,2,0.4,medium,#a1d99b,85.88498714,0,96.08994273,8.8,0,0,0
-2075,153413,41,Deciduous Forest,,153,Conservation,Private easement,-1,-1,-1,-1,-1,0,1,-1,3,0.66,high,#31a354,85.88498714,0,96.08994273,8.8,0,0,0
-2076,153420,42,Evergreen Forest,,153,Conservation,Private easement,-1,-1,-1,-1,-1,0,1,-1,0,0,none,#ffffff,105.6849871,0,96.08994273,14.4,0,0,0
-2077,153421,42,Evergreen Forest,,153,Conservation,Private easement,-1,-1,-1,-1,-1,0,1,-1,1,0.15,low,#e5f5e0,105.6849871,0,96.08994273,14.4,0,0,0
-2078,153422,42,Evergreen Forest,,153,Conservation,Private easement,-1,-1,-1,-1,-1,0,1,-1,2,0.4,medium,#a1d99b,105.6849871,0,96.08994273,14.4,0,0,0
-2079,153423,42,Evergreen Forest,,153,Conservation,Private easement,-1,-1,-1,-1,-1,0,1,-1,3,0.66,high,#31a354,105.6849871,0,96.08994273,14.4,0,0,0
-2080,153430,43,Mixed Forest,,153,Conservation,Private easement,-1,-1,-1,-1,-1,0,1,-1,0,0,none,#ffffff,91.76997429,0,119.1798855,8.8,0,0,0
-2081,153431,43,Mixed Forest,,153,Conservation,Private easement,-1,-1,-1,-1,-1,0,1,-1,1,0.15,low,#e5f5e0,91.76997429,0,119.1798855,8.8,0,0,0
-2082,153432,43,Mixed Forest,,153,Conservation,Private easement,-1,-1,-1,-1,-1,0,1,-1,2,0.4,medium,#a1d99b,91.76997429,0,119.1798855,8.8,0,0,0
-2083,153433,43,Mixed Forest,,153,Conservation,Private easement,-1,-1,-1,-1,-1,0,1,-1,3,0.66,high,#31a354,91.76997429,0,119.1798855,8.8,0,0,0
-2084,153520,52,Shrub/Scrub,,153,Conservation,Private easement,-1,-1,-1,1,-1,0,1,-1,0,0,none,#ffffff,47.875,0,68.15477645,0,0,0,0
-2085,153521,52,Shrub/Scrub,,153,Conservation,Private easement,-1,-1,-1,1,-1,0,1,-1,1,0.15,low,#e5f5e0,54.86074743,0,73.49954853,1.6,0,0,0
-2086,153522,52,Shrub/Scrub,,153,Conservation,Private easement,-1,-1,-1,1,-1,0,1,-1,2,0.4,medium,#a1d99b,66.5036598,0,82.407502,4.266666667,0,0,0
-2087,153523,52,Shrub/Scrub,,153,Conservation,Private easement,-1,-1,-1,1,-1,0,1,-1,3,0.66,high,#31a354,78.61228868,0,91.6717736,7.04,0,0,0
-2088,153710,71,Herbaceuous,,153,Conservation,Private easement,-1,-1,-1,1,-1,0,1,-1,0,0,none,#ffffff,10.10660117,8,98.79264417,0,0,0,0
-2089,153711,71,Herbaceuous,,153,Conservation,Private easement,-1,-1,-1,1,-1,0,1,-1,1,0.15,low,#e5f5e0,22.75760842,6.8,99.54173609,1.6,0,0,0
-2090,153712,71,Herbaceuous,,153,Conservation,Private easement,-1,-1,-1,1,-1,0,1,-1,2,0.4,medium,#a1d99b,43.84262051,4.8,100.7902226,4.266666667,0,0,0
-2091,153713,71,Herbaceuous,,153,Conservation,Private easement,-1,-1,-1,1,-1,0,1,-1,3,0.66,high,#31a354,65.77103307,2.72,102.0886486,7.04,0,0,0
-2092,153810,81,Hay/Pasture,,153,Conservation,Private easement,-1,-1,-1,1,-1,0,1,-1,0,0,none,#ffffff,10.10660117,8,98.79264417,0,0,0,0
-2093,153811,81,Hay/Pasture,,153,Conservation,Private easement,-1,-1,-1,1,-1,0,1,-1,1,0.15,low,#e5f5e0,22.75760842,6.8,99.54173609,1.6,0,0,0
-2094,153812,81,Hay/Pasture,,153,Conservation,Private easement,-1,-1,-1,1,-1,0,1,-1,2,0.4,medium,#a1d99b,43.84262051,4.8,100.7902226,4.266666667,0,0,0
-2095,153813,81,Hay/Pasture,,153,Conservation,Private easement,-1,-1,-1,1,-1,0,1,-1,3,0.66,high,#31a354,65.77103307,2.72,102.0886486,7.04,0,0,0
-2096,153820,82,Cultivated Crops,,153,Conservation,Private easement,-1,-1,-1,-1,-1,0,1,-1,0,0,none,#ffffff,4.793840162,0,65.75263422,0,0,0,0
-2097,153821,82,Cultivated Crops,,153,Conservation,Private easement,-1,-1,-1,-1,-1,0,1,-1,1,0.15,low,#e5f5e0,18.24176156,0,71.45772764,1.6,0,0,0
-2098,153822,82,Cultivated Crops,,153,Conservation,Private easement,-1,-1,-1,-1,-1,0,1,-1,2,0.4,medium,#a1d99b,40.6549639,0,80.96621666,4.266666667,0,0,0
-2099,153823,82,Cultivated Crops,,153,Conservation,Private easement,-1,-1,-1,-1,-1,0,1,-1,3,0.66,high,#31a354,63.96469433,0,90.85504525,7.04,0,0,0
-2100,153900,90,Woody Wetlands,,153,Conservation,Private easement,-1,-1,-1,-1,-1,0,1,-1,0,0,none,#ffffff,33.5,0,259,0,0,0,0
-2101,153901,90,Woody Wetlands,,153,Conservation,Private easement,-1,-1,-1,-1,-1,0,1,-1,1,0.15,low,#e5f5e0,42.64199743,0,235.7179885,1.6,0,0,0
-2102,153902,90,Woody Wetlands,,153,Conservation,Private easement,-1,-1,-1,-1,-1,0,1,-1,2,0.4,medium,#a1d99b,57.8786598,0,196.9146361,4.266666667,0,0,0
-2103,153903,90,Woody Wetlands,,153,Conservation,Private easement,-1,-1,-1,-1,-1,0,1,-1,3,0.66,high,#31a354,73.72478868,0,156.5591496,7.04,0,0,0
-2104,153950,95,Emergent Herbaceuous Wetlands,,153,Conservation,Private easement,-1,-1,-1,-1,-1,0,1,-1,0,0,none,#ffffff,33.5,0,259,0,0,0,0
-2105,153951,95,Emergent Herbaceuous Wetlands,,153,Conservation,Private easement,-1,-1,-1,-1,-1,0,1,-1,1,0.15,low,#e5f5e0,42.64199743,0,235.7179885,1.6,0,0,0
-2106,153952,95,Emergent Herbaceuous Wetlands,,153,Conservation,Private easement,-1,-1,-1,-1,-1,0,1,-1,2,0.4,medium,#a1d99b,57.8786598,0,196.9146361,4.266666667,0,0,0
-2107,153953,95,Emergent Herbaceuous Wetlands,,153,Conservation,Private easement,-1,-1,-1,-1,-1,0,1,-1,3,0.66,high,#31a354,73.72478868,0,156.5591496,7.04,0,0,0
+﻿lucode,code,nlcd,LULC_name,notes,nlud_simple,nlud_simple_class,nlud_simple_subclass,fertilizer,pesticide,irrigation,planting_diversity,mowing,public_access,green_space,building_type,tree,tree_canopy_percentage,tree_canopy_cover,tree_canopy_colors,c_above,c_below,c_soil,c_dead,c_embedded_storage,c_embedded_emissions,c_annual_emissions
+0,1110,11,Open Water,,1,Waterbody,Natural,-1,-1,-1,-1,-1,-1,-1,-1,0,0,none,#ffffff,0,0,0,0,0,0,0
+1,1111,11,Open Water,,1,Waterbody,Natural,-1,-1,-1,-1,-1,-1,-1,-1,1,0.15,low,#e5f5e0,14.16699743,0,15.56798855,1.6,0,0,0
+2,1112,11,Open Water,,1,Waterbody,Natural,-1,-1,-1,-1,-1,-1,-1,-1,2,0.4,medium,#a1d99b,37.7786598,0,41.51463613,4.266666667,0,0,0
+3,1113,11,Open Water,,1,Waterbody,Natural,-1,-1,-1,-1,-1,-1,-1,-1,3,0.66,high,#31a354,62.33478868,0,68.49914961,7.04,0,0,0
+4,1120,12,Perennial Ice/Snow,,1,Waterbody,Natural,-1,-1,-1,-1,-1,-1,-1,-1,0,0,none,#ffffff,0,0,0,0,0,0,0
+5,1121,12,Perennial Ice/Snow,,1,Waterbody,Natural,-1,-1,-1,-1,-1,-1,-1,-1,1,0.15,low,#e5f5e0,14.16699743,0,15.56798855,1.6,0,0,0
+6,1122,12,Perennial Ice/Snow,,1,Waterbody,Natural,-1,-1,-1,-1,-1,-1,-1,-1,2,0.4,medium,#a1d99b,37.7786598,0,41.51463613,4.266666667,0,0,0
+7,1123,12,Perennial Ice/Snow,,1,Waterbody,Natural,-1,-1,-1,-1,-1,-1,-1,-1,3,0.66,high,#31a354,62.33478868,0,68.49914961,7.04,0,0,0
+8,1210,21,"Developed, Open Space","20% trees, 60% grass, and 10% buildings and 10% bare soil",1,Waterbody,Natural,-1,-1,-1,-1,-1,-1,-1,-1,0,0,none,#ffffff,25.49986095,4.08,79.01411479,1.76,51.81402439,212.31,37.03522039
+9,1211,21,"Developed, Open Space","20% trees, 60% grass, and 10% buildings and 10% bare soil",1,Waterbody,Natural,-1,-1,-1,-1,-1,-1,-1,-1,1,0.15,low,#e5f5e0,35.84187923,3.468,82.72998612,3.096,51.81402439,212.31,37.03522039
+10,1212,21,"Developed, Open Space","20% trees, 60% grass, and 10% buildings and 10% bare soil",1,Waterbody,Natural,-1,-1,-1,-1,-1,-1,-1,-1,2,0.4,medium,#a1d99b,53.07857637,2.448,88.923105,5.322666667,51.81402439,212.31,37.03522039
+11,1213,21,"Developed, Open Space","20% trees, 60% grass, and 10% buildings and 10% bare soil",1,Waterbody,Natural,-1,-1,-1,-1,-1,-1,-1,-1,3,0.66,high,#31a354,71.0047414,1.3872,95.36394864,7.6384,51.81402439,212.31,37.03522039
+12,1220,22,"Developed, Low Intensity","20% trees, 40% grass, and 40% buildings",1,Waterbody,Natural,-1,-1,-1,-1,-1,-1,-1,-1,0,0,none,#ffffff,20.90844667,3.52,72.06732319,0.61,207.2560976,849.24,147.1338816
+13,1221,22,"Developed, Low Intensity","20% trees, 40% grass, and 40% buildings",1,Waterbody,Natural,-1,-1,-1,-1,-1,-1,-1,-1,1,0.15,low,#e5f5e0,31.9391771,2.992,76.82521326,2.1185,207.2560976,849.24,147.1338816
+14,1222,22,"Developed, Low Intensity","20% trees, 40% grass, and 40% buildings",1,Waterbody,Natural,-1,-1,-1,-1,-1,-1,-1,-1,2,0.4,medium,#a1d99b,50.32372781,2.112,84.75503004,4.632666667,207.2560976,849.24,147.1338816
+15,1223,22,"Developed, Low Intensity","20% trees, 40% grass, and 40% buildings",1,Waterbody,Natural,-1,-1,-1,-1,-1,-1,-1,-1,3,0.66,high,#31a354,69.44366054,1.1968,93.0020395,7.2474,207.2560976,849.24,147.1338816
+16,1230,23,"Developed, Medium Intensity","15% trees, 35% grass, and 50% buildings",1,Waterbody,Natural,-1,-1,-1,-1,-1,-1,-1,-1,0,0,none,#ffffff,17.69813636,3.08,61.93838294,0.36,234.070122,954.85,720.4716833
+17,1231,23,"Developed, Medium Intensity","15% trees, 35% grass, and 50% buildings",1,Waterbody,Natural,-1,-1,-1,-1,-1,-1,-1,-1,1,0.15,low,#e5f5e0,29.21041333,2.618,68.21561405,1.906,234.070122,954.85,720.4716833
+18,1232,23,"Developed, Medium Intensity","15% trees, 35% grass, and 50% buildings",1,Waterbody,Natural,-1,-1,-1,-1,-1,-1,-1,-1,2,0.4,medium,#a1d99b,48.39754162,1.848,78.67766589,4.482666667,234.070122,954.85,720.4716833
+19,1233,23,"Developed, Medium Intensity","15% trees, 35% grass, and 50% buildings",1,Waterbody,Natural,-1,-1,-1,-1,-1,-1,-1,-1,3,0.66,high,#31a354,68.35215504,1.0472,89.55819981,7.1624,234.070122,954.85,720.4716833
+20,1240,24,"Developed, High Intensity","10% trees, 20% grass, and 70% buildings",1,Waterbody,Natural,-1,-1,-1,-1,-1,-1,-1,-1,0,0,none,#ffffff,10.98142029,1.76,44.78642515,0.245,267.9065041,3418.485,1805.616283
+21,1241,24,"Developed, High Intensity","10% trees, 20% grass, and 70% buildings",1,Waterbody,Natural,-1,-1,-1,-1,-1,-1,-1,-1,1,0.15,low,#e5f5e0,23.50120467,1.496,53.63644993,1.80825,267.9065041,3418.485,1805.616283
+22,1242,24,"Developed, High Intensity","10% trees, 20% grass, and 70% buildings",1,Waterbody,Natural,-1,-1,-1,-1,-1,-1,-1,-1,2,0.4,medium,#a1d99b,44.36751198,1.056,68.38649122,4.413666667,267.9065041,3418.485,1805.616283
+23,1243,24,"Developed, High Intensity","10% trees, 20% grass, and 70% buildings",1,Waterbody,Natural,-1,-1,-1,-1,-1,-1,-1,-1,3,0.66,high,#31a354,66.06847158,0.5984,83.72653416,7.1233,267.9065041,3418.485,1805.616283
+24,1310,31,Barren Land,,1,Waterbody,Natural,-1,-1,-1,-1,-1,-1,-1,-1,0,0,none,#ffffff,6.8,0,25.5,0,0,0,0
+25,1311,31,Barren Land,,1,Waterbody,Natural,-1,-1,-1,-1,-1,-1,-1,-1,1,0.15,low,#e5f5e0,19.94699743,0,37.24298855,1.6,0,0,0
+26,1312,31,Barren Land,,1,Waterbody,Natural,-1,-1,-1,-1,-1,-1,-1,-1,2,0.4,medium,#a1d99b,41.8586598,0,56.81463613,4.266666667,0,0,0
+27,1313,31,Barren Land,,1,Waterbody,Natural,-1,-1,-1,-1,-1,-1,-1,-1,3,0.66,high,#31a354,64.64678868,0,77.16914961,7.04,0,0,0
+28,1410,41,Deciduous Forest,,1,Waterbody,Natural,-1,-1,-1,-1,-1,-1,-1,-1,0,0,none,#ffffff,85.88498714,0,96.08994273,8.8,0,0,0
+29,1411,41,Deciduous Forest,,1,Waterbody,Natural,-1,-1,-1,-1,-1,-1,-1,-1,1,0.15,low,#e5f5e0,85.88498714,0,96.08994273,8.8,0,0,0
+30,1412,41,Deciduous Forest,,1,Waterbody,Natural,-1,-1,-1,-1,-1,-1,-1,-1,2,0.4,medium,#a1d99b,85.88498714,0,96.08994273,8.8,0,0,0
+31,1413,41,Deciduous Forest,,1,Waterbody,Natural,-1,-1,-1,-1,-1,-1,-1,-1,3,0.66,high,#31a354,85.88498714,0,96.08994273,8.8,0,0,0
+32,1420,42,Evergreen Forest,,1,Waterbody,Natural,-1,-1,-1,-1,-1,-1,-1,-1,0,0,none,#ffffff,105.6849871,0,96.08994273,14.4,0,0,0
+33,1421,42,Evergreen Forest,,1,Waterbody,Natural,-1,-1,-1,-1,-1,-1,-1,-1,1,0.15,low,#e5f5e0,105.6849871,0,96.08994273,14.4,0,0,0
+34,1422,42,Evergreen Forest,,1,Waterbody,Natural,-1,-1,-1,-1,-1,-1,-1,-1,2,0.4,medium,#a1d99b,105.6849871,0,96.08994273,14.4,0,0,0
+35,1423,42,Evergreen Forest,,1,Waterbody,Natural,-1,-1,-1,-1,-1,-1,-1,-1,3,0.66,high,#31a354,105.6849871,0,96.08994273,14.4,0,0,0
+36,1430,43,Mixed Forest,,1,Waterbody,Natural,-1,-1,-1,-1,-1,-1,-1,-1,0,0,none,#ffffff,91.76997429,0,119.1798855,8.8,0,0,0
+37,1431,43,Mixed Forest,,1,Waterbody,Natural,-1,-1,-1,-1,-1,-1,-1,-1,1,0.15,low,#e5f5e0,91.76997429,0,119.1798855,8.8,0,0,0
+38,1432,43,Mixed Forest,,1,Waterbody,Natural,-1,-1,-1,-1,-1,-1,-1,-1,2,0.4,medium,#a1d99b,91.76997429,0,119.1798855,8.8,0,0,0
+39,1433,43,Mixed Forest,,1,Waterbody,Natural,-1,-1,-1,-1,-1,-1,-1,-1,3,0.66,high,#31a354,91.76997429,0,119.1798855,8.8,0,0,0
+40,1520,52,Shrub/Scrub,,1,Waterbody,Natural,-1,-1,-1,-1,-1,-1,-1,-1,0,0,none,#ffffff,47.875,0,68.15477645,0,0,0,0
+41,1521,52,Shrub/Scrub,,1,Waterbody,Natural,-1,-1,-1,-1,-1,-1,-1,-1,1,0.15,low,#e5f5e0,54.86074743,0,73.49954853,1.6,0,0,0
+42,1522,52,Shrub/Scrub,,1,Waterbody,Natural,-1,-1,-1,-1,-1,-1,-1,-1,2,0.4,medium,#a1d99b,66.5036598,0,82.407502,4.266666667,0,0,0
+43,1523,52,Shrub/Scrub,,1,Waterbody,Natural,-1,-1,-1,-1,-1,-1,-1,-1,3,0.66,high,#31a354,78.61228868,0,91.6717736,7.04,0,0,0
+44,1710,71,Herbaceuous,,1,Waterbody,Natural,-1,-1,-1,-1,-1,-1,-1,-1,0,0,none,#ffffff,10.10660117,8,98.79264417,0,0,0,0
+45,1711,71,Herbaceuous,,1,Waterbody,Natural,-1,-1,-1,-1,-1,-1,-1,-1,1,0.15,low,#e5f5e0,22.75760842,6.8,99.54173609,1.6,0,0,0
+46,1712,71,Herbaceuous,,1,Waterbody,Natural,-1,-1,-1,-1,-1,-1,-1,-1,2,0.4,medium,#a1d99b,43.84262051,4.8,100.7902226,4.266666667,0,0,0
+47,1713,71,Herbaceuous,,1,Waterbody,Natural,-1,-1,-1,-1,-1,-1,-1,-1,3,0.66,high,#31a354,65.77103307,2.72,102.0886486,7.04,0,0,0
+48,1810,81,Hay/Pasture,,1,Waterbody,Natural,-1,-1,-1,-1,-1,-1,-1,-1,0,0,none,#ffffff,10.10660117,8,98.79264417,0,0,0,0
+49,1811,81,Hay/Pasture,,1,Waterbody,Natural,-1,-1,-1,-1,-1,-1,-1,-1,1,0.15,low,#e5f5e0,22.75760842,6.8,99.54173609,1.6,0,0,0
+50,1812,81,Hay/Pasture,,1,Waterbody,Natural,-1,-1,-1,-1,-1,-1,-1,-1,2,0.4,medium,#a1d99b,43.84262051,4.8,100.7902226,4.266666667,0,0,0
+51,1813,81,Hay/Pasture,,1,Waterbody,Natural,-1,-1,-1,-1,-1,-1,-1,-1,3,0.66,high,#31a354,65.77103307,2.72,102.0886486,7.04,0,0,0
+52,1820,82,Cultivated Crops,,1,Waterbody,Natural,-1,-1,-1,-1,-1,-1,-1,-1,0,0,none,#ffffff,4.793840162,0,65.75263422,0,0,0,0
+53,1821,82,Cultivated Crops,,1,Waterbody,Natural,-1,-1,-1,-1,-1,-1,-1,-1,1,0.15,low,#e5f5e0,18.24176156,0,71.45772764,1.6,0,0,0
+54,1822,82,Cultivated Crops,,1,Waterbody,Natural,-1,-1,-1,-1,-1,-1,-1,-1,2,0.4,medium,#a1d99b,40.6549639,0,80.96621666,4.266666667,0,0,0
+55,1823,82,Cultivated Crops,,1,Waterbody,Natural,-1,-1,-1,-1,-1,-1,-1,-1,3,0.66,high,#31a354,63.96469433,0,90.85504525,7.04,0,0,0
+56,1900,90,Woody Wetlands,,1,Waterbody,Natural,-1,-1,-1,-1,-1,-1,-1,-1,0,0,none,#ffffff,33.5,0,259,0,0,0,0
+57,1901,90,Woody Wetlands,,1,Waterbody,Natural,-1,-1,-1,-1,-1,-1,-1,-1,1,0.15,low,#e5f5e0,42.64199743,0,235.7179885,1.6,0,0,0
+58,1902,90,Woody Wetlands,,1,Waterbody,Natural,-1,-1,-1,-1,-1,-1,-1,-1,2,0.4,medium,#a1d99b,57.8786598,0,196.9146361,4.266666667,0,0,0
+59,1903,90,Woody Wetlands,,1,Waterbody,Natural,-1,-1,-1,-1,-1,-1,-1,-1,3,0.66,high,#31a354,73.72478868,0,156.5591496,7.04,0,0,0
+60,1950,95,Emergent Herbaceuous Wetlands,,1,Waterbody,Natural,-1,-1,-1,-1,-1,-1,-1,-1,0,0,none,#ffffff,33.5,0,259,0,0,0,0
+61,1951,95,Emergent Herbaceuous Wetlands,,1,Waterbody,Natural,-1,-1,-1,-1,-1,-1,-1,-1,1,0.15,low,#e5f5e0,42.64199743,0,235.7179885,1.6,0,0,0
+62,1952,95,Emergent Herbaceuous Wetlands,,1,Waterbody,Natural,-1,-1,-1,-1,-1,-1,-1,-1,2,0.4,medium,#a1d99b,57.8786598,0,196.9146361,4.266666667,0,0,0
+63,1953,95,Emergent Herbaceuous Wetlands,,1,Waterbody,Natural,-1,-1,-1,-1,-1,-1,-1,-1,3,0.66,high,#31a354,73.72478868,0,156.5591496,7.04,0,0,0
+64,2110,11,Open Water,,2,Waterbody,Wetland,-1,-1,-1,-1,-1,-1,-1,-1,0,0,none,#ffffff,0,0,0,0,0,0,0
+65,2111,11,Open Water,,2,Waterbody,Wetland,-1,-1,-1,-1,-1,-1,-1,-1,1,0.15,low,#e5f5e0,14.16699743,0,15.56798855,1.6,0,0,0
+66,2112,11,Open Water,,2,Waterbody,Wetland,-1,-1,-1,-1,-1,-1,-1,-1,2,0.4,medium,#a1d99b,37.7786598,0,41.51463613,4.266666667,0,0,0
+67,2113,11,Open Water,,2,Waterbody,Wetland,-1,-1,-1,-1,-1,-1,-1,-1,3,0.66,high,#31a354,62.33478868,0,68.49914961,7.04,0,0,0
+68,2120,12,Perennial Ice/Snow,,2,Waterbody,Wetland,-1,-1,-1,-1,-1,-1,-1,-1,0,0,none,#ffffff,0,0,0,0,0,0,0
+69,2121,12,Perennial Ice/Snow,,2,Waterbody,Wetland,-1,-1,-1,-1,-1,-1,-1,-1,1,0.15,low,#e5f5e0,14.16699743,0,15.56798855,1.6,0,0,0
+70,2122,12,Perennial Ice/Snow,,2,Waterbody,Wetland,-1,-1,-1,-1,-1,-1,-1,-1,2,0.4,medium,#a1d99b,37.7786598,0,41.51463613,4.266666667,0,0,0
+71,2123,12,Perennial Ice/Snow,,2,Waterbody,Wetland,-1,-1,-1,-1,-1,-1,-1,-1,3,0.66,high,#31a354,62.33478868,0,68.49914961,7.04,0,0,0
+72,2210,21,"Developed, Open Space","20% trees, 60% grass, and 10% buildings and 10% bare soil",2,Waterbody,Wetland,-1,-1,-1,-1,-1,-1,-1,-1,0,0,none,#ffffff,25.49986095,4.08,79.01411479,1.76,51.81402439,212.31,37.03522039
+73,2211,21,"Developed, Open Space","20% trees, 60% grass, and 10% buildings and 10% bare soil",2,Waterbody,Wetland,-1,-1,-1,-1,-1,-1,-1,-1,1,0.15,low,#e5f5e0,35.84187923,3.468,82.72998612,3.096,51.81402439,212.31,37.03522039
+74,2212,21,"Developed, Open Space","20% trees, 60% grass, and 10% buildings and 10% bare soil",2,Waterbody,Wetland,-1,-1,-1,-1,-1,-1,-1,-1,2,0.4,medium,#a1d99b,53.07857637,2.448,88.923105,5.322666667,51.81402439,212.31,37.03522039
+75,2213,21,"Developed, Open Space","20% trees, 60% grass, and 10% buildings and 10% bare soil",2,Waterbody,Wetland,-1,-1,-1,-1,-1,-1,-1,-1,3,0.66,high,#31a354,71.0047414,1.3872,95.36394864,7.6384,51.81402439,212.31,37.03522039
+76,2220,22,"Developed, Low Intensity","20% trees, 40% grass, and 40% buildings",2,Waterbody,Wetland,-1,-1,-1,-1,-1,-1,-1,-1,0,0,none,#ffffff,20.90844667,3.52,72.06732319,0.61,207.2560976,849.24,147.1338816
+77,2221,22,"Developed, Low Intensity","20% trees, 40% grass, and 40% buildings",2,Waterbody,Wetland,-1,-1,-1,-1,-1,-1,-1,-1,1,0.15,low,#e5f5e0,31.9391771,2.992,76.82521326,2.1185,207.2560976,849.24,147.1338816
+78,2222,22,"Developed, Low Intensity","20% trees, 40% grass, and 40% buildings",2,Waterbody,Wetland,-1,-1,-1,-1,-1,-1,-1,-1,2,0.4,medium,#a1d99b,50.32372781,2.112,84.75503004,4.632666667,207.2560976,849.24,147.1338816
+79,2223,22,"Developed, Low Intensity","20% trees, 40% grass, and 40% buildings",2,Waterbody,Wetland,-1,-1,-1,-1,-1,-1,-1,-1,3,0.66,high,#31a354,69.44366054,1.1968,93.0020395,7.2474,207.2560976,849.24,147.1338816
+80,2230,23,"Developed, Medium Intensity","15% trees, 35% grass, and 50% buildings",2,Waterbody,Wetland,-1,-1,-1,-1,-1,-1,-1,-1,0,0,none,#ffffff,17.69813636,3.08,61.93838294,0.36,234.070122,954.85,720.4716833
+81,2231,23,"Developed, Medium Intensity","15% trees, 35% grass, and 50% buildings",2,Waterbody,Wetland,-1,-1,-1,-1,-1,-1,-1,-1,1,0.15,low,#e5f5e0,29.21041333,2.618,68.21561405,1.906,234.070122,954.85,720.4716833
+82,2232,23,"Developed, Medium Intensity","15% trees, 35% grass, and 50% buildings",2,Waterbody,Wetland,-1,-1,-1,-1,-1,-1,-1,-1,2,0.4,medium,#a1d99b,48.39754162,1.848,78.67766589,4.482666667,234.070122,954.85,720.4716833
+83,2233,23,"Developed, Medium Intensity","15% trees, 35% grass, and 50% buildings",2,Waterbody,Wetland,-1,-1,-1,-1,-1,-1,-1,-1,3,0.66,high,#31a354,68.35215504,1.0472,89.55819981,7.1624,234.070122,954.85,720.4716833
+84,2240,24,"Developed, High Intensity","10% trees, 20% grass, and 70% buildings",2,Waterbody,Wetland,-1,-1,-1,-1,-1,-1,-1,-1,0,0,none,#ffffff,10.98142029,1.76,44.78642515,0.245,267.9065041,3418.485,1805.616283
+85,2241,24,"Developed, High Intensity","10% trees, 20% grass, and 70% buildings",2,Waterbody,Wetland,-1,-1,-1,-1,-1,-1,-1,-1,1,0.15,low,#e5f5e0,23.50120467,1.496,53.63644993,1.80825,267.9065041,3418.485,1805.616283
+86,2242,24,"Developed, High Intensity","10% trees, 20% grass, and 70% buildings",2,Waterbody,Wetland,-1,-1,-1,-1,-1,-1,-1,-1,2,0.4,medium,#a1d99b,44.36751198,1.056,68.38649122,4.413666667,267.9065041,3418.485,1805.616283
+87,2243,24,"Developed, High Intensity","10% trees, 20% grass, and 70% buildings",2,Waterbody,Wetland,-1,-1,-1,-1,-1,-1,-1,-1,3,0.66,high,#31a354,66.06847158,0.5984,83.72653416,7.1233,267.9065041,3418.485,1805.616283
+88,2310,31,Barren Land,,2,Waterbody,Wetland,-1,-1,-1,-1,-1,-1,-1,-1,0,0,none,#ffffff,6.8,0,25.5,0,0,0,0
+89,2311,31,Barren Land,,2,Waterbody,Wetland,-1,-1,-1,-1,-1,-1,-1,-1,1,0.15,low,#e5f5e0,19.94699743,0,37.24298855,1.6,0,0,0
+90,2312,31,Barren Land,,2,Waterbody,Wetland,-1,-1,-1,-1,-1,-1,-1,-1,2,0.4,medium,#a1d99b,41.8586598,0,56.81463613,4.266666667,0,0,0
+91,2313,31,Barren Land,,2,Waterbody,Wetland,-1,-1,-1,-1,-1,-1,-1,-1,3,0.66,high,#31a354,64.64678868,0,77.16914961,7.04,0,0,0
+92,2410,41,Deciduous Forest,,2,Waterbody,Wetland,-1,-1,-1,-1,-1,-1,-1,-1,0,0,none,#ffffff,85.88498714,0,96.08994273,8.8,0,0,0
+93,2411,41,Deciduous Forest,,2,Waterbody,Wetland,-1,-1,-1,-1,-1,-1,-1,-1,1,0.15,low,#e5f5e0,85.88498714,0,96.08994273,8.8,0,0,0
+94,2412,41,Deciduous Forest,,2,Waterbody,Wetland,-1,-1,-1,-1,-1,-1,-1,-1,2,0.4,medium,#a1d99b,85.88498714,0,96.08994273,8.8,0,0,0
+95,2413,41,Deciduous Forest,,2,Waterbody,Wetland,-1,-1,-1,-1,-1,-1,-1,-1,3,0.66,high,#31a354,85.88498714,0,96.08994273,8.8,0,0,0
+96,2420,42,Evergreen Forest,,2,Waterbody,Wetland,-1,-1,-1,-1,-1,-1,-1,-1,0,0,none,#ffffff,105.6849871,0,96.08994273,14.4,0,0,0
+97,2421,42,Evergreen Forest,,2,Waterbody,Wetland,-1,-1,-1,-1,-1,-1,-1,-1,1,0.15,low,#e5f5e0,105.6849871,0,96.08994273,14.4,0,0,0
+98,2422,42,Evergreen Forest,,2,Waterbody,Wetland,-1,-1,-1,-1,-1,-1,-1,-1,2,0.4,medium,#a1d99b,105.6849871,0,96.08994273,14.4,0,0,0
+99,2423,42,Evergreen Forest,,2,Waterbody,Wetland,-1,-1,-1,-1,-1,-1,-1,-1,3,0.66,high,#31a354,105.6849871,0,96.08994273,14.4,0,0,0
+100,2430,43,Mixed Forest,,2,Waterbody,Wetland,-1,-1,-1,-1,-1,-1,-1,-1,0,0,none,#ffffff,91.76997429,0,119.1798855,8.8,0,0,0
+101,2431,43,Mixed Forest,,2,Waterbody,Wetland,-1,-1,-1,-1,-1,-1,-1,-1,1,0.15,low,#e5f5e0,91.76997429,0,119.1798855,8.8,0,0,0
+102,2432,43,Mixed Forest,,2,Waterbody,Wetland,-1,-1,-1,-1,-1,-1,-1,-1,2,0.4,medium,#a1d99b,91.76997429,0,119.1798855,8.8,0,0,0
+103,2433,43,Mixed Forest,,2,Waterbody,Wetland,-1,-1,-1,-1,-1,-1,-1,-1,3,0.66,high,#31a354,91.76997429,0,119.1798855,8.8,0,0,0
+104,2520,52,Shrub/Scrub,,2,Waterbody,Wetland,-1,-1,-1,-1,-1,-1,-1,-1,0,0,none,#ffffff,47.875,0,68.15477645,0,0,0,0
+105,2521,52,Shrub/Scrub,,2,Waterbody,Wetland,-1,-1,-1,-1,-1,-1,-1,-1,1,0.15,low,#e5f5e0,54.86074743,0,73.49954853,1.6,0,0,0
+106,2522,52,Shrub/Scrub,,2,Waterbody,Wetland,-1,-1,-1,-1,-1,-1,-1,-1,2,0.4,medium,#a1d99b,66.5036598,0,82.407502,4.266666667,0,0,0
+107,2523,52,Shrub/Scrub,,2,Waterbody,Wetland,-1,-1,-1,-1,-1,-1,-1,-1,3,0.66,high,#31a354,78.61228868,0,91.6717736,7.04,0,0,0
+108,2710,71,Herbaceuous,,2,Waterbody,Wetland,-1,-1,-1,-1,-1,-1,-1,-1,0,0,none,#ffffff,10.10660117,8,98.79264417,0,0,0,0
+109,2711,71,Herbaceuous,,2,Waterbody,Wetland,-1,-1,-1,-1,-1,-1,-1,-1,1,0.15,low,#e5f5e0,22.75760842,6.8,99.54173609,1.6,0,0,0
+110,2712,71,Herbaceuous,,2,Waterbody,Wetland,-1,-1,-1,-1,-1,-1,-1,-1,2,0.4,medium,#a1d99b,43.84262051,4.8,100.7902226,4.266666667,0,0,0
+111,2713,71,Herbaceuous,,2,Waterbody,Wetland,-1,-1,-1,-1,-1,-1,-1,-1,3,0.66,high,#31a354,65.77103307,2.72,102.0886486,7.04,0,0,0
+112,2810,81,Hay/Pasture,,2,Waterbody,Wetland,-1,-1,-1,-1,-1,-1,-1,-1,0,0,none,#ffffff,10.10660117,8,98.79264417,0,0,0,0
+113,2811,81,Hay/Pasture,,2,Waterbody,Wetland,-1,-1,-1,-1,-1,-1,-1,-1,1,0.15,low,#e5f5e0,22.75760842,6.8,99.54173609,1.6,0,0,0
+114,2812,81,Hay/Pasture,,2,Waterbody,Wetland,-1,-1,-1,-1,-1,-1,-1,-1,2,0.4,medium,#a1d99b,43.84262051,4.8,100.7902226,4.266666667,0,0,0
+115,2813,81,Hay/Pasture,,2,Waterbody,Wetland,-1,-1,-1,-1,-1,-1,-1,-1,3,0.66,high,#31a354,65.77103307,2.72,102.0886486,7.04,0,0,0
+116,2820,82,Cultivated Crops,,2,Waterbody,Wetland,-1,-1,-1,-1,-1,-1,-1,-1,0,0,none,#ffffff,4.793840162,0,65.75263422,0,0,0,0
+117,2821,82,Cultivated Crops,,2,Waterbody,Wetland,-1,-1,-1,-1,-1,-1,-1,-1,1,0.15,low,#e5f5e0,18.24176156,0,71.45772764,1.6,0,0,0
+118,2822,82,Cultivated Crops,,2,Waterbody,Wetland,-1,-1,-1,-1,-1,-1,-1,-1,2,0.4,medium,#a1d99b,40.6549639,0,80.96621666,4.266666667,0,0,0
+119,2823,82,Cultivated Crops,,2,Waterbody,Wetland,-1,-1,-1,-1,-1,-1,-1,-1,3,0.66,high,#31a354,63.96469433,0,90.85504525,7.04,0,0,0
+120,2900,90,Woody Wetlands,,2,Waterbody,Wetland,-1,-1,-1,-1,-1,-1,-1,-1,0,0,none,#ffffff,33.5,0,259,0,0,0,0
+121,2901,90,Woody Wetlands,,2,Waterbody,Wetland,-1,-1,-1,-1,-1,-1,-1,-1,1,0.15,low,#e5f5e0,42.64199743,0,235.7179885,1.6,0,0,0
+122,2902,90,Woody Wetlands,,2,Waterbody,Wetland,-1,-1,-1,-1,-1,-1,-1,-1,2,0.4,medium,#a1d99b,57.8786598,0,196.9146361,4.266666667,0,0,0
+123,2903,90,Woody Wetlands,,2,Waterbody,Wetland,-1,-1,-1,-1,-1,-1,-1,-1,3,0.66,high,#31a354,73.72478868,0,156.5591496,7.04,0,0,0
+124,2950,95,Emergent Herbaceuous Wetlands,,2,Waterbody,Wetland,-1,-1,-1,-1,-1,-1,-1,-1,0,0,none,#ffffff,33.5,0,259,0,0,0,0
+125,2951,95,Emergent Herbaceuous Wetlands,,2,Waterbody,Wetland,-1,-1,-1,-1,-1,-1,-1,-1,1,0.15,low,#e5f5e0,42.64199743,0,235.7179885,1.6,0,0,0
+126,2952,95,Emergent Herbaceuous Wetlands,,2,Waterbody,Wetland,-1,-1,-1,-1,-1,-1,-1,-1,2,0.4,medium,#a1d99b,57.8786598,0,196.9146361,4.266666667,0,0,0
+127,2953,95,Emergent Herbaceuous Wetlands,,2,Waterbody,Wetland,-1,-1,-1,-1,-1,-1,-1,-1,3,0.66,high,#31a354,73.72478868,0,156.5591496,7.04,0,0,0
+128,3110,11,Open Water,,3,Waterbody,Artificial,-1,-1,-1,-1,-1,-1,-1,-1,0,0,none,#ffffff,0,0,0,0,0,0,0
+129,3111,11,Open Water,,3,Waterbody,Artificial,-1,-1,-1,-1,-1,-1,-1,-1,1,0.15,low,#e5f5e0,14.16699743,0,15.56798855,1.6,0,0,0
+130,3112,11,Open Water,,3,Waterbody,Artificial,-1,-1,-1,-1,-1,-1,-1,-1,2,0.4,medium,#a1d99b,37.7786598,0,41.51463613,4.266666667,0,0,0
+131,3113,11,Open Water,,3,Waterbody,Artificial,-1,-1,-1,-1,-1,-1,-1,-1,3,0.66,high,#31a354,62.33478868,0,68.49914961,7.04,0,0,0
+132,3120,12,Perennial Ice/Snow,,3,Waterbody,Artificial,-1,-1,-1,-1,-1,-1,-1,-1,0,0,none,#ffffff,0,0,0,0,0,0,0
+133,3121,12,Perennial Ice/Snow,,3,Waterbody,Artificial,-1,-1,-1,-1,-1,-1,-1,-1,1,0.15,low,#e5f5e0,14.16699743,0,15.56798855,1.6,0,0,0
+134,3122,12,Perennial Ice/Snow,,3,Waterbody,Artificial,-1,-1,-1,-1,-1,-1,-1,-1,2,0.4,medium,#a1d99b,37.7786598,0,41.51463613,4.266666667,0,0,0
+135,3123,12,Perennial Ice/Snow,,3,Waterbody,Artificial,-1,-1,-1,-1,-1,-1,-1,-1,3,0.66,high,#31a354,62.33478868,0,68.49914961,7.04,0,0,0
+136,3210,21,"Developed, Open Space","20% trees, 60% grass, and 10% buildings and 10% bare soil",3,Waterbody,Artificial,-1,-1,-1,-1,-1,-1,-1,-1,0,0,none,#ffffff,25.49986095,4.08,79.01411479,1.76,51.81402439,212.31,37.03522039
+137,3211,21,"Developed, Open Space","20% trees, 60% grass, and 10% buildings and 10% bare soil",3,Waterbody,Artificial,-1,-1,-1,-1,-1,-1,-1,-1,1,0.15,low,#e5f5e0,35.84187923,3.468,82.72998612,3.096,51.81402439,212.31,37.03522039
+138,3212,21,"Developed, Open Space","20% trees, 60% grass, and 10% buildings and 10% bare soil",3,Waterbody,Artificial,-1,-1,-1,-1,-1,-1,-1,-1,2,0.4,medium,#a1d99b,53.07857637,2.448,88.923105,5.322666667,51.81402439,212.31,37.03522039
+139,3213,21,"Developed, Open Space","20% trees, 60% grass, and 10% buildings and 10% bare soil",3,Waterbody,Artificial,-1,-1,-1,-1,-1,-1,-1,-1,3,0.66,high,#31a354,71.0047414,1.3872,95.36394864,7.6384,51.81402439,212.31,37.03522039
+140,3220,22,"Developed, Low Intensity","20% trees, 40% grass, and 40% buildings",3,Waterbody,Artificial,-1,-1,-1,-1,-1,-1,-1,-1,0,0,none,#ffffff,20.90844667,3.52,72.06732319,0.61,207.2560976,849.24,147.1338816
+141,3221,22,"Developed, Low Intensity","20% trees, 40% grass, and 40% buildings",3,Waterbody,Artificial,-1,-1,-1,-1,-1,-1,-1,-1,1,0.15,low,#e5f5e0,31.9391771,2.992,76.82521326,2.1185,207.2560976,849.24,147.1338816
+142,3222,22,"Developed, Low Intensity","20% trees, 40% grass, and 40% buildings",3,Waterbody,Artificial,-1,-1,-1,-1,-1,-1,-1,-1,2,0.4,medium,#a1d99b,50.32372781,2.112,84.75503004,4.632666667,207.2560976,849.24,147.1338816
+143,3223,22,"Developed, Low Intensity","20% trees, 40% grass, and 40% buildings",3,Waterbody,Artificial,-1,-1,-1,-1,-1,-1,-1,-1,3,0.66,high,#31a354,69.44366054,1.1968,93.0020395,7.2474,207.2560976,849.24,147.1338816
+144,3230,23,"Developed, Medium Intensity","15% trees, 35% grass, and 50% buildings",3,Waterbody,Artificial,-1,-1,-1,-1,-1,-1,-1,-1,0,0,none,#ffffff,17.69813636,3.08,61.93838294,0.36,234.070122,954.85,720.4716833
+145,3231,23,"Developed, Medium Intensity","15% trees, 35% grass, and 50% buildings",3,Waterbody,Artificial,-1,-1,-1,-1,-1,-1,-1,-1,1,0.15,low,#e5f5e0,29.21041333,2.618,68.21561405,1.906,234.070122,954.85,720.4716833
+146,3232,23,"Developed, Medium Intensity","15% trees, 35% grass, and 50% buildings",3,Waterbody,Artificial,-1,-1,-1,-1,-1,-1,-1,-1,2,0.4,medium,#a1d99b,48.39754162,1.848,78.67766589,4.482666667,234.070122,954.85,720.4716833
+147,3233,23,"Developed, Medium Intensity","15% trees, 35% grass, and 50% buildings",3,Waterbody,Artificial,-1,-1,-1,-1,-1,-1,-1,-1,3,0.66,high,#31a354,68.35215504,1.0472,89.55819981,7.1624,234.070122,954.85,720.4716833
+148,3240,24,"Developed, High Intensity","10% trees, 20% grass, and 70% buildings",3,Waterbody,Artificial,-1,-1,-1,-1,-1,-1,-1,-1,0,0,none,#ffffff,10.98142029,1.76,44.78642515,0.245,267.9065041,3418.485,1805.616283
+149,3241,24,"Developed, High Intensity","10% trees, 20% grass, and 70% buildings",3,Waterbody,Artificial,-1,-1,-1,-1,-1,-1,-1,-1,1,0.15,low,#e5f5e0,23.50120467,1.496,53.63644993,1.80825,267.9065041,3418.485,1805.616283
+150,3242,24,"Developed, High Intensity","10% trees, 20% grass, and 70% buildings",3,Waterbody,Artificial,-1,-1,-1,-1,-1,-1,-1,-1,2,0.4,medium,#a1d99b,44.36751198,1.056,68.38649122,4.413666667,267.9065041,3418.485,1805.616283
+151,3243,24,"Developed, High Intensity","10% trees, 20% grass, and 70% buildings",3,Waterbody,Artificial,-1,-1,-1,-1,-1,-1,-1,-1,3,0.66,high,#31a354,66.06847158,0.5984,83.72653416,7.1233,267.9065041,3418.485,1805.616283
+152,3310,31,Barren Land,,3,Waterbody,Artificial,-1,-1,-1,-1,-1,-1,-1,-1,0,0,none,#ffffff,6.8,0,25.5,0,0,0,0
+153,3311,31,Barren Land,,3,Waterbody,Artificial,-1,-1,-1,-1,-1,-1,-1,-1,1,0.15,low,#e5f5e0,19.94699743,0,37.24298855,1.6,0,0,0
+154,3312,31,Barren Land,,3,Waterbody,Artificial,-1,-1,-1,-1,-1,-1,-1,-1,2,0.4,medium,#a1d99b,41.8586598,0,56.81463613,4.266666667,0,0,0
+155,3313,31,Barren Land,,3,Waterbody,Artificial,-1,-1,-1,-1,-1,-1,-1,-1,3,0.66,high,#31a354,64.64678868,0,77.16914961,7.04,0,0,0
+156,3410,41,Deciduous Forest,,3,Waterbody,Artificial,-1,-1,-1,-1,-1,-1,-1,-1,0,0,none,#ffffff,85.88498714,0,96.08994273,8.8,0,0,0
+157,3411,41,Deciduous Forest,,3,Waterbody,Artificial,-1,-1,-1,-1,-1,-1,-1,-1,1,0.15,low,#e5f5e0,85.88498714,0,96.08994273,8.8,0,0,0
+158,3412,41,Deciduous Forest,,3,Waterbody,Artificial,-1,-1,-1,-1,-1,-1,-1,-1,2,0.4,medium,#a1d99b,85.88498714,0,96.08994273,8.8,0,0,0
+159,3413,41,Deciduous Forest,,3,Waterbody,Artificial,-1,-1,-1,-1,-1,-1,-1,-1,3,0.66,high,#31a354,85.88498714,0,96.08994273,8.8,0,0,0
+160,3420,42,Evergreen Forest,,3,Waterbody,Artificial,-1,-1,-1,-1,-1,-1,-1,-1,0,0,none,#ffffff,105.6849871,0,96.08994273,14.4,0,0,0
+161,3421,42,Evergreen Forest,,3,Waterbody,Artificial,-1,-1,-1,-1,-1,-1,-1,-1,1,0.15,low,#e5f5e0,105.6849871,0,96.08994273,14.4,0,0,0
+162,3422,42,Evergreen Forest,,3,Waterbody,Artificial,-1,-1,-1,-1,-1,-1,-1,-1,2,0.4,medium,#a1d99b,105.6849871,0,96.08994273,14.4,0,0,0
+163,3423,42,Evergreen Forest,,3,Waterbody,Artificial,-1,-1,-1,-1,-1,-1,-1,-1,3,0.66,high,#31a354,105.6849871,0,96.08994273,14.4,0,0,0
+164,3430,43,Mixed Forest,,3,Waterbody,Artificial,-1,-1,-1,-1,-1,-1,-1,-1,0,0,none,#ffffff,91.76997429,0,119.1798855,8.8,0,0,0
+165,3431,43,Mixed Forest,,3,Waterbody,Artificial,-1,-1,-1,-1,-1,-1,-1,-1,1,0.15,low,#e5f5e0,91.76997429,0,119.1798855,8.8,0,0,0
+166,3432,43,Mixed Forest,,3,Waterbody,Artificial,-1,-1,-1,-1,-1,-1,-1,-1,2,0.4,medium,#a1d99b,91.76997429,0,119.1798855,8.8,0,0,0
+167,3433,43,Mixed Forest,,3,Waterbody,Artificial,-1,-1,-1,-1,-1,-1,-1,-1,3,0.66,high,#31a354,91.76997429,0,119.1798855,8.8,0,0,0
+168,3520,52,Shrub/Scrub,,3,Waterbody,Artificial,-1,-1,-1,-1,-1,-1,-1,-1,0,0,none,#ffffff,47.875,0,68.15477645,0,0,0,0
+169,3521,52,Shrub/Scrub,,3,Waterbody,Artificial,-1,-1,-1,-1,-1,-1,-1,-1,1,0.15,low,#e5f5e0,54.86074743,0,73.49954853,1.6,0,0,0
+170,3522,52,Shrub/Scrub,,3,Waterbody,Artificial,-1,-1,-1,-1,-1,-1,-1,-1,2,0.4,medium,#a1d99b,66.5036598,0,82.407502,4.266666667,0,0,0
+171,3523,52,Shrub/Scrub,,3,Waterbody,Artificial,-1,-1,-1,-1,-1,-1,-1,-1,3,0.66,high,#31a354,78.61228868,0,91.6717736,7.04,0,0,0
+172,3710,71,Herbaceuous,,3,Waterbody,Artificial,-1,-1,-1,-1,-1,-1,-1,-1,0,0,none,#ffffff,10.10660117,8,98.79264417,0,0,0,0
+173,3711,71,Herbaceuous,,3,Waterbody,Artificial,-1,-1,-1,-1,-1,-1,-1,-1,1,0.15,low,#e5f5e0,22.75760842,6.8,99.54173609,1.6,0,0,0
+174,3712,71,Herbaceuous,,3,Waterbody,Artificial,-1,-1,-1,-1,-1,-1,-1,-1,2,0.4,medium,#a1d99b,43.84262051,4.8,100.7902226,4.266666667,0,0,0
+175,3713,71,Herbaceuous,,3,Waterbody,Artificial,-1,-1,-1,-1,-1,-1,-1,-1,3,0.66,high,#31a354,65.77103307,2.72,102.0886486,7.04,0,0,0
+176,3810,81,Hay/Pasture,,3,Waterbody,Artificial,-1,-1,-1,-1,-1,-1,-1,-1,0,0,none,#ffffff,10.10660117,8,98.79264417,0,0,0,0
+177,3811,81,Hay/Pasture,,3,Waterbody,Artificial,-1,-1,-1,-1,-1,-1,-1,-1,1,0.15,low,#e5f5e0,22.75760842,6.8,99.54173609,1.6,0,0,0
+178,3812,81,Hay/Pasture,,3,Waterbody,Artificial,-1,-1,-1,-1,-1,-1,-1,-1,2,0.4,medium,#a1d99b,43.84262051,4.8,100.7902226,4.266666667,0,0,0
+179,3813,81,Hay/Pasture,,3,Waterbody,Artificial,-1,-1,-1,-1,-1,-1,-1,-1,3,0.66,high,#31a354,65.77103307,2.72,102.0886486,7.04,0,0,0
+180,3820,82,Cultivated Crops,,3,Waterbody,Artificial,-1,-1,-1,-1,-1,-1,-1,-1,0,0,none,#ffffff,4.793840162,0,65.75263422,0,0,0,0
+181,3821,82,Cultivated Crops,,3,Waterbody,Artificial,-1,-1,-1,-1,-1,-1,-1,-1,1,0.15,low,#e5f5e0,18.24176156,0,71.45772764,1.6,0,0,0
+182,3822,82,Cultivated Crops,,3,Waterbody,Artificial,-1,-1,-1,-1,-1,-1,-1,-1,2,0.4,medium,#a1d99b,40.6549639,0,80.96621666,4.266666667,0,0,0
+183,3823,82,Cultivated Crops,,3,Waterbody,Artificial,-1,-1,-1,-1,-1,-1,-1,-1,3,0.66,high,#31a354,63.96469433,0,90.85504525,7.04,0,0,0
+184,3900,90,Woody Wetlands,,3,Waterbody,Artificial,-1,-1,-1,-1,-1,-1,-1,-1,0,0,none,#ffffff,33.5,0,259,0,0,0,0
+185,3901,90,Woody Wetlands,,3,Waterbody,Artificial,-1,-1,-1,-1,-1,-1,-1,-1,1,0.15,low,#e5f5e0,42.64199743,0,235.7179885,1.6,0,0,0
+186,3902,90,Woody Wetlands,,3,Waterbody,Artificial,-1,-1,-1,-1,-1,-1,-1,-1,2,0.4,medium,#a1d99b,57.8786598,0,196.9146361,4.266666667,0,0,0
+187,3903,90,Woody Wetlands,,3,Waterbody,Artificial,-1,-1,-1,-1,-1,-1,-1,-1,3,0.66,high,#31a354,73.72478868,0,156.5591496,7.04,0,0,0
+188,3950,95,Emergent Herbaceuous Wetlands,,3,Waterbody,Artificial,-1,-1,-1,-1,-1,-1,-1,-1,0,0,none,#ffffff,33.5,0,259,0,0,0,0
+189,3951,95,Emergent Herbaceuous Wetlands,,3,Waterbody,Artificial,-1,-1,-1,-1,-1,-1,-1,-1,1,0.15,low,#e5f5e0,42.64199743,0,235.7179885,1.6,0,0,0
+190,3952,95,Emergent Herbaceuous Wetlands,,3,Waterbody,Artificial,-1,-1,-1,-1,-1,-1,-1,-1,2,0.4,medium,#a1d99b,57.8786598,0,196.9146361,4.266666667,0,0,0
+191,3953,95,Emergent Herbaceuous Wetlands,,3,Waterbody,Artificial,-1,-1,-1,-1,-1,-1,-1,-1,3,0.66,high,#31a354,73.72478868,0,156.5591496,7.04,0,0,0
+192,4110,11,Open Water,,4,Waterbody,Perennial Ice/Snow,-1,-1,-1,-1,-1,-1,-1,-1,0,0,none,#ffffff,0,0,0,0,0,0,0
+193,4111,11,Open Water,,4,Waterbody,Perennial Ice/Snow,-1,-1,-1,-1,-1,-1,-1,-1,1,0.15,low,#e5f5e0,14.16699743,0,15.56798855,1.6,0,0,0
+194,4112,11,Open Water,,4,Waterbody,Perennial Ice/Snow,-1,-1,-1,-1,-1,-1,-1,-1,2,0.4,medium,#a1d99b,37.7786598,0,41.51463613,4.266666667,0,0,0
+195,4113,11,Open Water,,4,Waterbody,Perennial Ice/Snow,-1,-1,-1,-1,-1,-1,-1,-1,3,0.66,high,#31a354,62.33478868,0,68.49914961,7.04,0,0,0
+196,4120,12,Perennial Ice/Snow,,4,Waterbody,Perennial Ice/Snow,-1,-1,-1,-1,-1,-1,-1,-1,0,0,none,#ffffff,0,0,0,0,0,0,0
+197,4121,12,Perennial Ice/Snow,,4,Waterbody,Perennial Ice/Snow,-1,-1,-1,-1,-1,-1,-1,-1,1,0.15,low,#e5f5e0,14.16699743,0,15.56798855,1.6,0,0,0
+198,4122,12,Perennial Ice/Snow,,4,Waterbody,Perennial Ice/Snow,-1,-1,-1,-1,-1,-1,-1,-1,2,0.4,medium,#a1d99b,37.7786598,0,41.51463613,4.266666667,0,0,0
+199,4123,12,Perennial Ice/Snow,,4,Waterbody,Perennial Ice/Snow,-1,-1,-1,-1,-1,-1,-1,-1,3,0.66,high,#31a354,62.33478868,0,68.49914961,7.04,0,0,0
+200,4210,21,"Developed, Open Space","20% trees, 60% grass, and 10% buildings and 10% bare soil",4,Waterbody,Perennial Ice/Snow,-1,-1,-1,-1,-1,-1,-1,-1,0,0,none,#ffffff,25.49986095,4.08,79.01411479,1.76,51.81402439,212.31,37.03522039
+201,4211,21,"Developed, Open Space","20% trees, 60% grass, and 10% buildings and 10% bare soil",4,Waterbody,Perennial Ice/Snow,-1,-1,-1,-1,-1,-1,-1,-1,1,0.15,low,#e5f5e0,35.84187923,3.468,82.72998612,3.096,51.81402439,212.31,37.03522039
+202,4212,21,"Developed, Open Space","20% trees, 60% grass, and 10% buildings and 10% bare soil",4,Waterbody,Perennial Ice/Snow,-1,-1,-1,-1,-1,-1,-1,-1,2,0.4,medium,#a1d99b,53.07857637,2.448,88.923105,5.322666667,51.81402439,212.31,37.03522039
+203,4213,21,"Developed, Open Space","20% trees, 60% grass, and 10% buildings and 10% bare soil",4,Waterbody,Perennial Ice/Snow,-1,-1,-1,-1,-1,-1,-1,-1,3,0.66,high,#31a354,71.0047414,1.3872,95.36394864,7.6384,51.81402439,212.31,37.03522039
+204,4220,22,"Developed, Low Intensity","20% trees, 40% grass, and 40% buildings",4,Waterbody,Perennial Ice/Snow,-1,-1,-1,-1,-1,-1,-1,-1,0,0,none,#ffffff,20.90844667,3.52,72.06732319,0.61,207.2560976,849.24,147.1338816
+205,4221,22,"Developed, Low Intensity","20% trees, 40% grass, and 40% buildings",4,Waterbody,Perennial Ice/Snow,-1,-1,-1,-1,-1,-1,-1,-1,1,0.15,low,#e5f5e0,31.9391771,2.992,76.82521326,2.1185,207.2560976,849.24,147.1338816
+206,4222,22,"Developed, Low Intensity","20% trees, 40% grass, and 40% buildings",4,Waterbody,Perennial Ice/Snow,-1,-1,-1,-1,-1,-1,-1,-1,2,0.4,medium,#a1d99b,50.32372781,2.112,84.75503004,4.632666667,207.2560976,849.24,147.1338816
+207,4223,22,"Developed, Low Intensity","20% trees, 40% grass, and 40% buildings",4,Waterbody,Perennial Ice/Snow,-1,-1,-1,-1,-1,-1,-1,-1,3,0.66,high,#31a354,69.44366054,1.1968,93.0020395,7.2474,207.2560976,849.24,147.1338816
+208,4230,23,"Developed, Medium Intensity","15% trees, 35% grass, and 50% buildings",4,Waterbody,Perennial Ice/Snow,-1,-1,-1,-1,-1,-1,-1,-1,0,0,none,#ffffff,17.69813636,3.08,61.93838294,0.36,234.070122,954.85,720.4716833
+209,4231,23,"Developed, Medium Intensity","15% trees, 35% grass, and 50% buildings",4,Waterbody,Perennial Ice/Snow,-1,-1,-1,-1,-1,-1,-1,-1,1,0.15,low,#e5f5e0,29.21041333,2.618,68.21561405,1.906,234.070122,954.85,720.4716833
+210,4232,23,"Developed, Medium Intensity","15% trees, 35% grass, and 50% buildings",4,Waterbody,Perennial Ice/Snow,-1,-1,-1,-1,-1,-1,-1,-1,2,0.4,medium,#a1d99b,48.39754162,1.848,78.67766589,4.482666667,234.070122,954.85,720.4716833
+211,4233,23,"Developed, Medium Intensity","15% trees, 35% grass, and 50% buildings",4,Waterbody,Perennial Ice/Snow,-1,-1,-1,-1,-1,-1,-1,-1,3,0.66,high,#31a354,68.35215504,1.0472,89.55819981,7.1624,234.070122,954.85,720.4716833
+212,4240,24,"Developed, High Intensity","10% trees, 20% grass, and 70% buildings",4,Waterbody,Perennial Ice/Snow,-1,-1,-1,-1,-1,-1,-1,-1,0,0,none,#ffffff,10.98142029,1.76,44.78642515,0.245,267.9065041,3418.485,1805.616283
+213,4241,24,"Developed, High Intensity","10% trees, 20% grass, and 70% buildings",4,Waterbody,Perennial Ice/Snow,-1,-1,-1,-1,-1,-1,-1,-1,1,0.15,low,#e5f5e0,23.50120467,1.496,53.63644993,1.80825,267.9065041,3418.485,1805.616283
+214,4242,24,"Developed, High Intensity","10% trees, 20% grass, and 70% buildings",4,Waterbody,Perennial Ice/Snow,-1,-1,-1,-1,-1,-1,-1,-1,2,0.4,medium,#a1d99b,44.36751198,1.056,68.38649122,4.413666667,267.9065041,3418.485,1805.616283
+215,4243,24,"Developed, High Intensity","10% trees, 20% grass, and 70% buildings",4,Waterbody,Perennial Ice/Snow,-1,-1,-1,-1,-1,-1,-1,-1,3,0.66,high,#31a354,66.06847158,0.5984,83.72653416,7.1233,267.9065041,3418.485,1805.616283
+216,4310,31,Barren Land,,4,Waterbody,Perennial Ice/Snow,-1,-1,-1,-1,-1,-1,-1,-1,0,0,none,#ffffff,6.8,0,25.5,0,0,0,0
+217,4311,31,Barren Land,,4,Waterbody,Perennial Ice/Snow,-1,-1,-1,-1,-1,-1,-1,-1,1,0.15,low,#e5f5e0,19.94699743,0,37.24298855,1.6,0,0,0
+218,4312,31,Barren Land,,4,Waterbody,Perennial Ice/Snow,-1,-1,-1,-1,-1,-1,-1,-1,2,0.4,medium,#a1d99b,41.8586598,0,56.81463613,4.266666667,0,0,0
+219,4313,31,Barren Land,,4,Waterbody,Perennial Ice/Snow,-1,-1,-1,-1,-1,-1,-1,-1,3,0.66,high,#31a354,64.64678868,0,77.16914961,7.04,0,0,0
+220,4410,41,Deciduous Forest,,4,Waterbody,Perennial Ice/Snow,-1,-1,-1,-1,-1,-1,-1,-1,0,0,none,#ffffff,85.88498714,0,96.08994273,8.8,0,0,0
+221,4411,41,Deciduous Forest,,4,Waterbody,Perennial Ice/Snow,-1,-1,-1,-1,-1,-1,-1,-1,1,0.15,low,#e5f5e0,85.88498714,0,96.08994273,8.8,0,0,0
+222,4412,41,Deciduous Forest,,4,Waterbody,Perennial Ice/Snow,-1,-1,-1,-1,-1,-1,-1,-1,2,0.4,medium,#a1d99b,85.88498714,0,96.08994273,8.8,0,0,0
+223,4413,41,Deciduous Forest,,4,Waterbody,Perennial Ice/Snow,-1,-1,-1,-1,-1,-1,-1,-1,3,0.66,high,#31a354,85.88498714,0,96.08994273,8.8,0,0,0
+224,4420,42,Evergreen Forest,,4,Waterbody,Perennial Ice/Snow,-1,-1,-1,-1,-1,-1,-1,-1,0,0,none,#ffffff,105.6849871,0,96.08994273,14.4,0,0,0
+225,4421,42,Evergreen Forest,,4,Waterbody,Perennial Ice/Snow,-1,-1,-1,-1,-1,-1,-1,-1,1,0.15,low,#e5f5e0,105.6849871,0,96.08994273,14.4,0,0,0
+226,4422,42,Evergreen Forest,,4,Waterbody,Perennial Ice/Snow,-1,-1,-1,-1,-1,-1,-1,-1,2,0.4,medium,#a1d99b,105.6849871,0,96.08994273,14.4,0,0,0
+227,4423,42,Evergreen Forest,,4,Waterbody,Perennial Ice/Snow,-1,-1,-1,-1,-1,-1,-1,-1,3,0.66,high,#31a354,105.6849871,0,96.08994273,14.4,0,0,0
+228,4430,43,Mixed Forest,,4,Waterbody,Perennial Ice/Snow,-1,-1,-1,-1,-1,-1,-1,-1,0,0,none,#ffffff,91.76997429,0,119.1798855,8.8,0,0,0
+229,4431,43,Mixed Forest,,4,Waterbody,Perennial Ice/Snow,-1,-1,-1,-1,-1,-1,-1,-1,1,0.15,low,#e5f5e0,91.76997429,0,119.1798855,8.8,0,0,0
+230,4432,43,Mixed Forest,,4,Waterbody,Perennial Ice/Snow,-1,-1,-1,-1,-1,-1,-1,-1,2,0.4,medium,#a1d99b,91.76997429,0,119.1798855,8.8,0,0,0
+231,4433,43,Mixed Forest,,4,Waterbody,Perennial Ice/Snow,-1,-1,-1,-1,-1,-1,-1,-1,3,0.66,high,#31a354,91.76997429,0,119.1798855,8.8,0,0,0
+232,4520,52,Shrub/Scrub,,4,Waterbody,Perennial Ice/Snow,-1,-1,-1,-1,-1,-1,-1,-1,0,0,none,#ffffff,47.875,0,68.15477645,0,0,0,0
+233,4521,52,Shrub/Scrub,,4,Waterbody,Perennial Ice/Snow,-1,-1,-1,-1,-1,-1,-1,-1,1,0.15,low,#e5f5e0,54.86074743,0,73.49954853,1.6,0,0,0
+234,4522,52,Shrub/Scrub,,4,Waterbody,Perennial Ice/Snow,-1,-1,-1,-1,-1,-1,-1,-1,2,0.4,medium,#a1d99b,66.5036598,0,82.407502,4.266666667,0,0,0
+235,4523,52,Shrub/Scrub,,4,Waterbody,Perennial Ice/Snow,-1,-1,-1,-1,-1,-1,-1,-1,3,0.66,high,#31a354,78.61228868,0,91.6717736,7.04,0,0,0
+236,4710,71,Herbaceuous,,4,Waterbody,Perennial Ice/Snow,-1,-1,-1,-1,-1,-1,-1,-1,0,0,none,#ffffff,10.10660117,8,98.79264417,0,0,0,0
+237,4711,71,Herbaceuous,,4,Waterbody,Perennial Ice/Snow,-1,-1,-1,-1,-1,-1,-1,-1,1,0.15,low,#e5f5e0,22.75760842,6.8,99.54173609,1.6,0,0,0
+238,4712,71,Herbaceuous,,4,Waterbody,Perennial Ice/Snow,-1,-1,-1,-1,-1,-1,-1,-1,2,0.4,medium,#a1d99b,43.84262051,4.8,100.7902226,4.266666667,0,0,0
+239,4713,71,Herbaceuous,,4,Waterbody,Perennial Ice/Snow,-1,-1,-1,-1,-1,-1,-1,-1,3,0.66,high,#31a354,65.77103307,2.72,102.0886486,7.04,0,0,0
+240,4810,81,Hay/Pasture,,4,Waterbody,Perennial Ice/Snow,-1,-1,-1,-1,-1,-1,-1,-1,0,0,none,#ffffff,10.10660117,8,98.79264417,0,0,0,0
+241,4811,81,Hay/Pasture,,4,Waterbody,Perennial Ice/Snow,-1,-1,-1,-1,-1,-1,-1,-1,1,0.15,low,#e5f5e0,22.75760842,6.8,99.54173609,1.6,0,0,0
+242,4812,81,Hay/Pasture,,4,Waterbody,Perennial Ice/Snow,-1,-1,-1,-1,-1,-1,-1,-1,2,0.4,medium,#a1d99b,43.84262051,4.8,100.7902226,4.266666667,0,0,0
+243,4813,81,Hay/Pasture,,4,Waterbody,Perennial Ice/Snow,-1,-1,-1,-1,-1,-1,-1,-1,3,0.66,high,#31a354,65.77103307,2.72,102.0886486,7.04,0,0,0
+244,4820,82,Cultivated Crops,,4,Waterbody,Perennial Ice/Snow,-1,-1,-1,-1,-1,-1,-1,-1,0,0,none,#ffffff,4.793840162,0,65.75263422,0,0,0,0
+245,4821,82,Cultivated Crops,,4,Waterbody,Perennial Ice/Snow,-1,-1,-1,-1,-1,-1,-1,-1,1,0.15,low,#e5f5e0,18.24176156,0,71.45772764,1.6,0,0,0
+246,4822,82,Cultivated Crops,,4,Waterbody,Perennial Ice/Snow,-1,-1,-1,-1,-1,-1,-1,-1,2,0.4,medium,#a1d99b,40.6549639,0,80.96621666,4.266666667,0,0,0
+247,4823,82,Cultivated Crops,,4,Waterbody,Perennial Ice/Snow,-1,-1,-1,-1,-1,-1,-1,-1,3,0.66,high,#31a354,63.96469433,0,90.85504525,7.04,0,0,0
+248,4900,90,Woody Wetlands,,4,Waterbody,Perennial Ice/Snow,-1,-1,-1,-1,-1,-1,-1,-1,0,0,none,#ffffff,33.5,0,259,0,0,0,0
+249,4901,90,Woody Wetlands,,4,Waterbody,Perennial Ice/Snow,-1,-1,-1,-1,-1,-1,-1,-1,1,0.15,low,#e5f5e0,42.64199743,0,235.7179885,1.6,0,0,0
+250,4902,90,Woody Wetlands,,4,Waterbody,Perennial Ice/Snow,-1,-1,-1,-1,-1,-1,-1,-1,2,0.4,medium,#a1d99b,57.8786598,0,196.9146361,4.266666667,0,0,0
+251,4903,90,Woody Wetlands,,4,Waterbody,Perennial Ice/Snow,-1,-1,-1,-1,-1,-1,-1,-1,3,0.66,high,#31a354,73.72478868,0,156.5591496,7.04,0,0,0
+252,4950,95,Emergent Herbaceuous Wetlands,,4,Waterbody,Perennial Ice/Snow,-1,-1,-1,-1,-1,-1,-1,-1,0,0,none,#ffffff,33.5,0,259,0,0,0,0
+253,4951,95,Emergent Herbaceuous Wetlands,,4,Waterbody,Perennial Ice/Snow,-1,-1,-1,-1,-1,-1,-1,-1,1,0.15,low,#e5f5e0,42.64199743,0,235.7179885,1.6,0,0,0
+254,4952,95,Emergent Herbaceuous Wetlands,,4,Waterbody,Perennial Ice/Snow,-1,-1,-1,-1,-1,-1,-1,-1,2,0.4,medium,#a1d99b,57.8786598,0,196.9146361,4.266666667,0,0,0
+255,4953,95,Emergent Herbaceuous Wetlands,,4,Waterbody,Perennial Ice/Snow,-1,-1,-1,-1,-1,-1,-1,-1,3,0.66,high,#31a354,73.72478868,0,156.5591496,7.04,0,0,0
+256,11110,11,Open Water,,11,Residential,Dense urban,-1,-1,-1,-1,-1,-1,-1,-1,0,0,none,#ffffff,0,0,0,0,0,0,0
+257,11111,11,Open Water,,11,Residential,Dense urban,-1,-1,-1,-1,-1,-1,-1,-1,1,0.15,low,#e5f5e0,14.16699743,0,15.56798855,1.6,0,0,0
+258,11112,11,Open Water,,11,Residential,Dense urban,-1,-1,-1,-1,-1,-1,-1,-1,2,0.4,medium,#a1d99b,37.7786598,0,41.51463613,4.266666667,0,0,0
+259,11113,11,Open Water,,11,Residential,Dense urban,-1,-1,-1,-1,-1,-1,-1,-1,3,0.66,high,#31a354,62.33478868,0,68.49914961,7.04,0,0,0
+260,11120,12,Perennial Ice/Snow,,11,Residential,Dense urban,-1,-1,-1,-1,-1,-1,-1,-1,0,0,none,#ffffff,0,0,0,0,0,0,0
+261,11121,12,Perennial Ice/Snow,,11,Residential,Dense urban,-1,-1,-1,-1,-1,-1,-1,-1,1,0.15,low,#e5f5e0,14.16699743,0,15.56798855,1.6,0,0,0
+262,11122,12,Perennial Ice/Snow,,11,Residential,Dense urban,-1,-1,-1,-1,-1,-1,-1,-1,2,0.4,medium,#a1d99b,37.7786598,0,41.51463613,4.266666667,0,0,0
+263,11123,12,Perennial Ice/Snow,,11,Residential,Dense urban,-1,-1,-1,-1,-1,-1,-1,-1,3,0.66,high,#31a354,62.33478868,0,68.49914961,7.04,0,0,0
+264,11210,21,"Developed, Open Space","20% trees, 60% grass, and 10% buildings and 10% bare soil",11,Residential,Dense urban,0.8,0.8,0.8,0.1,1,-1,-1,-1,0,0,none,#ffffff,25.49986095,4.08,79.01411479,1.76,51.81402439,212.31,37.03522039
+265,11211,21,"Developed, Open Space","20% trees, 60% grass, and 10% buildings and 10% bare soil",11,Residential,Dense urban,0.8,0.8,0.8,0.1,1,-1,-1,-1,1,0.15,low,#e5f5e0,35.84187923,3.468,82.72998612,3.096,51.81402439,212.31,37.03522039
+266,11212,21,"Developed, Open Space","20% trees, 60% grass, and 10% buildings and 10% bare soil",11,Residential,Dense urban,0.8,0.8,0.8,0.1,1,-1,-1,-1,2,0.4,medium,#a1d99b,53.07857637,2.448,88.923105,5.322666667,51.81402439,212.31,37.03522039
+267,11213,21,"Developed, Open Space","20% trees, 60% grass, and 10% buildings and 10% bare soil",11,Residential,Dense urban,0.8,0.8,0.8,0.1,1,-1,-1,-1,3,0.66,high,#31a354,71.0047414,1.3872,95.36394864,7.6384,51.81402439,212.31,37.03522039
+268,11220,22,"Developed, Low Intensity","20% trees, 40% grass, and 40% buildings",11,Residential,Dense urban,0.8,0.8,0.8,0.1,1,-1,-1,-1,0,0,none,#ffffff,20.90844667,3.52,72.06732319,0.61,207.2560976,849.24,147.1338816
+269,11221,22,"Developed, Low Intensity","20% trees, 40% grass, and 40% buildings",11,Residential,Dense urban,0.8,0.8,0.8,0.1,1,-1,-1,-1,1,0.15,low,#e5f5e0,31.9391771,2.992,76.82521326,2.1185,207.2560976,849.24,147.1338816
+270,11222,22,"Developed, Low Intensity","20% trees, 40% grass, and 40% buildings",11,Residential,Dense urban,0.8,0.8,0.8,0.1,1,-1,-1,-1,2,0.4,medium,#a1d99b,50.32372781,2.112,84.75503004,4.632666667,207.2560976,849.24,147.1338816
+271,11223,22,"Developed, Low Intensity","20% trees, 40% grass, and 40% buildings",11,Residential,Dense urban,0.8,0.8,0.8,0.1,1,-1,-1,-1,3,0.66,high,#31a354,69.44366054,1.1968,93.0020395,7.2474,207.2560976,849.24,147.1338816
+272,11230,23,"Developed, Medium Intensity","15% trees, 35% grass, and 50% buildings",11,Residential,Dense urban,0.8,0.8,0.8,0.1,1,-1,-1,-1,0,0,none,#ffffff,17.69813636,3.08,61.93838294,0.36,234.070122,954.85,720.4716833
+273,11231,23,"Developed, Medium Intensity","15% trees, 35% grass, and 50% buildings",11,Residential,Dense urban,0.8,0.8,0.8,0.1,1,-1,-1,-1,1,0.15,low,#e5f5e0,29.21041333,2.618,68.21561405,1.906,234.070122,954.85,720.4716833
+274,11232,23,"Developed, Medium Intensity","15% trees, 35% grass, and 50% buildings",11,Residential,Dense urban,0.8,0.8,0.8,0.1,1,-1,-1,-1,2,0.4,medium,#a1d99b,48.39754162,1.848,78.67766589,4.482666667,234.070122,954.85,720.4716833
+275,11233,23,"Developed, Medium Intensity","15% trees, 35% grass, and 50% buildings",11,Residential,Dense urban,0.8,0.8,0.8,0.1,1,-1,-1,-1,3,0.66,high,#31a354,68.35215504,1.0472,89.55819981,7.1624,234.070122,954.85,720.4716833
+276,11240,24,"Developed, High Intensity","10% trees, 20% grass, and 70% buildings",11,Residential,Dense urban,0.8,0.8,0.8,0.1,1,-1,-1,-1,0,0,none,#ffffff,10.98142029,1.76,44.78642515,0.245,267.9065041,3418.485,1805.616283
+277,11241,24,"Developed, High Intensity","10% trees, 20% grass, and 70% buildings",11,Residential,Dense urban,0.8,0.8,0.8,0.1,1,-1,-1,-1,1,0.15,low,#e5f5e0,23.50120467,1.496,53.63644993,1.80825,267.9065041,3418.485,1805.616283
+278,11242,24,"Developed, High Intensity","10% trees, 20% grass, and 70% buildings",11,Residential,Dense urban,0.8,0.8,0.8,0.1,1,-1,-1,-1,2,0.4,medium,#a1d99b,44.36751198,1.056,68.38649122,4.413666667,267.9065041,3418.485,1805.616283
+279,11243,24,"Developed, High Intensity","10% trees, 20% grass, and 70% buildings",11,Residential,Dense urban,0.8,0.8,0.8,0.1,1,-1,-1,-1,3,0.66,high,#31a354,66.06847158,0.5984,83.72653416,7.1233,267.9065041,3418.485,1805.616283
+280,11310,31,Barren Land,,11,Residential,Dense urban,0.8,0.8,0.8,0.1,1,-1,-1,-1,0,0,none,#ffffff,6.8,0,25.5,0,0,0,0
+281,11311,31,Barren Land,,11,Residential,Dense urban,0.8,0.8,0.8,0.1,1,-1,-1,-1,1,0.15,low,#e5f5e0,19.94699743,0,37.24298855,1.6,0,0,0
+282,11312,31,Barren Land,,11,Residential,Dense urban,0.8,0.8,0.8,0.1,1,-1,-1,-1,2,0.4,medium,#a1d99b,41.8586598,0,56.81463613,4.266666667,0,0,0
+283,11313,31,Barren Land,,11,Residential,Dense urban,0.8,0.8,0.8,0.1,1,-1,-1,-1,3,0.66,high,#31a354,64.64678868,0,77.16914961,7.04,0,0,0
+284,11410,41,Deciduous Forest,,11,Residential,Dense urban,-1,0.8,-1,-1,1,-1,-1,-1,0,0,none,#ffffff,85.88498714,0,96.08994273,8.8,0,0,0
+285,11411,41,Deciduous Forest,,11,Residential,Dense urban,-1,0.8,-1,-1,1,-1,-1,-1,1,0.15,low,#e5f5e0,85.88498714,0,96.08994273,8.8,0,0,0
+286,11412,41,Deciduous Forest,,11,Residential,Dense urban,-1,0.8,-1,-1,1,-1,-1,-1,2,0.4,medium,#a1d99b,85.88498714,0,96.08994273,8.8,0,0,0
+287,11413,41,Deciduous Forest,,11,Residential,Dense urban,-1,0.8,-1,-1,1,-1,-1,-1,3,0.66,high,#31a354,85.88498714,0,96.08994273,8.8,0,0,0
+288,11420,42,Evergreen Forest,,11,Residential,Dense urban,-1,0.8,-1,-1,1,-1,-1,-1,0,0,none,#ffffff,105.6849871,0,96.08994273,14.4,0,0,0
+289,11421,42,Evergreen Forest,,11,Residential,Dense urban,-1,0.8,-1,-1,1,-1,-1,-1,1,0.15,low,#e5f5e0,105.6849871,0,96.08994273,14.4,0,0,0
+290,11422,42,Evergreen Forest,,11,Residential,Dense urban,-1,0.8,-1,-1,1,-1,-1,-1,2,0.4,medium,#a1d99b,105.6849871,0,96.08994273,14.4,0,0,0
+291,11423,42,Evergreen Forest,,11,Residential,Dense urban,-1,0.8,-1,-1,1,-1,-1,-1,3,0.66,high,#31a354,105.6849871,0,96.08994273,14.4,0,0,0
+292,11430,43,Mixed Forest,,11,Residential,Dense urban,-1,0.8,-1,-1,1,-1,-1,-1,0,0,none,#ffffff,91.76997429,0,119.1798855,8.8,0,0,0
+293,11431,43,Mixed Forest,,11,Residential,Dense urban,-1,0.8,-1,-1,1,-1,-1,-1,1,0.15,low,#e5f5e0,91.76997429,0,119.1798855,8.8,0,0,0
+294,11432,43,Mixed Forest,,11,Residential,Dense urban,-1,0.8,-1,-1,1,-1,-1,-1,2,0.4,medium,#a1d99b,91.76997429,0,119.1798855,8.8,0,0,0
+295,11433,43,Mixed Forest,,11,Residential,Dense urban,-1,0.8,-1,-1,1,-1,-1,-1,3,0.66,high,#31a354,91.76997429,0,119.1798855,8.8,0,0,0
+296,11520,52,Shrub/Scrub,,11,Residential,Dense urban,0.8,0.8,0.8,0.1,1,-1,-1,-1,0,0,none,#ffffff,47.875,0,68.15477645,0,0,0,0
+297,11521,52,Shrub/Scrub,,11,Residential,Dense urban,0.8,0.8,0.8,0.1,1,-1,-1,-1,1,0.15,low,#e5f5e0,54.86074743,0,73.49954853,1.6,0,0,0
+298,11522,52,Shrub/Scrub,,11,Residential,Dense urban,0.8,0.8,0.8,0.1,1,-1,-1,-1,2,0.4,medium,#a1d99b,66.5036598,0,82.407502,4.266666667,0,0,0
+299,11523,52,Shrub/Scrub,,11,Residential,Dense urban,0.8,0.8,0.8,0.1,1,-1,-1,-1,3,0.66,high,#31a354,78.61228868,0,91.6717736,7.04,0,0,0
+300,11710,71,Herbaceuous,,11,Residential,Dense urban,0.8,0.8,0.8,0.1,1,-1,-1,-1,0,0,none,#ffffff,10.10660117,8,98.79264417,0,0,0,0
+301,11711,71,Herbaceuous,,11,Residential,Dense urban,0.8,0.8,0.8,0.1,1,-1,-1,-1,1,0.15,low,#e5f5e0,22.75760842,6.8,99.54173609,1.6,0,0,0
+302,11712,71,Herbaceuous,,11,Residential,Dense urban,0.8,0.8,0.8,0.1,1,-1,-1,-1,2,0.4,medium,#a1d99b,43.84262051,4.8,100.7902226,4.266666667,0,0,0
+303,11713,71,Herbaceuous,,11,Residential,Dense urban,0.8,0.8,0.8,0.1,1,-1,-1,-1,3,0.66,high,#31a354,65.77103307,2.72,102.0886486,7.04,0,0,0
+304,11810,81,Hay/Pasture,,11,Residential,Dense urban,0.8,0.8,0.8,0.1,1,-1,-1,-1,0,0,none,#ffffff,10.10660117,8,98.79264417,0,0,0,0
+305,11811,81,Hay/Pasture,,11,Residential,Dense urban,0.8,0.8,0.8,0.1,1,-1,-1,-1,1,0.15,low,#e5f5e0,22.75760842,6.8,99.54173609,1.6,0,0,0
+306,11812,81,Hay/Pasture,,11,Residential,Dense urban,0.8,0.8,0.8,0.1,1,-1,-1,-1,2,0.4,medium,#a1d99b,43.84262051,4.8,100.7902226,4.266666667,0,0,0
+307,11813,81,Hay/Pasture,,11,Residential,Dense urban,0.8,0.8,0.8,0.1,1,-1,-1,-1,3,0.66,high,#31a354,65.77103307,2.72,102.0886486,7.04,0,0,0
+308,11820,82,Cultivated Crops,,11,Residential,Dense urban,0.8,0.8,0.8,-1,-1,-1,-1,-1,0,0,none,#ffffff,4.793840162,0,65.75263422,0,0,0,0
+309,11821,82,Cultivated Crops,,11,Residential,Dense urban,0.8,0.8,0.8,-1,-1,-1,-1,-1,1,0.15,low,#e5f5e0,18.24176156,0,71.45772764,1.6,0,0,0
+310,11822,82,Cultivated Crops,,11,Residential,Dense urban,0.8,0.8,0.8,-1,-1,-1,-1,-1,2,0.4,medium,#a1d99b,40.6549639,0,80.96621666,4.266666667,0,0,0
+311,11823,82,Cultivated Crops,,11,Residential,Dense urban,0.8,0.8,0.8,-1,-1,-1,-1,-1,3,0.66,high,#31a354,63.96469433,0,90.85504525,7.04,0,0,0
+312,11900,90,Woody Wetlands,,11,Residential,Dense urban,0.8,0.8,-1,-1,1,-1,-1,-1,0,0,none,#ffffff,33.5,0,259,0,0,0,0
+313,11901,90,Woody Wetlands,,11,Residential,Dense urban,0.8,0.8,-1,-1,1,-1,-1,-1,1,0.15,low,#e5f5e0,42.64199743,0,235.7179885,1.6,0,0,0
+314,11902,90,Woody Wetlands,,11,Residential,Dense urban,0.8,0.8,-1,-1,1,-1,-1,-1,2,0.4,medium,#a1d99b,57.8786598,0,196.9146361,4.266666667,0,0,0
+315,11903,90,Woody Wetlands,,11,Residential,Dense urban,0.8,0.8,-1,-1,1,-1,-1,-1,3,0.66,high,#31a354,73.72478868,0,156.5591496,7.04,0,0,0
+316,11950,95,Emergent Herbaceuous Wetlands,,11,Residential,Dense urban,0.8,0.8,-1,-1,1,-1,-1,-1,0,0,none,#ffffff,33.5,0,259,0,0,0,0
+317,11951,95,Emergent Herbaceuous Wetlands,,11,Residential,Dense urban,0.8,0.8,-1,-1,1,-1,-1,-1,1,0.15,low,#e5f5e0,42.64199743,0,235.7179885,1.6,0,0,0
+318,11952,95,Emergent Herbaceuous Wetlands,,11,Residential,Dense urban,0.8,0.8,-1,-1,1,-1,-1,-1,2,0.4,medium,#a1d99b,57.8786598,0,196.9146361,4.266666667,0,0,0
+319,11953,95,Emergent Herbaceuous Wetlands,,11,Residential,Dense urban,0.8,0.8,-1,-1,1,-1,-1,-1,3,0.66,high,#31a354,73.72478868,0,156.5591496,7.04,0,0,0
+320,12110,11,Open Water,,12,Residential,Urban,-1,-1,-1,-1,-1,-1,-1,-1,0,0,none,#ffffff,0,0,0,0,0,0,0
+321,12111,11,Open Water,,12,Residential,Urban,-1,-1,-1,-1,-1,-1,-1,-1,1,0.15,low,#e5f5e0,14.16699743,0,15.56798855,1.6,0,0,0
+322,12112,11,Open Water,,12,Residential,Urban,-1,-1,-1,-1,-1,-1,-1,-1,2,0.4,medium,#a1d99b,37.7786598,0,41.51463613,4.266666667,0,0,0
+323,12113,11,Open Water,,12,Residential,Urban,-1,-1,-1,-1,-1,-1,-1,-1,3,0.66,high,#31a354,62.33478868,0,68.49914961,7.04,0,0,0
+324,12120,12,Perennial Ice/Snow,,12,Residential,Urban,-1,-1,-1,-1,-1,-1,-1,-1,0,0,none,#ffffff,0,0,0,0,0,0,0
+325,12121,12,Perennial Ice/Snow,,12,Residential,Urban,-1,-1,-1,-1,-1,-1,-1,-1,1,0.15,low,#e5f5e0,14.16699743,0,15.56798855,1.6,0,0,0
+326,12122,12,Perennial Ice/Snow,,12,Residential,Urban,-1,-1,-1,-1,-1,-1,-1,-1,2,0.4,medium,#a1d99b,37.7786598,0,41.51463613,4.266666667,0,0,0
+327,12123,12,Perennial Ice/Snow,,12,Residential,Urban,-1,-1,-1,-1,-1,-1,-1,-1,3,0.66,high,#31a354,62.33478868,0,68.49914961,7.04,0,0,0
+328,12210,21,"Developed, Open Space","20% trees, 60% grass, and 10% buildings and 10% bare soil",12,Residential,Urban,0.8,0.8,0.8,0.3,1,-1,-1,-1,0,0,none,#ffffff,25.49986095,4.08,79.01411479,1.76,51.81402439,212.31,37.03522039
+329,12211,21,"Developed, Open Space","20% trees, 60% grass, and 10% buildings and 10% bare soil",12,Residential,Urban,0.8,0.8,0.8,0.3,1,-1,-1,-1,1,0.15,low,#e5f5e0,35.84187923,3.468,82.72998612,3.096,51.81402439,212.31,37.03522039
+330,12212,21,"Developed, Open Space","20% trees, 60% grass, and 10% buildings and 10% bare soil",12,Residential,Urban,0.8,0.8,0.8,0.3,1,-1,-1,-1,2,0.4,medium,#a1d99b,53.07857637,2.448,88.923105,5.322666667,51.81402439,212.31,37.03522039
+331,12213,21,"Developed, Open Space","20% trees, 60% grass, and 10% buildings and 10% bare soil",12,Residential,Urban,0.8,0.8,0.8,0.3,1,-1,-1,-1,3,0.66,high,#31a354,71.0047414,1.3872,95.36394864,7.6384,51.81402439,212.31,37.03522039
+332,12220,22,"Developed, Low Intensity","20% trees, 40% grass, and 40% buildings",12,Residential,Urban,0.8,0.8,0.8,0.3,1,-1,-1,-1,0,0,none,#ffffff,20.90844667,3.52,72.06732319,0.61,207.2560976,849.24,147.1338816
+333,12221,22,"Developed, Low Intensity","20% trees, 40% grass, and 40% buildings",12,Residential,Urban,0.8,0.8,0.8,0.3,1,-1,-1,-1,1,0.15,low,#e5f5e0,31.9391771,2.992,76.82521326,2.1185,207.2560976,849.24,147.1338816
+334,12222,22,"Developed, Low Intensity","20% trees, 40% grass, and 40% buildings",12,Residential,Urban,0.8,0.8,0.8,0.3,1,-1,-1,-1,2,0.4,medium,#a1d99b,50.32372781,2.112,84.75503004,4.632666667,207.2560976,849.24,147.1338816
+335,12223,22,"Developed, Low Intensity","20% trees, 40% grass, and 40% buildings",12,Residential,Urban,0.8,0.8,0.8,0.3,1,-1,-1,-1,3,0.66,high,#31a354,69.44366054,1.1968,93.0020395,7.2474,207.2560976,849.24,147.1338816
+336,12230,23,"Developed, Medium Intensity","15% trees, 35% grass, and 50% buildings",12,Residential,Urban,0.8,0.8,0.8,0.3,1,-1,-1,-1,0,0,none,#ffffff,17.69813636,3.08,61.93838294,0.36,234.070122,954.85,720.4716833
+337,12231,23,"Developed, Medium Intensity","15% trees, 35% grass, and 50% buildings",12,Residential,Urban,0.8,0.8,0.8,0.3,1,-1,-1,-1,1,0.15,low,#e5f5e0,29.21041333,2.618,68.21561405,1.906,234.070122,954.85,720.4716833
+338,12232,23,"Developed, Medium Intensity","15% trees, 35% grass, and 50% buildings",12,Residential,Urban,0.8,0.8,0.8,0.3,1,-1,-1,-1,2,0.4,medium,#a1d99b,48.39754162,1.848,78.67766589,4.482666667,234.070122,954.85,720.4716833
+339,12233,23,"Developed, Medium Intensity","15% trees, 35% grass, and 50% buildings",12,Residential,Urban,0.8,0.8,0.8,0.3,1,-1,-1,-1,3,0.66,high,#31a354,68.35215504,1.0472,89.55819981,7.1624,234.070122,954.85,720.4716833
+340,12240,24,"Developed, High Intensity","10% trees, 20% grass, and 70% buildings",12,Residential,Urban,0.8,0.8,0.8,0.3,1,-1,-1,-1,0,0,none,#ffffff,10.98142029,1.76,44.78642515,0.245,267.9065041,3418.485,1805.616283
+341,12241,24,"Developed, High Intensity","10% trees, 20% grass, and 70% buildings",12,Residential,Urban,0.8,0.8,0.8,0.3,1,-1,-1,-1,1,0.15,low,#e5f5e0,23.50120467,1.496,53.63644993,1.80825,267.9065041,3418.485,1805.616283
+342,12242,24,"Developed, High Intensity","10% trees, 20% grass, and 70% buildings",12,Residential,Urban,0.8,0.8,0.8,0.3,1,-1,-1,-1,2,0.4,medium,#a1d99b,44.36751198,1.056,68.38649122,4.413666667,267.9065041,3418.485,1805.616283
+343,12243,24,"Developed, High Intensity","10% trees, 20% grass, and 70% buildings",12,Residential,Urban,0.8,0.8,0.8,0.3,1,-1,-1,-1,3,0.66,high,#31a354,66.06847158,0.5984,83.72653416,7.1233,267.9065041,3418.485,1805.616283
+344,12310,31,Barren Land,,12,Residential,Urban,0.8,0.8,0.8,0.3,1,-1,-1,-1,0,0,none,#ffffff,6.8,0,25.5,0,0,0,0
+345,12311,31,Barren Land,,12,Residential,Urban,0.8,0.8,0.8,0.3,1,-1,-1,-1,1,0.15,low,#e5f5e0,19.94699743,0,37.24298855,1.6,0,0,0
+346,12312,31,Barren Land,,12,Residential,Urban,0.8,0.8,0.8,0.3,1,-1,-1,-1,2,0.4,medium,#a1d99b,41.8586598,0,56.81463613,4.266666667,0,0,0
+347,12313,31,Barren Land,,12,Residential,Urban,0.8,0.8,0.8,0.3,1,-1,-1,-1,3,0.66,high,#31a354,64.64678868,0,77.16914961,7.04,0,0,0
+348,12410,41,Deciduous Forest,,12,Residential,Urban,-1,0.8,-1,-1,1,-1,-1,-1,0,0,none,#ffffff,85.88498714,0,96.08994273,8.8,0,0,0
+349,12411,41,Deciduous Forest,,12,Residential,Urban,-1,0.8,-1,-1,1,-1,-1,-1,1,0.15,low,#e5f5e0,85.88498714,0,96.08994273,8.8,0,0,0
+350,12412,41,Deciduous Forest,,12,Residential,Urban,-1,0.8,-1,-1,1,-1,-1,-1,2,0.4,medium,#a1d99b,85.88498714,0,96.08994273,8.8,0,0,0
+351,12413,41,Deciduous Forest,,12,Residential,Urban,-1,0.8,-1,-1,1,-1,-1,-1,3,0.66,high,#31a354,85.88498714,0,96.08994273,8.8,0,0,0
+352,12420,42,Evergreen Forest,,12,Residential,Urban,-1,0.8,-1,-1,1,-1,-1,-1,0,0,none,#ffffff,105.6849871,0,96.08994273,14.4,0,0,0
+353,12421,42,Evergreen Forest,,12,Residential,Urban,-1,0.8,-1,-1,1,-1,-1,-1,1,0.15,low,#e5f5e0,105.6849871,0,96.08994273,14.4,0,0,0
+354,12422,42,Evergreen Forest,,12,Residential,Urban,-1,0.8,-1,-1,1,-1,-1,-1,2,0.4,medium,#a1d99b,105.6849871,0,96.08994273,14.4,0,0,0
+355,12423,42,Evergreen Forest,,12,Residential,Urban,-1,0.8,-1,-1,1,-1,-1,-1,3,0.66,high,#31a354,105.6849871,0,96.08994273,14.4,0,0,0
+356,12430,43,Mixed Forest,,12,Residential,Urban,-1,0.8,-1,-1,1,-1,-1,-1,0,0,none,#ffffff,91.76997429,0,119.1798855,8.8,0,0,0
+357,12431,43,Mixed Forest,,12,Residential,Urban,-1,0.8,-1,-1,1,-1,-1,-1,1,0.15,low,#e5f5e0,91.76997429,0,119.1798855,8.8,0,0,0
+358,12432,43,Mixed Forest,,12,Residential,Urban,-1,0.8,-1,-1,1,-1,-1,-1,2,0.4,medium,#a1d99b,91.76997429,0,119.1798855,8.8,0,0,0
+359,12433,43,Mixed Forest,,12,Residential,Urban,-1,0.8,-1,-1,1,-1,-1,-1,3,0.66,high,#31a354,91.76997429,0,119.1798855,8.8,0,0,0
+360,12520,52,Shrub/Scrub,,12,Residential,Urban,0.8,0.8,0.8,0.3,1,-1,-1,-1,0,0,none,#ffffff,47.875,0,68.15477645,0,0,0,0
+361,12521,52,Shrub/Scrub,,12,Residential,Urban,0.8,0.8,0.8,0.3,1,-1,-1,-1,1,0.15,low,#e5f5e0,54.86074743,0,73.49954853,1.6,0,0,0
+362,12522,52,Shrub/Scrub,,12,Residential,Urban,0.8,0.8,0.8,0.3,1,-1,-1,-1,2,0.4,medium,#a1d99b,66.5036598,0,82.407502,4.266666667,0,0,0
+363,12523,52,Shrub/Scrub,,12,Residential,Urban,0.8,0.8,0.8,0.3,1,-1,-1,-1,3,0.66,high,#31a354,78.61228868,0,91.6717736,7.04,0,0,0
+364,12710,71,Herbaceuous,,12,Residential,Urban,0.8,0.8,0.8,0.3,1,-1,-1,-1,0,0,none,#ffffff,10.10660117,8,98.79264417,0,0,0,0
+365,12711,71,Herbaceuous,,12,Residential,Urban,0.8,0.8,0.8,0.3,1,-1,-1,-1,1,0.15,low,#e5f5e0,22.75760842,6.8,99.54173609,1.6,0,0,0
+366,12712,71,Herbaceuous,,12,Residential,Urban,0.8,0.8,0.8,0.3,1,-1,-1,-1,2,0.4,medium,#a1d99b,43.84262051,4.8,100.7902226,4.266666667,0,0,0
+367,12713,71,Herbaceuous,,12,Residential,Urban,0.8,0.8,0.8,0.3,1,-1,-1,-1,3,0.66,high,#31a354,65.77103307,2.72,102.0886486,7.04,0,0,0
+368,12810,81,Hay/Pasture,,12,Residential,Urban,0.8,0.8,0.8,0.3,1,-1,-1,-1,0,0,none,#ffffff,10.10660117,8,98.79264417,0,0,0,0
+369,12811,81,Hay/Pasture,,12,Residential,Urban,0.8,0.8,0.8,0.3,1,-1,-1,-1,1,0.15,low,#e5f5e0,22.75760842,6.8,99.54173609,1.6,0,0,0
+370,12812,81,Hay/Pasture,,12,Residential,Urban,0.8,0.8,0.8,0.3,1,-1,-1,-1,2,0.4,medium,#a1d99b,43.84262051,4.8,100.7902226,4.266666667,0,0,0
+371,12813,81,Hay/Pasture,,12,Residential,Urban,0.8,0.8,0.8,0.3,1,-1,-1,-1,3,0.66,high,#31a354,65.77103307,2.72,102.0886486,7.04,0,0,0
+372,12820,82,Cultivated Crops,,12,Residential,Urban,0.8,0.8,0.8,-1,-1,-1,-1,-1,0,0,none,#ffffff,4.793840162,0,65.75263422,0,0,0,0
+373,12821,82,Cultivated Crops,,12,Residential,Urban,0.8,0.8,0.8,-1,-1,-1,-1,-1,1,0.15,low,#e5f5e0,18.24176156,0,71.45772764,1.6,0,0,0
+374,12822,82,Cultivated Crops,,12,Residential,Urban,0.8,0.8,0.8,-1,-1,-1,-1,-1,2,0.4,medium,#a1d99b,40.6549639,0,80.96621666,4.266666667,0,0,0
+375,12823,82,Cultivated Crops,,12,Residential,Urban,0.8,0.8,0.8,-1,-1,-1,-1,-1,3,0.66,high,#31a354,63.96469433,0,90.85504525,7.04,0,0,0
+376,12900,90,Woody Wetlands,,12,Residential,Urban,0.8,0.8,-1,-1,1,-1,-1,-1,0,0,none,#ffffff,33.5,0,259,0,0,0,0
+377,12901,90,Woody Wetlands,,12,Residential,Urban,0.8,0.8,-1,-1,1,-1,-1,-1,1,0.15,low,#e5f5e0,42.64199743,0,235.7179885,1.6,0,0,0
+378,12902,90,Woody Wetlands,,12,Residential,Urban,0.8,0.8,-1,-1,1,-1,-1,-1,2,0.4,medium,#a1d99b,57.8786598,0,196.9146361,4.266666667,0,0,0
+379,12903,90,Woody Wetlands,,12,Residential,Urban,0.8,0.8,-1,-1,1,-1,-1,-1,3,0.66,high,#31a354,73.72478868,0,156.5591496,7.04,0,0,0
+380,12950,95,Emergent Herbaceuous Wetlands,,12,Residential,Urban,0.8,0.8,-1,-1,1,-1,-1,-1,0,0,none,#ffffff,33.5,0,259,0,0,0,0
+381,12951,95,Emergent Herbaceuous Wetlands,,12,Residential,Urban,0.8,0.8,-1,-1,1,-1,-1,-1,1,0.15,low,#e5f5e0,42.64199743,0,235.7179885,1.6,0,0,0
+382,12952,95,Emergent Herbaceuous Wetlands,,12,Residential,Urban,0.8,0.8,-1,-1,1,-1,-1,-1,2,0.4,medium,#a1d99b,57.8786598,0,196.9146361,4.266666667,0,0,0
+383,12953,95,Emergent Herbaceuous Wetlands,,12,Residential,Urban,0.8,0.8,-1,-1,1,-1,-1,-1,3,0.66,high,#31a354,73.72478868,0,156.5591496,7.04,0,0,0
+384,13110,11,Open Water,,13,Residential,Suburban,-1,-1,-1,-1,-1,-1,-1,-1,0,0,none,#ffffff,0,0,0,0,0,0,0
+385,13111,11,Open Water,,13,Residential,Suburban,-1,-1,-1,-1,-1,-1,-1,-1,1,0.15,low,#e5f5e0,14.16699743,0,15.56798855,1.6,0,0,0
+386,13112,11,Open Water,,13,Residential,Suburban,-1,-1,-1,-1,-1,-1,-1,-1,2,0.4,medium,#a1d99b,37.7786598,0,41.51463613,4.266666667,0,0,0
+387,13113,11,Open Water,,13,Residential,Suburban,-1,-1,-1,-1,-1,-1,-1,-1,3,0.66,high,#31a354,62.33478868,0,68.49914961,7.04,0,0,0
+388,13120,12,Perennial Ice/Snow,,13,Residential,Suburban,-1,-1,-1,-1,-1,-1,-1,-1,0,0,none,#ffffff,0,0,0,0,0,0,0
+389,13121,12,Perennial Ice/Snow,,13,Residential,Suburban,-1,-1,-1,-1,-1,-1,-1,-1,1,0.15,low,#e5f5e0,14.16699743,0,15.56798855,1.6,0,0,0
+390,13122,12,Perennial Ice/Snow,,13,Residential,Suburban,-1,-1,-1,-1,-1,-1,-1,-1,2,0.4,medium,#a1d99b,37.7786598,0,41.51463613,4.266666667,0,0,0
+391,13123,12,Perennial Ice/Snow,,13,Residential,Suburban,-1,-1,-1,-1,-1,-1,-1,-1,3,0.66,high,#31a354,62.33478868,0,68.49914961,7.04,0,0,0
+392,13210,21,"Developed, Open Space","20% trees, 60% grass, and 10% buildings and 10% bare soil",13,Residential,Suburban,0.8,0.8,0.8,0.5,1,-1,-1,-1,0,0,none,#ffffff,25.49986095,4.08,79.01411479,1.76,51.81402439,212.31,37.03522039
+393,13211,21,"Developed, Open Space","20% trees, 60% grass, and 10% buildings and 10% bare soil",13,Residential,Suburban,0.8,0.8,0.8,0.5,1,-1,-1,-1,1,0.15,low,#e5f5e0,35.84187923,3.468,82.72998612,3.096,51.81402439,212.31,37.03522039
+394,13212,21,"Developed, Open Space","20% trees, 60% grass, and 10% buildings and 10% bare soil",13,Residential,Suburban,0.8,0.8,0.8,0.5,1,-1,-1,-1,2,0.4,medium,#a1d99b,53.07857637,2.448,88.923105,5.322666667,51.81402439,212.31,37.03522039
+395,13213,21,"Developed, Open Space","20% trees, 60% grass, and 10% buildings and 10% bare soil",13,Residential,Suburban,0.8,0.8,0.8,0.5,1,-1,-1,-1,3,0.66,high,#31a354,71.0047414,1.3872,95.36394864,7.6384,51.81402439,212.31,37.03522039
+396,13220,22,"Developed, Low Intensity","20% trees, 40% grass, and 40% buildings",13,Residential,Suburban,0.8,0.8,0.8,0.5,1,-1,-1,-1,0,0,none,#ffffff,20.90844667,3.52,72.06732319,0.61,207.2560976,849.24,147.1338816
+397,13221,22,"Developed, Low Intensity","20% trees, 40% grass, and 40% buildings",13,Residential,Suburban,0.8,0.8,0.8,0.5,1,-1,-1,-1,1,0.15,low,#e5f5e0,31.9391771,2.992,76.82521326,2.1185,207.2560976,849.24,147.1338816
+398,13222,22,"Developed, Low Intensity","20% trees, 40% grass, and 40% buildings",13,Residential,Suburban,0.8,0.8,0.8,0.5,1,-1,-1,-1,2,0.4,medium,#a1d99b,50.32372781,2.112,84.75503004,4.632666667,207.2560976,849.24,147.1338816
+399,13223,22,"Developed, Low Intensity","20% trees, 40% grass, and 40% buildings",13,Residential,Suburban,0.8,0.8,0.8,0.5,1,-1,-1,-1,3,0.66,high,#31a354,69.44366054,1.1968,93.0020395,7.2474,207.2560976,849.24,147.1338816
+400,13230,23,"Developed, Medium Intensity","15% trees, 35% grass, and 50% buildings",13,Residential,Suburban,0.8,0.8,0.8,0.5,1,-1,-1,-1,0,0,none,#ffffff,17.69813636,3.08,61.93838294,0.36,234.070122,954.85,720.4716833
+401,13231,23,"Developed, Medium Intensity","15% trees, 35% grass, and 50% buildings",13,Residential,Suburban,0.8,0.8,0.8,0.5,1,-1,-1,-1,1,0.15,low,#e5f5e0,29.21041333,2.618,68.21561405,1.906,234.070122,954.85,720.4716833
+402,13232,23,"Developed, Medium Intensity","15% trees, 35% grass, and 50% buildings",13,Residential,Suburban,0.8,0.8,0.8,0.5,1,-1,-1,-1,2,0.4,medium,#a1d99b,48.39754162,1.848,78.67766589,4.482666667,234.070122,954.85,720.4716833
+403,13233,23,"Developed, Medium Intensity","15% trees, 35% grass, and 50% buildings",13,Residential,Suburban,0.8,0.8,0.8,0.5,1,-1,-1,-1,3,0.66,high,#31a354,68.35215504,1.0472,89.55819981,7.1624,234.070122,954.85,720.4716833
+404,13240,24,"Developed, High Intensity","10% trees, 20% grass, and 70% buildings",13,Residential,Suburban,0.8,0.8,0.8,0.5,1,-1,-1,-1,0,0,none,#ffffff,10.98142029,1.76,44.78642515,0.245,267.9065041,3418.485,1805.616283
+405,13241,24,"Developed, High Intensity","10% trees, 20% grass, and 70% buildings",13,Residential,Suburban,0.8,0.8,0.8,0.5,1,-1,-1,-1,1,0.15,low,#e5f5e0,23.50120467,1.496,53.63644993,1.80825,267.9065041,3418.485,1805.616283
+406,13242,24,"Developed, High Intensity","10% trees, 20% grass, and 70% buildings",13,Residential,Suburban,0.8,0.8,0.8,0.5,1,-1,-1,-1,2,0.4,medium,#a1d99b,44.36751198,1.056,68.38649122,4.413666667,267.9065041,3418.485,1805.616283
+407,13243,24,"Developed, High Intensity","10% trees, 20% grass, and 70% buildings",13,Residential,Suburban,0.8,0.8,0.8,0.5,1,-1,-1,-1,3,0.66,high,#31a354,66.06847158,0.5984,83.72653416,7.1233,267.9065041,3418.485,1805.616283
+408,13310,31,Barren Land,,13,Residential,Suburban,0.8,0.8,0.8,0.5,1,-1,-1,-1,0,0,none,#ffffff,6.8,0,25.5,0,0,0,0
+409,13311,31,Barren Land,,13,Residential,Suburban,0.8,0.8,0.8,0.5,1,-1,-1,-1,1,0.15,low,#e5f5e0,19.94699743,0,37.24298855,1.6,0,0,0
+410,13312,31,Barren Land,,13,Residential,Suburban,0.8,0.8,0.8,0.5,1,-1,-1,-1,2,0.4,medium,#a1d99b,41.8586598,0,56.81463613,4.266666667,0,0,0
+411,13313,31,Barren Land,,13,Residential,Suburban,0.8,0.8,0.8,0.5,1,-1,-1,-1,3,0.66,high,#31a354,64.64678868,0,77.16914961,7.04,0,0,0
+412,13410,41,Deciduous Forest,,13,Residential,Suburban,-1,0.8,-1,-1,1,-1,-1,-1,0,0,none,#ffffff,85.88498714,0,96.08994273,8.8,0,0,0
+413,13411,41,Deciduous Forest,,13,Residential,Suburban,-1,0.8,-1,-1,1,-1,-1,-1,1,0.15,low,#e5f5e0,85.88498714,0,96.08994273,8.8,0,0,0
+414,13412,41,Deciduous Forest,,13,Residential,Suburban,-1,0.8,-1,-1,1,-1,-1,-1,2,0.4,medium,#a1d99b,85.88498714,0,96.08994273,8.8,0,0,0
+415,13413,41,Deciduous Forest,,13,Residential,Suburban,-1,0.8,-1,-1,1,-1,-1,-1,3,0.66,high,#31a354,85.88498714,0,96.08994273,8.8,0,0,0
+416,13420,42,Evergreen Forest,,13,Residential,Suburban,-1,0.8,-1,-1,1,-1,-1,-1,0,0,none,#ffffff,105.6849871,0,96.08994273,14.4,0,0,0
+417,13421,42,Evergreen Forest,,13,Residential,Suburban,-1,0.8,-1,-1,1,-1,-1,-1,1,0.15,low,#e5f5e0,105.6849871,0,96.08994273,14.4,0,0,0
+418,13422,42,Evergreen Forest,,13,Residential,Suburban,-1,0.8,-1,-1,1,-1,-1,-1,2,0.4,medium,#a1d99b,105.6849871,0,96.08994273,14.4,0,0,0
+419,13423,42,Evergreen Forest,,13,Residential,Suburban,-1,0.8,-1,-1,1,-1,-1,-1,3,0.66,high,#31a354,105.6849871,0,96.08994273,14.4,0,0,0
+420,13430,43,Mixed Forest,,13,Residential,Suburban,-1,0.8,-1,-1,1,-1,-1,-1,0,0,none,#ffffff,91.76997429,0,119.1798855,8.8,0,0,0
+421,13431,43,Mixed Forest,,13,Residential,Suburban,-1,0.8,-1,-1,1,-1,-1,-1,1,0.15,low,#e5f5e0,91.76997429,0,119.1798855,8.8,0,0,0
+422,13432,43,Mixed Forest,,13,Residential,Suburban,-1,0.8,-1,-1,1,-1,-1,-1,2,0.4,medium,#a1d99b,91.76997429,0,119.1798855,8.8,0,0,0
+423,13433,43,Mixed Forest,,13,Residential,Suburban,-1,0.8,-1,-1,1,-1,-1,-1,3,0.66,high,#31a354,91.76997429,0,119.1798855,8.8,0,0,0
+424,13520,52,Shrub/Scrub,,13,Residential,Suburban,0.8,0.8,0.8,0.5,1,-1,-1,-1,0,0,none,#ffffff,47.875,0,68.15477645,0,0,0,0
+425,13521,52,Shrub/Scrub,,13,Residential,Suburban,0.8,0.8,0.8,0.5,1,-1,-1,-1,1,0.15,low,#e5f5e0,54.86074743,0,73.49954853,1.6,0,0,0
+426,13522,52,Shrub/Scrub,,13,Residential,Suburban,0.8,0.8,0.8,0.5,1,-1,-1,-1,2,0.4,medium,#a1d99b,66.5036598,0,82.407502,4.266666667,0,0,0
+427,13523,52,Shrub/Scrub,,13,Residential,Suburban,0.8,0.8,0.8,0.5,1,-1,-1,-1,3,0.66,high,#31a354,78.61228868,0,91.6717736,7.04,0,0,0
+428,13710,71,Herbaceuous,,13,Residential,Suburban,0.8,0.8,0.8,0.5,1,-1,-1,-1,0,0,none,#ffffff,10.10660117,8,98.79264417,0,0,0,0
+429,13711,71,Herbaceuous,,13,Residential,Suburban,0.8,0.8,0.8,0.5,1,-1,-1,-1,1,0.15,low,#e5f5e0,22.75760842,6.8,99.54173609,1.6,0,0,0
+430,13712,71,Herbaceuous,,13,Residential,Suburban,0.8,0.8,0.8,0.5,1,-1,-1,-1,2,0.4,medium,#a1d99b,43.84262051,4.8,100.7902226,4.266666667,0,0,0
+431,13713,71,Herbaceuous,,13,Residential,Suburban,0.8,0.8,0.8,0.5,1,-1,-1,-1,3,0.66,high,#31a354,65.77103307,2.72,102.0886486,7.04,0,0,0
+432,13810,81,Hay/Pasture,,13,Residential,Suburban,0.8,0.8,0.8,0.5,1,-1,-1,-1,0,0,none,#ffffff,10.10660117,8,98.79264417,0,0,0,0
+433,13811,81,Hay/Pasture,,13,Residential,Suburban,0.8,0.8,0.8,0.5,1,-1,-1,-1,1,0.15,low,#e5f5e0,22.75760842,6.8,99.54173609,1.6,0,0,0
+434,13812,81,Hay/Pasture,,13,Residential,Suburban,0.8,0.8,0.8,0.5,1,-1,-1,-1,2,0.4,medium,#a1d99b,43.84262051,4.8,100.7902226,4.266666667,0,0,0
+435,13813,81,Hay/Pasture,,13,Residential,Suburban,0.8,0.8,0.8,0.5,1,-1,-1,-1,3,0.66,high,#31a354,65.77103307,2.72,102.0886486,7.04,0,0,0
+436,13820,82,Cultivated Crops,,13,Residential,Suburban,0.8,0.8,0.8,-1,-1,-1,-1,-1,0,0,none,#ffffff,4.793840162,0,65.75263422,0,0,0,0
+437,13821,82,Cultivated Crops,,13,Residential,Suburban,0.8,0.8,0.8,-1,-1,-1,-1,-1,1,0.15,low,#e5f5e0,18.24176156,0,71.45772764,1.6,0,0,0
+438,13822,82,Cultivated Crops,,13,Residential,Suburban,0.8,0.8,0.8,-1,-1,-1,-1,-1,2,0.4,medium,#a1d99b,40.6549639,0,80.96621666,4.266666667,0,0,0
+439,13823,82,Cultivated Crops,,13,Residential,Suburban,0.8,0.8,0.8,-1,-1,-1,-1,-1,3,0.66,high,#31a354,63.96469433,0,90.85504525,7.04,0,0,0
+440,13900,90,Woody Wetlands,,13,Residential,Suburban,0.8,0.8,-1,-1,1,-1,-1,-1,0,0,none,#ffffff,33.5,0,259,0,0,0,0
+441,13901,90,Woody Wetlands,,13,Residential,Suburban,0.8,0.8,-1,-1,1,-1,-1,-1,1,0.15,low,#e5f5e0,42.64199743,0,235.7179885,1.6,0,0,0
+442,13902,90,Woody Wetlands,,13,Residential,Suburban,0.8,0.8,-1,-1,1,-1,-1,-1,2,0.4,medium,#a1d99b,57.8786598,0,196.9146361,4.266666667,0,0,0
+443,13903,90,Woody Wetlands,,13,Residential,Suburban,0.8,0.8,-1,-1,1,-1,-1,-1,3,0.66,high,#31a354,73.72478868,0,156.5591496,7.04,0,0,0
+444,13950,95,Emergent Herbaceuous Wetlands,,13,Residential,Suburban,0.8,0.8,-1,-1,1,-1,-1,-1,0,0,none,#ffffff,33.5,0,259,0,0,0,0
+445,13951,95,Emergent Herbaceuous Wetlands,,13,Residential,Suburban,0.8,0.8,-1,-1,1,-1,-1,-1,1,0.15,low,#e5f5e0,42.64199743,0,235.7179885,1.6,0,0,0
+446,13952,95,Emergent Herbaceuous Wetlands,,13,Residential,Suburban,0.8,0.8,-1,-1,1,-1,-1,-1,2,0.4,medium,#a1d99b,57.8786598,0,196.9146361,4.266666667,0,0,0
+447,13953,95,Emergent Herbaceuous Wetlands,,13,Residential,Suburban,0.8,0.8,-1,-1,1,-1,-1,-1,3,0.66,high,#31a354,73.72478868,0,156.5591496,7.04,0,0,0
+448,14110,11,Open Water,,14,Residential,Exurban,-1,-1,-1,-1,-1,-1,-1,-1,0,0,none,#ffffff,0,0,0,0,0,0,0
+449,14111,11,Open Water,,14,Residential,Exurban,-1,-1,-1,-1,-1,-1,-1,-1,1,0.15,low,#e5f5e0,14.16699743,0,15.56798855,1.6,0,0,0
+450,14112,11,Open Water,,14,Residential,Exurban,-1,-1,-1,-1,-1,-1,-1,-1,2,0.4,medium,#a1d99b,37.7786598,0,41.51463613,4.266666667,0,0,0
+451,14113,11,Open Water,,14,Residential,Exurban,-1,-1,-1,-1,-1,-1,-1,-1,3,0.66,high,#31a354,62.33478868,0,68.49914961,7.04,0,0,0
+452,14120,12,Perennial Ice/Snow,,14,Residential,Exurban,-1,-1,-1,-1,-1,-1,-1,-1,0,0,none,#ffffff,0,0,0,0,0,0,0
+453,14121,12,Perennial Ice/Snow,,14,Residential,Exurban,-1,-1,-1,-1,-1,-1,-1,-1,1,0.15,low,#e5f5e0,14.16699743,0,15.56798855,1.6,0,0,0
+454,14122,12,Perennial Ice/Snow,,14,Residential,Exurban,-1,-1,-1,-1,-1,-1,-1,-1,2,0.4,medium,#a1d99b,37.7786598,0,41.51463613,4.266666667,0,0,0
+455,14123,12,Perennial Ice/Snow,,14,Residential,Exurban,-1,-1,-1,-1,-1,-1,-1,-1,3,0.66,high,#31a354,62.33478868,0,68.49914961,7.04,0,0,0
+456,14210,21,"Developed, Open Space","20% trees, 60% grass, and 10% buildings and 10% bare soil",14,Residential,Exurban,0.6,0.6,0.6,0.7,0.8,-1,-1,-1,0,0,none,#ffffff,25.49986095,4.08,79.01411479,1.76,51.81402439,212.31,37.03522039
+457,14211,21,"Developed, Open Space","20% trees, 60% grass, and 10% buildings and 10% bare soil",14,Residential,Exurban,0.6,0.6,0.6,0.7,0.8,-1,-1,-1,1,0.15,low,#e5f5e0,35.84187923,3.468,82.72998612,3.096,51.81402439,212.31,37.03522039
+458,14212,21,"Developed, Open Space","20% trees, 60% grass, and 10% buildings and 10% bare soil",14,Residential,Exurban,0.6,0.6,0.6,0.7,0.8,-1,-1,-1,2,0.4,medium,#a1d99b,53.07857637,2.448,88.923105,5.322666667,51.81402439,212.31,37.03522039
+459,14213,21,"Developed, Open Space","20% trees, 60% grass, and 10% buildings and 10% bare soil",14,Residential,Exurban,0.6,0.6,0.6,0.7,0.8,-1,-1,-1,3,0.66,high,#31a354,71.0047414,1.3872,95.36394864,7.6384,51.81402439,212.31,37.03522039
+460,14220,22,"Developed, Low Intensity","20% trees, 40% grass, and 40% buildings",14,Residential,Exurban,0.6,0.6,0.6,0.7,0.8,-1,-1,-1,0,0,none,#ffffff,20.90844667,3.52,72.06732319,0.61,207.2560976,849.24,147.1338816
+461,14221,22,"Developed, Low Intensity","20% trees, 40% grass, and 40% buildings",14,Residential,Exurban,0.6,0.6,0.6,0.7,0.8,-1,-1,-1,1,0.15,low,#e5f5e0,31.9391771,2.992,76.82521326,2.1185,207.2560976,849.24,147.1338816
+462,14222,22,"Developed, Low Intensity","20% trees, 40% grass, and 40% buildings",14,Residential,Exurban,0.6,0.6,0.6,0.7,0.8,-1,-1,-1,2,0.4,medium,#a1d99b,50.32372781,2.112,84.75503004,4.632666667,207.2560976,849.24,147.1338816
+463,14223,22,"Developed, Low Intensity","20% trees, 40% grass, and 40% buildings",14,Residential,Exurban,0.6,0.6,0.6,0.7,0.8,-1,-1,-1,3,0.66,high,#31a354,69.44366054,1.1968,93.0020395,7.2474,207.2560976,849.24,147.1338816
+464,14230,23,"Developed, Medium Intensity","15% trees, 35% grass, and 50% buildings",14,Residential,Exurban,0.6,0.6,0.6,0.7,0.8,-1,-1,-1,0,0,none,#ffffff,17.69813636,3.08,61.93838294,0.36,234.070122,954.85,720.4716833
+465,14231,23,"Developed, Medium Intensity","15% trees, 35% grass, and 50% buildings",14,Residential,Exurban,0.6,0.6,0.6,0.7,0.8,-1,-1,-1,1,0.15,low,#e5f5e0,29.21041333,2.618,68.21561405,1.906,234.070122,954.85,720.4716833
+466,14232,23,"Developed, Medium Intensity","15% trees, 35% grass, and 50% buildings",14,Residential,Exurban,0.6,0.6,0.6,0.7,0.8,-1,-1,-1,2,0.4,medium,#a1d99b,48.39754162,1.848,78.67766589,4.482666667,234.070122,954.85,720.4716833
+467,14233,23,"Developed, Medium Intensity","15% trees, 35% grass, and 50% buildings",14,Residential,Exurban,0.6,0.6,0.6,0.7,0.8,-1,-1,-1,3,0.66,high,#31a354,68.35215504,1.0472,89.55819981,7.1624,234.070122,954.85,720.4716833
+468,14240,24,"Developed, High Intensity","10% trees, 20% grass, and 70% buildings",14,Residential,Exurban,0.6,0.6,0.6,0.7,0.8,-1,-1,-1,0,0,none,#ffffff,10.98142029,1.76,44.78642515,0.245,267.9065041,3418.485,1805.616283
+469,14241,24,"Developed, High Intensity","10% trees, 20% grass, and 70% buildings",14,Residential,Exurban,0.6,0.6,0.6,0.7,0.8,-1,-1,-1,1,0.15,low,#e5f5e0,23.50120467,1.496,53.63644993,1.80825,267.9065041,3418.485,1805.616283
+470,14242,24,"Developed, High Intensity","10% trees, 20% grass, and 70% buildings",14,Residential,Exurban,0.6,0.6,0.6,0.7,0.8,-1,-1,-1,2,0.4,medium,#a1d99b,44.36751198,1.056,68.38649122,4.413666667,267.9065041,3418.485,1805.616283
+471,14243,24,"Developed, High Intensity","10% trees, 20% grass, and 70% buildings",14,Residential,Exurban,0.6,0.6,0.6,0.7,0.8,-1,-1,-1,3,0.66,high,#31a354,66.06847158,0.5984,83.72653416,7.1233,267.9065041,3418.485,1805.616283
+472,14310,31,Barren Land,,14,Residential,Exurban,0.6,0.6,0.6,0.7,0.8,-1,-1,-1,0,0,none,#ffffff,6.8,0,25.5,0,0,0,0
+473,14311,31,Barren Land,,14,Residential,Exurban,0.6,0.6,0.6,0.7,0.8,-1,-1,-1,1,0.15,low,#e5f5e0,19.94699743,0,37.24298855,1.6,0,0,0
+474,14312,31,Barren Land,,14,Residential,Exurban,0.6,0.6,0.6,0.7,0.8,-1,-1,-1,2,0.4,medium,#a1d99b,41.8586598,0,56.81463613,4.266666667,0,0,0
+475,14313,31,Barren Land,,14,Residential,Exurban,0.6,0.6,0.6,0.7,0.8,-1,-1,-1,3,0.66,high,#31a354,64.64678868,0,77.16914961,7.04,0,0,0
+476,14410,41,Deciduous Forest,,14,Residential,Exurban,-1,0.6,-1,-1,0.8,-1,-1,-1,0,0,none,#ffffff,85.88498714,0,96.08994273,8.8,0,0,0
+477,14411,41,Deciduous Forest,,14,Residential,Exurban,-1,0.6,-1,-1,0.8,-1,-1,-1,1,0.15,low,#e5f5e0,85.88498714,0,96.08994273,8.8,0,0,0
+478,14412,41,Deciduous Forest,,14,Residential,Exurban,-1,0.6,-1,-1,0.8,-1,-1,-1,2,0.4,medium,#a1d99b,85.88498714,0,96.08994273,8.8,0,0,0
+479,14413,41,Deciduous Forest,,14,Residential,Exurban,-1,0.6,-1,-1,0.8,-1,-1,-1,3,0.66,high,#31a354,85.88498714,0,96.08994273,8.8,0,0,0
+480,14420,42,Evergreen Forest,,14,Residential,Exurban,-1,0.6,-1,-1,0.8,-1,-1,-1,0,0,none,#ffffff,105.6849871,0,96.08994273,14.4,0,0,0
+481,14421,42,Evergreen Forest,,14,Residential,Exurban,-1,0.6,-1,-1,0.8,-1,-1,-1,1,0.15,low,#e5f5e0,105.6849871,0,96.08994273,14.4,0,0,0
+482,14422,42,Evergreen Forest,,14,Residential,Exurban,-1,0.6,-1,-1,0.8,-1,-1,-1,2,0.4,medium,#a1d99b,105.6849871,0,96.08994273,14.4,0,0,0
+483,14423,42,Evergreen Forest,,14,Residential,Exurban,-1,0.6,-1,-1,0.8,-1,-1,-1,3,0.66,high,#31a354,105.6849871,0,96.08994273,14.4,0,0,0
+484,14430,43,Mixed Forest,,14,Residential,Exurban,-1,0.6,-1,-1,0.8,-1,-1,-1,0,0,none,#ffffff,91.76997429,0,119.1798855,8.8,0,0,0
+485,14431,43,Mixed Forest,,14,Residential,Exurban,-1,0.6,-1,-1,0.8,-1,-1,-1,1,0.15,low,#e5f5e0,91.76997429,0,119.1798855,8.8,0,0,0
+486,14432,43,Mixed Forest,,14,Residential,Exurban,-1,0.6,-1,-1,0.8,-1,-1,-1,2,0.4,medium,#a1d99b,91.76997429,0,119.1798855,8.8,0,0,0
+487,14433,43,Mixed Forest,,14,Residential,Exurban,-1,0.6,-1,-1,0.8,-1,-1,-1,3,0.66,high,#31a354,91.76997429,0,119.1798855,8.8,0,0,0
+488,14520,52,Shrub/Scrub,,14,Residential,Exurban,0.6,0.6,0.6,0.7,0.8,-1,-1,-1,0,0,none,#ffffff,47.875,0,68.15477645,0,0,0,0
+489,14521,52,Shrub/Scrub,,14,Residential,Exurban,0.6,0.6,0.6,0.7,0.8,-1,-1,-1,1,0.15,low,#e5f5e0,54.86074743,0,73.49954853,1.6,0,0,0
+490,14522,52,Shrub/Scrub,,14,Residential,Exurban,0.6,0.6,0.6,0.7,0.8,-1,-1,-1,2,0.4,medium,#a1d99b,66.5036598,0,82.407502,4.266666667,0,0,0
+491,14523,52,Shrub/Scrub,,14,Residential,Exurban,0.6,0.6,0.6,0.7,0.8,-1,-1,-1,3,0.66,high,#31a354,78.61228868,0,91.6717736,7.04,0,0,0
+492,14710,71,Herbaceuous,,14,Residential,Exurban,0.6,0.6,0.6,0.7,0.8,-1,-1,-1,0,0,none,#ffffff,10.10660117,8,98.79264417,0,0,0,0
+493,14711,71,Herbaceuous,,14,Residential,Exurban,0.6,0.6,0.6,0.7,0.8,-1,-1,-1,1,0.15,low,#e5f5e0,22.75760842,6.8,99.54173609,1.6,0,0,0
+494,14712,71,Herbaceuous,,14,Residential,Exurban,0.6,0.6,0.6,0.7,0.8,-1,-1,-1,2,0.4,medium,#a1d99b,43.84262051,4.8,100.7902226,4.266666667,0,0,0
+495,14713,71,Herbaceuous,,14,Residential,Exurban,0.6,0.6,0.6,0.7,0.8,-1,-1,-1,3,0.66,high,#31a354,65.77103307,2.72,102.0886486,7.04,0,0,0
+496,14810,81,Hay/Pasture,,14,Residential,Exurban,0.6,0.6,0.6,0.7,0.8,-1,-1,-1,0,0,none,#ffffff,10.10660117,8,98.79264417,0,0,0,0
+497,14811,81,Hay/Pasture,,14,Residential,Exurban,0.6,0.6,0.6,0.7,0.8,-1,-1,-1,1,0.15,low,#e5f5e0,22.75760842,6.8,99.54173609,1.6,0,0,0
+498,14812,81,Hay/Pasture,,14,Residential,Exurban,0.6,0.6,0.6,0.7,0.8,-1,-1,-1,2,0.4,medium,#a1d99b,43.84262051,4.8,100.7902226,4.266666667,0,0,0
+499,14813,81,Hay/Pasture,,14,Residential,Exurban,0.6,0.6,0.6,0.7,0.8,-1,-1,-1,3,0.66,high,#31a354,65.77103307,2.72,102.0886486,7.04,0,0,0
+500,14820,82,Cultivated Crops,,14,Residential,Exurban,0.6,0.6,0.6,-1,-1,-1,-1,-1,0,0,none,#ffffff,4.793840162,0,65.75263422,0,0,0,0
+501,14821,82,Cultivated Crops,,14,Residential,Exurban,0.6,0.6,0.6,-1,-1,-1,-1,-1,1,0.15,low,#e5f5e0,18.24176156,0,71.45772764,1.6,0,0,0
+502,14822,82,Cultivated Crops,,14,Residential,Exurban,0.6,0.6,0.6,-1,-1,-1,-1,-1,2,0.4,medium,#a1d99b,40.6549639,0,80.96621666,4.266666667,0,0,0
+503,14823,82,Cultivated Crops,,14,Residential,Exurban,0.6,0.6,0.6,-1,-1,-1,-1,-1,3,0.66,high,#31a354,63.96469433,0,90.85504525,7.04,0,0,0
+504,14900,90,Woody Wetlands,,14,Residential,Exurban,0.6,0.6,-1,-1,0.8,-1,-1,-1,0,0,none,#ffffff,33.5,0,259,0,0,0,0
+505,14901,90,Woody Wetlands,,14,Residential,Exurban,0.6,0.6,-1,-1,0.8,-1,-1,-1,1,0.15,low,#e5f5e0,42.64199743,0,235.7179885,1.6,0,0,0
+506,14902,90,Woody Wetlands,,14,Residential,Exurban,0.6,0.6,-1,-1,0.8,-1,-1,-1,2,0.4,medium,#a1d99b,57.8786598,0,196.9146361,4.266666667,0,0,0
+507,14903,90,Woody Wetlands,,14,Residential,Exurban,0.6,0.6,-1,-1,0.8,-1,-1,-1,3,0.66,high,#31a354,73.72478868,0,156.5591496,7.04,0,0,0
+508,14950,95,Emergent Herbaceuous Wetlands,,14,Residential,Exurban,0.6,0.6,-1,-1,0.8,-1,-1,-1,0,0,none,#ffffff,33.5,0,259,0,0,0,0
+509,14951,95,Emergent Herbaceuous Wetlands,,14,Residential,Exurban,0.6,0.6,-1,-1,0.8,-1,-1,-1,1,0.15,low,#e5f5e0,42.64199743,0,235.7179885,1.6,0,0,0
+510,14952,95,Emergent Herbaceuous Wetlands,,14,Residential,Exurban,0.6,0.6,-1,-1,0.8,-1,-1,-1,2,0.4,medium,#a1d99b,57.8786598,0,196.9146361,4.266666667,0,0,0
+511,14953,95,Emergent Herbaceuous Wetlands,,14,Residential,Exurban,0.6,0.6,-1,-1,0.8,-1,-1,-1,3,0.66,high,#31a354,73.72478868,0,156.5591496,7.04,0,0,0
+512,15110,11,Open Water,,15,Residential,Rural,-1,-1,-1,-1,-1,-1,-1,-1,0,0,none,#ffffff,0,0,0,0,0,0,0
+513,15111,11,Open Water,,15,Residential,Rural,-1,-1,-1,-1,-1,-1,-1,-1,1,0.15,low,#e5f5e0,14.16699743,0,15.56798855,1.6,0,0,0
+514,15112,11,Open Water,,15,Residential,Rural,-1,-1,-1,-1,-1,-1,-1,-1,2,0.4,medium,#a1d99b,37.7786598,0,41.51463613,4.266666667,0,0,0
+515,15113,11,Open Water,,15,Residential,Rural,-1,-1,-1,-1,-1,-1,-1,-1,3,0.66,high,#31a354,62.33478868,0,68.49914961,7.04,0,0,0
+516,15120,12,Perennial Ice/Snow,,15,Residential,Rural,-1,-1,-1,-1,-1,-1,-1,-1,0,0,none,#ffffff,0,0,0,0,0,0,0
+517,15121,12,Perennial Ice/Snow,,15,Residential,Rural,-1,-1,-1,-1,-1,-1,-1,-1,1,0.15,low,#e5f5e0,14.16699743,0,15.56798855,1.6,0,0,0
+518,15122,12,Perennial Ice/Snow,,15,Residential,Rural,-1,-1,-1,-1,-1,-1,-1,-1,2,0.4,medium,#a1d99b,37.7786598,0,41.51463613,4.266666667,0,0,0
+519,15123,12,Perennial Ice/Snow,,15,Residential,Rural,-1,-1,-1,-1,-1,-1,-1,-1,3,0.66,high,#31a354,62.33478868,0,68.49914961,7.04,0,0,0
+520,15210,21,"Developed, Open Space","20% trees, 60% grass, and 10% buildings and 10% bare soil",15,Residential,Rural,0.4,0.4,0.4,0.9,0.6,-1,-1,-1,0,0,none,#ffffff,25.49986095,4.08,79.01411479,1.76,51.81402439,212.31,37.03522039
+521,15211,21,"Developed, Open Space","20% trees, 60% grass, and 10% buildings and 10% bare soil",15,Residential,Rural,0.4,0.4,0.4,0.9,0.6,-1,-1,-1,1,0.15,low,#e5f5e0,35.84187923,3.468,82.72998612,3.096,51.81402439,212.31,37.03522039
+522,15212,21,"Developed, Open Space","20% trees, 60% grass, and 10% buildings and 10% bare soil",15,Residential,Rural,0.4,0.4,0.4,0.9,0.6,-1,-1,-1,2,0.4,medium,#a1d99b,53.07857637,2.448,88.923105,5.322666667,51.81402439,212.31,37.03522039
+523,15213,21,"Developed, Open Space","20% trees, 60% grass, and 10% buildings and 10% bare soil",15,Residential,Rural,0.4,0.4,0.4,0.9,0.6,-1,-1,-1,3,0.66,high,#31a354,71.0047414,1.3872,95.36394864,7.6384,51.81402439,212.31,37.03522039
+524,15220,22,"Developed, Low Intensity","20% trees, 40% grass, and 40% buildings",15,Residential,Rural,0.4,0.4,0.4,0.9,0.6,-1,-1,-1,0,0,none,#ffffff,20.90844667,3.52,72.06732319,0.61,207.2560976,849.24,147.1338816
+525,15221,22,"Developed, Low Intensity","20% trees, 40% grass, and 40% buildings",15,Residential,Rural,0.4,0.4,0.4,0.9,0.6,-1,-1,-1,1,0.15,low,#e5f5e0,31.9391771,2.992,76.82521326,2.1185,207.2560976,849.24,147.1338816
+526,15222,22,"Developed, Low Intensity","20% trees, 40% grass, and 40% buildings",15,Residential,Rural,0.4,0.4,0.4,0.9,0.6,-1,-1,-1,2,0.4,medium,#a1d99b,50.32372781,2.112,84.75503004,4.632666667,207.2560976,849.24,147.1338816
+527,15223,22,"Developed, Low Intensity","20% trees, 40% grass, and 40% buildings",15,Residential,Rural,0.4,0.4,0.4,0.9,0.6,-1,-1,-1,3,0.66,high,#31a354,69.44366054,1.1968,93.0020395,7.2474,207.2560976,849.24,147.1338816
+528,15230,23,"Developed, Medium Intensity","15% trees, 35% grass, and 50% buildings",15,Residential,Rural,0.4,0.4,0.4,0.9,0.6,-1,-1,-1,0,0,none,#ffffff,17.69813636,3.08,61.93838294,0.36,234.070122,954.85,720.4716833
+529,15231,23,"Developed, Medium Intensity","15% trees, 35% grass, and 50% buildings",15,Residential,Rural,0.4,0.4,0.4,0.9,0.6,-1,-1,-1,1,0.15,low,#e5f5e0,29.21041333,2.618,68.21561405,1.906,234.070122,954.85,720.4716833
+530,15232,23,"Developed, Medium Intensity","15% trees, 35% grass, and 50% buildings",15,Residential,Rural,0.4,0.4,0.4,0.9,0.6,-1,-1,-1,2,0.4,medium,#a1d99b,48.39754162,1.848,78.67766589,4.482666667,234.070122,954.85,720.4716833
+531,15233,23,"Developed, Medium Intensity","15% trees, 35% grass, and 50% buildings",15,Residential,Rural,0.4,0.4,0.4,0.9,0.6,-1,-1,-1,3,0.66,high,#31a354,68.35215504,1.0472,89.55819981,7.1624,234.070122,954.85,720.4716833
+532,15240,24,"Developed, High Intensity","10% trees, 20% grass, and 70% buildings",15,Residential,Rural,0.4,0.4,0.4,0.9,0.6,-1,-1,-1,0,0,none,#ffffff,10.98142029,1.76,44.78642515,0.245,267.9065041,3418.485,1805.616283
+533,15241,24,"Developed, High Intensity","10% trees, 20% grass, and 70% buildings",15,Residential,Rural,0.4,0.4,0.4,0.9,0.6,-1,-1,-1,1,0.15,low,#e5f5e0,23.50120467,1.496,53.63644993,1.80825,267.9065041,3418.485,1805.616283
+534,15242,24,"Developed, High Intensity","10% trees, 20% grass, and 70% buildings",15,Residential,Rural,0.4,0.4,0.4,0.9,0.6,-1,-1,-1,2,0.4,medium,#a1d99b,44.36751198,1.056,68.38649122,4.413666667,267.9065041,3418.485,1805.616283
+535,15243,24,"Developed, High Intensity","10% trees, 20% grass, and 70% buildings",15,Residential,Rural,0.4,0.4,0.4,0.9,0.6,-1,-1,-1,3,0.66,high,#31a354,66.06847158,0.5984,83.72653416,7.1233,267.9065041,3418.485,1805.616283
+536,15310,31,Barren Land,,15,Residential,Rural,0.4,0.4,0.4,0.9,0.6,-1,-1,-1,0,0,none,#ffffff,6.8,0,25.5,0,0,0,0
+537,15311,31,Barren Land,,15,Residential,Rural,0.4,0.4,0.4,0.9,0.6,-1,-1,-1,1,0.15,low,#e5f5e0,19.94699743,0,37.24298855,1.6,0,0,0
+538,15312,31,Barren Land,,15,Residential,Rural,0.4,0.4,0.4,0.9,0.6,-1,-1,-1,2,0.4,medium,#a1d99b,41.8586598,0,56.81463613,4.266666667,0,0,0
+539,15313,31,Barren Land,,15,Residential,Rural,0.4,0.4,0.4,0.9,0.6,-1,-1,-1,3,0.66,high,#31a354,64.64678868,0,77.16914961,7.04,0,0,0
+540,15410,41,Deciduous Forest,,15,Residential,Rural,-1,0.4,-1,-1,0.6,-1,-1,-1,0,0,none,#ffffff,85.88498714,0,96.08994273,8.8,0,0,0
+541,15411,41,Deciduous Forest,,15,Residential,Rural,-1,0.4,-1,-1,0.6,-1,-1,-1,1,0.15,low,#e5f5e0,85.88498714,0,96.08994273,8.8,0,0,0
+542,15412,41,Deciduous Forest,,15,Residential,Rural,-1,0.4,-1,-1,0.6,-1,-1,-1,2,0.4,medium,#a1d99b,85.88498714,0,96.08994273,8.8,0,0,0
+543,15413,41,Deciduous Forest,,15,Residential,Rural,-1,0.4,-1,-1,0.6,-1,-1,-1,3,0.66,high,#31a354,85.88498714,0,96.08994273,8.8,0,0,0
+544,15420,42,Evergreen Forest,,15,Residential,Rural,-1,0.4,-1,-1,0.6,-1,-1,-1,0,0,none,#ffffff,105.6849871,0,96.08994273,14.4,0,0,0
+545,15421,42,Evergreen Forest,,15,Residential,Rural,-1,0.4,-1,-1,0.6,-1,-1,-1,1,0.15,low,#e5f5e0,105.6849871,0,96.08994273,14.4,0,0,0
+546,15422,42,Evergreen Forest,,15,Residential,Rural,-1,0.4,-1,-1,0.6,-1,-1,-1,2,0.4,medium,#a1d99b,105.6849871,0,96.08994273,14.4,0,0,0
+547,15423,42,Evergreen Forest,,15,Residential,Rural,-1,0.4,-1,-1,0.6,-1,-1,-1,3,0.66,high,#31a354,105.6849871,0,96.08994273,14.4,0,0,0
+548,15430,43,Mixed Forest,,15,Residential,Rural,-1,0.4,-1,-1,0.6,-1,-1,-1,0,0,none,#ffffff,91.76997429,0,119.1798855,8.8,0,0,0
+549,15431,43,Mixed Forest,,15,Residential,Rural,-1,0.4,-1,-1,0.6,-1,-1,-1,1,0.15,low,#e5f5e0,91.76997429,0,119.1798855,8.8,0,0,0
+550,15432,43,Mixed Forest,,15,Residential,Rural,-1,0.4,-1,-1,0.6,-1,-1,-1,2,0.4,medium,#a1d99b,91.76997429,0,119.1798855,8.8,0,0,0
+551,15433,43,Mixed Forest,,15,Residential,Rural,-1,0.4,-1,-1,0.6,-1,-1,-1,3,0.66,high,#31a354,91.76997429,0,119.1798855,8.8,0,0,0
+552,15520,52,Shrub/Scrub,,15,Residential,Rural,0.4,0.4,0.4,0.9,0.6,-1,-1,-1,0,0,none,#ffffff,47.875,0,68.15477645,0,0,0,0
+553,15521,52,Shrub/Scrub,,15,Residential,Rural,0.4,0.4,0.4,0.9,0.6,-1,-1,-1,1,0.15,low,#e5f5e0,54.86074743,0,73.49954853,1.6,0,0,0
+554,15522,52,Shrub/Scrub,,15,Residential,Rural,0.4,0.4,0.4,0.9,0.6,-1,-1,-1,2,0.4,medium,#a1d99b,66.5036598,0,82.407502,4.266666667,0,0,0
+555,15523,52,Shrub/Scrub,,15,Residential,Rural,0.4,0.4,0.4,0.9,0.6,-1,-1,-1,3,0.66,high,#31a354,78.61228868,0,91.6717736,7.04,0,0,0
+556,15710,71,Herbaceuous,,15,Residential,Rural,0.4,0.4,0.4,0.9,0.6,-1,-1,-1,0,0,none,#ffffff,10.10660117,8,98.79264417,0,0,0,0
+557,15711,71,Herbaceuous,,15,Residential,Rural,0.4,0.4,0.4,0.9,0.6,-1,-1,-1,1,0.15,low,#e5f5e0,22.75760842,6.8,99.54173609,1.6,0,0,0
+558,15712,71,Herbaceuous,,15,Residential,Rural,0.4,0.4,0.4,0.9,0.6,-1,-1,-1,2,0.4,medium,#a1d99b,43.84262051,4.8,100.7902226,4.266666667,0,0,0
+559,15713,71,Herbaceuous,,15,Residential,Rural,0.4,0.4,0.4,0.9,0.6,-1,-1,-1,3,0.66,high,#31a354,65.77103307,2.72,102.0886486,7.04,0,0,0
+560,15810,81,Hay/Pasture,,15,Residential,Rural,0.4,0.4,0.4,0.9,0.6,-1,-1,-1,0,0,none,#ffffff,10.10660117,8,98.79264417,0,0,0,0
+561,15811,81,Hay/Pasture,,15,Residential,Rural,0.4,0.4,0.4,0.9,0.6,-1,-1,-1,1,0.15,low,#e5f5e0,22.75760842,6.8,99.54173609,1.6,0,0,0
+562,15812,81,Hay/Pasture,,15,Residential,Rural,0.4,0.4,0.4,0.9,0.6,-1,-1,-1,2,0.4,medium,#a1d99b,43.84262051,4.8,100.7902226,4.266666667,0,0,0
+563,15813,81,Hay/Pasture,,15,Residential,Rural,0.4,0.4,0.4,0.9,0.6,-1,-1,-1,3,0.66,high,#31a354,65.77103307,2.72,102.0886486,7.04,0,0,0
+564,15820,82,Cultivated Crops,,15,Residential,Rural,0.4,0.4,0.4,-1,-1,-1,-1,-1,0,0,none,#ffffff,4.793840162,0,65.75263422,0,0,0,0
+565,15821,82,Cultivated Crops,,15,Residential,Rural,0.4,0.4,0.4,-1,-1,-1,-1,-1,1,0.15,low,#e5f5e0,18.24176156,0,71.45772764,1.6,0,0,0
+566,15822,82,Cultivated Crops,,15,Residential,Rural,0.4,0.4,0.4,-1,-1,-1,-1,-1,2,0.4,medium,#a1d99b,40.6549639,0,80.96621666,4.266666667,0,0,0
+567,15823,82,Cultivated Crops,,15,Residential,Rural,0.4,0.4,0.4,-1,-1,-1,-1,-1,3,0.66,high,#31a354,63.96469433,0,90.85504525,7.04,0,0,0
+568,15900,90,Woody Wetlands,,15,Residential,Rural,0.4,0.4,-1,-1,0.6,-1,-1,-1,0,0,none,#ffffff,33.5,0,259,0,0,0,0
+569,15901,90,Woody Wetlands,,15,Residential,Rural,0.4,0.4,-1,-1,0.6,-1,-1,-1,1,0.15,low,#e5f5e0,42.64199743,0,235.7179885,1.6,0,0,0
+570,15902,90,Woody Wetlands,,15,Residential,Rural,0.4,0.4,-1,-1,0.6,-1,-1,-1,2,0.4,medium,#a1d99b,57.8786598,0,196.9146361,4.266666667,0,0,0
+571,15903,90,Woody Wetlands,,15,Residential,Rural,0.4,0.4,-1,-1,0.6,-1,-1,-1,3,0.66,high,#31a354,73.72478868,0,156.5591496,7.04,0,0,0
+572,15950,95,Emergent Herbaceuous Wetlands,,15,Residential,Rural,0.4,0.4,-1,-1,0.6,-1,-1,-1,0,0,none,#ffffff,33.5,0,259,0,0,0,0
+573,15951,95,Emergent Herbaceuous Wetlands,,15,Residential,Rural,0.4,0.4,-1,-1,0.6,-1,-1,-1,1,0.15,low,#e5f5e0,42.64199743,0,235.7179885,1.6,0,0,0
+574,15952,95,Emergent Herbaceuous Wetlands,,15,Residential,Rural,0.4,0.4,-1,-1,0.6,-1,-1,-1,2,0.4,medium,#a1d99b,57.8786598,0,196.9146361,4.266666667,0,0,0
+575,15953,95,Emergent Herbaceuous Wetlands,,15,Residential,Rural,0.4,0.4,-1,-1,0.6,-1,-1,-1,3,0.66,high,#31a354,73.72478868,0,156.5591496,7.04,0,0,0
+576,20110,11,Open Water,,20,Commercial,,-1,-1,-1,-1,-1,0,-1,-1,0,0,none,#ffffff,0,0,0,0,0,0,0
+577,20111,11,Open Water,,20,Commercial,,-1,-1,-1,-1,-1,0,-1,-1,1,0.15,low,#e5f5e0,14.16699743,0,15.56798855,1.6,0,0,0
+578,20112,11,Open Water,,20,Commercial,,-1,-1,-1,-1,-1,0,-1,-1,2,0.4,medium,#a1d99b,37.7786598,0,41.51463613,4.266666667,0,0,0
+579,20113,11,Open Water,,20,Commercial,,-1,-1,-1,-1,-1,0,-1,-1,3,0.66,high,#31a354,62.33478868,0,68.49914961,7.04,0,0,0
+580,20120,12,Perennial Ice/Snow,,20,Commercial,,-1,-1,-1,-1,-1,-1,-1,-1,0,0,none,#ffffff,0,0,0,0,0,0,0
+581,20121,12,Perennial Ice/Snow,,20,Commercial,,-1,-1,-1,-1,-1,-1,-1,-1,1,0.15,low,#e5f5e0,14.16699743,0,15.56798855,1.6,0,0,0
+582,20122,12,Perennial Ice/Snow,,20,Commercial,,-1,-1,-1,-1,-1,-1,-1,-1,2,0.4,medium,#a1d99b,37.7786598,0,41.51463613,4.266666667,0,0,0
+583,20123,12,Perennial Ice/Snow,,20,Commercial,,-1,-1,-1,-1,-1,-1,-1,-1,3,0.66,high,#31a354,62.33478868,0,68.49914961,7.04,0,0,0
+584,20210,21,"Developed, Open Space","20% trees, 60% grass, and 10% buildings and 10% bare soil",20,Commercial,,0.6,0.6,0.6,0.1,1,0,-1,-1,0,0,none,#ffffff,25.49986095,4.08,79.01411479,1.76,51.81402439,212.31,37.03522039
+585,20211,21,"Developed, Open Space","20% trees, 60% grass, and 10% buildings and 10% bare soil",20,Commercial,,0.6,0.6,0.6,0.1,1,0,-1,-1,1,0.15,low,#e5f5e0,35.84187923,3.468,82.72998612,3.096,51.81402439,212.31,37.03522039
+586,20212,21,"Developed, Open Space","20% trees, 60% grass, and 10% buildings and 10% bare soil",20,Commercial,,0.6,0.6,0.6,0.1,1,0,-1,-1,2,0.4,medium,#a1d99b,53.07857637,2.448,88.923105,5.322666667,51.81402439,212.31,37.03522039
+587,20213,21,"Developed, Open Space","20% trees, 60% grass, and 10% buildings and 10% bare soil",20,Commercial,,0.6,0.6,0.6,0.1,1,0,-1,-1,3,0.66,high,#31a354,71.0047414,1.3872,95.36394864,7.6384,51.81402439,212.31,37.03522039
+588,20220,22,"Developed, Low Intensity","20% trees, 40% grass, and 40% buildings",20,Commercial,,0.6,0.6,0.6,0.1,1,-1,-1,-1,0,0,none,#ffffff,20.90844667,3.52,72.06732319,0.61,207.2560976,849.24,147.1338816
+589,20221,22,"Developed, Low Intensity","20% trees, 40% grass, and 40% buildings",20,Commercial,,0.6,0.6,0.6,0.1,1,-1,-1,-1,1,0.15,low,#e5f5e0,31.9391771,2.992,76.82521326,2.1185,207.2560976,849.24,147.1338816
+590,20222,22,"Developed, Low Intensity","20% trees, 40% grass, and 40% buildings",20,Commercial,,0.6,0.6,0.6,0.1,1,-1,-1,-1,2,0.4,medium,#a1d99b,50.32372781,2.112,84.75503004,4.632666667,207.2560976,849.24,147.1338816
+591,20223,22,"Developed, Low Intensity","20% trees, 40% grass, and 40% buildings",20,Commercial,,0.6,0.6,0.6,0.1,1,-1,-1,-1,3,0.66,high,#31a354,69.44366054,1.1968,93.0020395,7.2474,207.2560976,849.24,147.1338816
+592,20230,23,"Developed, Medium Intensity","15% trees, 35% grass, and 50% buildings",20,Commercial,,0.6,0.6,0.6,0.1,1,-1,-1,-1,0,0,none,#ffffff,17.69813636,3.08,61.93838294,0.36,234.070122,954.85,720.4716833
+593,20231,23,"Developed, Medium Intensity","15% trees, 35% grass, and 50% buildings",20,Commercial,,0.6,0.6,0.6,0.1,1,-1,-1,-1,1,0.15,low,#e5f5e0,29.21041333,2.618,68.21561405,1.906,234.070122,954.85,720.4716833
+594,20232,23,"Developed, Medium Intensity","15% trees, 35% grass, and 50% buildings",20,Commercial,,0.6,0.6,0.6,0.1,1,-1,-1,-1,2,0.4,medium,#a1d99b,48.39754162,1.848,78.67766589,4.482666667,234.070122,954.85,720.4716833
+595,20233,23,"Developed, Medium Intensity","15% trees, 35% grass, and 50% buildings",20,Commercial,,0.6,0.6,0.6,0.1,1,-1,-1,-1,3,0.66,high,#31a354,68.35215504,1.0472,89.55819981,7.1624,234.070122,954.85,720.4716833
+596,20240,24,"Developed, High Intensity","10% trees, 20% grass, and 70% buildings",20,Commercial,,0.6,0.6,0.6,0.1,1,-1,-1,-1,0,0,none,#ffffff,10.98142029,1.76,44.78642515,0.245,267.9065041,3418.485,1805.616283
+597,20241,24,"Developed, High Intensity","10% trees, 20% grass, and 70% buildings",20,Commercial,,0.6,0.6,0.6,0.1,1,-1,-1,-1,1,0.15,low,#e5f5e0,23.50120467,1.496,53.63644993,1.80825,267.9065041,3418.485,1805.616283
+598,20242,24,"Developed, High Intensity","10% trees, 20% grass, and 70% buildings",20,Commercial,,0.6,0.6,0.6,0.1,1,-1,-1,-1,2,0.4,medium,#a1d99b,44.36751198,1.056,68.38649122,4.413666667,267.9065041,3418.485,1805.616283
+599,20243,24,"Developed, High Intensity","10% trees, 20% grass, and 70% buildings",20,Commercial,,0.6,0.6,0.6,0.1,1,-1,-1,-1,3,0.66,high,#31a354,66.06847158,0.5984,83.72653416,7.1233,267.9065041,3418.485,1805.616283
+600,20310,31,Barren Land,,20,Commercial,,0.6,0.6,0.6,0.1,1,0,-1,-1,0,0,none,#ffffff,6.8,0,25.5,0,0,0,0
+601,20311,31,Barren Land,,20,Commercial,,0.6,0.6,0.6,0.1,1,0,-1,-1,1,0.15,low,#e5f5e0,19.94699743,0,37.24298855,1.6,0,0,0
+602,20312,31,Barren Land,,20,Commercial,,0.6,0.6,0.6,0.1,1,0,-1,-1,2,0.4,medium,#a1d99b,41.8586598,0,56.81463613,4.266666667,0,0,0
+603,20313,31,Barren Land,,20,Commercial,,0.6,0.6,0.6,0.1,1,0,-1,-1,3,0.66,high,#31a354,64.64678868,0,77.16914961,7.04,0,0,0
+604,20410,41,Deciduous Forest,,20,Commercial,,-1,0.6,-1,-1,1,0,-1,-1,0,0,none,#ffffff,85.88498714,0,96.08994273,8.8,0,0,0
+605,20411,41,Deciduous Forest,,20,Commercial,,-1,0.6,-1,-1,1,0,-1,-1,1,0.15,low,#e5f5e0,85.88498714,0,96.08994273,8.8,0,0,0
+606,20412,41,Deciduous Forest,,20,Commercial,,-1,0.6,-1,-1,1,0,-1,-1,2,0.4,medium,#a1d99b,85.88498714,0,96.08994273,8.8,0,0,0
+607,20413,41,Deciduous Forest,,20,Commercial,,-1,0.6,-1,-1,1,0,-1,-1,3,0.66,high,#31a354,85.88498714,0,96.08994273,8.8,0,0,0
+608,20420,42,Evergreen Forest,,20,Commercial,,-1,0.6,-1,-1,1,0,-1,-1,0,0,none,#ffffff,105.6849871,0,96.08994273,14.4,0,0,0
+609,20421,42,Evergreen Forest,,20,Commercial,,-1,0.6,-1,-1,1,0,-1,-1,1,0.15,low,#e5f5e0,105.6849871,0,96.08994273,14.4,0,0,0
+610,20422,42,Evergreen Forest,,20,Commercial,,-1,0.6,-1,-1,1,0,-1,-1,2,0.4,medium,#a1d99b,105.6849871,0,96.08994273,14.4,0,0,0
+611,20423,42,Evergreen Forest,,20,Commercial,,-1,0.6,-1,-1,1,0,-1,-1,3,0.66,high,#31a354,105.6849871,0,96.08994273,14.4,0,0,0
+612,20430,43,Mixed Forest,,20,Commercial,,-1,0.6,-1,-1,1,0,-1,-1,0,0,none,#ffffff,91.76997429,0,119.1798855,8.8,0,0,0
+613,20431,43,Mixed Forest,,20,Commercial,,-1,0.6,-1,-1,1,0,-1,-1,1,0.15,low,#e5f5e0,91.76997429,0,119.1798855,8.8,0,0,0
+614,20432,43,Mixed Forest,,20,Commercial,,-1,0.6,-1,-1,1,0,-1,-1,2,0.4,medium,#a1d99b,91.76997429,0,119.1798855,8.8,0,0,0
+615,20433,43,Mixed Forest,,20,Commercial,,-1,0.6,-1,-1,1,0,-1,-1,3,0.66,high,#31a354,91.76997429,0,119.1798855,8.8,0,0,0
+616,20520,52,Shrub/Scrub,,20,Commercial,,0.6,0.6,0.6,0.1,1,0,-1,-1,0,0,none,#ffffff,47.875,0,68.15477645,0,0,0,0
+617,20521,52,Shrub/Scrub,,20,Commercial,,0.6,0.6,0.6,0.1,1,0,-1,-1,1,0.15,low,#e5f5e0,54.86074743,0,73.49954853,1.6,0,0,0
+618,20522,52,Shrub/Scrub,,20,Commercial,,0.6,0.6,0.6,0.1,1,0,-1,-1,2,0.4,medium,#a1d99b,66.5036598,0,82.407502,4.266666667,0,0,0
+619,20523,52,Shrub/Scrub,,20,Commercial,,0.6,0.6,0.6,0.1,1,0,-1,-1,3,0.66,high,#31a354,78.61228868,0,91.6717736,7.04,0,0,0
+620,20710,71,Herbaceuous,,20,Commercial,,0.6,0.6,0.6,0.1,1,0,-1,-1,0,0,none,#ffffff,10.10660117,8,98.79264417,0,0,0,0
+621,20711,71,Herbaceuous,,20,Commercial,,0.6,0.6,0.6,0.1,1,0,-1,-1,1,0.15,low,#e5f5e0,22.75760842,6.8,99.54173609,1.6,0,0,0
+622,20712,71,Herbaceuous,,20,Commercial,,0.6,0.6,0.6,0.1,1,0,-1,-1,2,0.4,medium,#a1d99b,43.84262051,4.8,100.7902226,4.266666667,0,0,0
+623,20713,71,Herbaceuous,,20,Commercial,,0.6,0.6,0.6,0.1,1,0,-1,-1,3,0.66,high,#31a354,65.77103307,2.72,102.0886486,7.04,0,0,0
+624,20810,81,Hay/Pasture,,20,Commercial,,0.6,0.6,0.6,0.1,1,0,-1,-1,0,0,none,#ffffff,10.10660117,8,98.79264417,0,0,0,0
+625,20811,81,Hay/Pasture,,20,Commercial,,0.6,0.6,0.6,0.1,1,0,-1,-1,1,0.15,low,#e5f5e0,22.75760842,6.8,99.54173609,1.6,0,0,0
+626,20812,81,Hay/Pasture,,20,Commercial,,0.6,0.6,0.6,0.1,1,0,-1,-1,2,0.4,medium,#a1d99b,43.84262051,4.8,100.7902226,4.266666667,0,0,0
+627,20813,81,Hay/Pasture,,20,Commercial,,0.6,0.6,0.6,0.1,1,0,-1,-1,3,0.66,high,#31a354,65.77103307,2.72,102.0886486,7.04,0,0,0
+628,20820,82,Cultivated Crops,,20,Commercial,,0.6,0.6,0.6,-1,-1,0,-1,-1,0,0,none,#ffffff,4.793840162,0,65.75263422,0,0,0,0
+629,20821,82,Cultivated Crops,,20,Commercial,,0.6,0.6,0.6,-1,-1,0,-1,-1,1,0.15,low,#e5f5e0,18.24176156,0,71.45772764,1.6,0,0,0
+630,20822,82,Cultivated Crops,,20,Commercial,,0.6,0.6,0.6,-1,-1,0,-1,-1,2,0.4,medium,#a1d99b,40.6549639,0,80.96621666,4.266666667,0,0,0
+631,20823,82,Cultivated Crops,,20,Commercial,,0.6,0.6,0.6,-1,-1,0,-1,-1,3,0.66,high,#31a354,63.96469433,0,90.85504525,7.04,0,0,0
+632,20900,90,Woody Wetlands,,20,Commercial,,0.6,0.6,-1,-1,1,0,-1,-1,0,0,none,#ffffff,33.5,0,259,0,0,0,0
+633,20901,90,Woody Wetlands,,20,Commercial,,0.6,0.6,-1,-1,1,0,-1,-1,1,0.15,low,#e5f5e0,42.64199743,0,235.7179885,1.6,0,0,0
+634,20902,90,Woody Wetlands,,20,Commercial,,0.6,0.6,-1,-1,1,0,-1,-1,2,0.4,medium,#a1d99b,57.8786598,0,196.9146361,4.266666667,0,0,0
+635,20903,90,Woody Wetlands,,20,Commercial,,0.6,0.6,-1,-1,1,0,-1,-1,3,0.66,high,#31a354,73.72478868,0,156.5591496,7.04,0,0,0
+636,20950,95,Emergent Herbaceuous Wetlands,,20,Commercial,,0.6,0.6,-1,-1,1,0,-1,-1,0,0,none,#ffffff,33.5,0,259,0,0,0,0
+637,20951,95,Emergent Herbaceuous Wetlands,,20,Commercial,,0.6,0.6,-1,-1,1,0,-1,-1,1,0.15,low,#e5f5e0,42.64199743,0,235.7179885,1.6,0,0,0
+638,20952,95,Emergent Herbaceuous Wetlands,,20,Commercial,,0.6,0.6,-1,-1,1,0,-1,-1,2,0.4,medium,#a1d99b,57.8786598,0,196.9146361,4.266666667,0,0,0
+639,20953,95,Emergent Herbaceuous Wetlands,,20,Commercial,,0.6,0.6,-1,-1,1,0,-1,-1,3,0.66,high,#31a354,73.72478868,0,156.5591496,7.04,0,0,0
+640,30110,11,Open Water,,30,Industrial,,-1,-1,-1,-1,-1,0,-1,-1,0,0,none,#ffffff,0,0,0,0,0,0,0
+641,30111,11,Open Water,,30,Industrial,,-1,-1,-1,-1,-1,0,-1,-1,1,0.15,low,#e5f5e0,14.16699743,0,15.56798855,1.6,0,0,0
+642,30112,11,Open Water,,30,Industrial,,-1,-1,-1,-1,-1,0,-1,-1,2,0.4,medium,#a1d99b,37.7786598,0,41.51463613,4.266666667,0,0,0
+643,30113,11,Open Water,,30,Industrial,,-1,-1,-1,-1,-1,0,-1,-1,3,0.66,high,#31a354,62.33478868,0,68.49914961,7.04,0,0,0
+644,30120,12,Perennial Ice/Snow,,30,Industrial,,-1,-1,-1,-1,-1,-1,-1,-1,0,0,none,#ffffff,0,0,0,0,0,0,0
+645,30121,12,Perennial Ice/Snow,,30,Industrial,,-1,-1,-1,-1,-1,-1,-1,-1,1,0.15,low,#e5f5e0,14.16699743,0,15.56798855,1.6,0,0,0
+646,30122,12,Perennial Ice/Snow,,30,Industrial,,-1,-1,-1,-1,-1,-1,-1,-1,2,0.4,medium,#a1d99b,37.7786598,0,41.51463613,4.266666667,0,0,0
+647,30123,12,Perennial Ice/Snow,,30,Industrial,,-1,-1,-1,-1,-1,-1,-1,-1,3,0.66,high,#31a354,62.33478868,0,68.49914961,7.04,0,0,0
+648,30210,21,"Developed, Open Space","20% trees, 60% grass, and 10% buildings and 10% bare soil",30,Industrial,,0.1,0.1,0.1,0.1,0.2,0,-1,-1,0,0,none,#ffffff,25.49986095,4.08,79.01411479,1.76,51.81402439,212.31,37.03522039
+649,30211,21,"Developed, Open Space","20% trees, 60% grass, and 10% buildings and 10% bare soil",30,Industrial,,0.1,0.1,0.1,0.1,0.2,0,-1,-1,1,0.15,low,#e5f5e0,35.84187923,3.468,82.72998612,3.096,51.81402439,212.31,37.03522039
+650,30212,21,"Developed, Open Space","20% trees, 60% grass, and 10% buildings and 10% bare soil",30,Industrial,,0.1,0.1,0.1,0.1,0.2,0,-1,-1,2,0.4,medium,#a1d99b,53.07857637,2.448,88.923105,5.322666667,51.81402439,212.31,37.03522039
+651,30213,21,"Developed, Open Space","20% trees, 60% grass, and 10% buildings and 10% bare soil",30,Industrial,,0.1,0.1,0.1,0.1,0.2,0,-1,-1,3,0.66,high,#31a354,71.0047414,1.3872,95.36394864,7.6384,51.81402439,212.31,37.03522039
+652,30220,22,"Developed, Low Intensity","20% trees, 40% grass, and 40% buildings",30,Industrial,,0.1,0.1,0.1,0.1,0.2,-1,-1,-1,0,0,none,#ffffff,20.90844667,3.52,72.06732319,0.61,207.2560976,849.24,147.1338816
+653,30221,22,"Developed, Low Intensity","20% trees, 40% grass, and 40% buildings",30,Industrial,,0.1,0.1,0.1,0.1,0.2,-1,-1,-1,1,0.15,low,#e5f5e0,31.9391771,2.992,76.82521326,2.1185,207.2560976,849.24,147.1338816
+654,30222,22,"Developed, Low Intensity","20% trees, 40% grass, and 40% buildings",30,Industrial,,0.1,0.1,0.1,0.1,0.2,-1,-1,-1,2,0.4,medium,#a1d99b,50.32372781,2.112,84.75503004,4.632666667,207.2560976,849.24,147.1338816
+655,30223,22,"Developed, Low Intensity","20% trees, 40% grass, and 40% buildings",30,Industrial,,0.1,0.1,0.1,0.1,0.2,-1,-1,-1,3,0.66,high,#31a354,69.44366054,1.1968,93.0020395,7.2474,207.2560976,849.24,147.1338816
+656,30230,23,"Developed, Medium Intensity","15% trees, 35% grass, and 50% buildings",30,Industrial,,0.1,0.1,0.1,0.1,0.2,-1,-1,-1,0,0,none,#ffffff,17.69813636,3.08,61.93838294,0.36,234.070122,954.85,720.4716833
+657,30231,23,"Developed, Medium Intensity","15% trees, 35% grass, and 50% buildings",30,Industrial,,0.1,0.1,0.1,0.1,0.2,-1,-1,-1,1,0.15,low,#e5f5e0,29.21041333,2.618,68.21561405,1.906,234.070122,954.85,720.4716833
+658,30232,23,"Developed, Medium Intensity","15% trees, 35% grass, and 50% buildings",30,Industrial,,0.1,0.1,0.1,0.1,0.2,-1,-1,-1,2,0.4,medium,#a1d99b,48.39754162,1.848,78.67766589,4.482666667,234.070122,954.85,720.4716833
+659,30233,23,"Developed, Medium Intensity","15% trees, 35% grass, and 50% buildings",30,Industrial,,0.1,0.1,0.1,0.1,0.2,-1,-1,-1,3,0.66,high,#31a354,68.35215504,1.0472,89.55819981,7.1624,234.070122,954.85,720.4716833
+660,30240,24,"Developed, High Intensity","10% trees, 20% grass, and 70% buildings",30,Industrial,,0.1,0.1,0.1,0.1,0.2,-1,-1,-1,0,0,none,#ffffff,10.98142029,1.76,44.78642515,0.245,267.9065041,3418.485,1805.616283
+661,30241,24,"Developed, High Intensity","10% trees, 20% grass, and 70% buildings",30,Industrial,,0.1,0.1,0.1,0.1,0.2,-1,-1,-1,1,0.15,low,#e5f5e0,23.50120467,1.496,53.63644993,1.80825,267.9065041,3418.485,1805.616283
+662,30242,24,"Developed, High Intensity","10% trees, 20% grass, and 70% buildings",30,Industrial,,0.1,0.1,0.1,0.1,0.2,-1,-1,-1,2,0.4,medium,#a1d99b,44.36751198,1.056,68.38649122,4.413666667,267.9065041,3418.485,1805.616283
+663,30243,24,"Developed, High Intensity","10% trees, 20% grass, and 70% buildings",30,Industrial,,0.1,0.1,0.1,0.1,0.2,-1,-1,-1,3,0.66,high,#31a354,66.06847158,0.5984,83.72653416,7.1233,267.9065041,3418.485,1805.616283
+664,30310,31,Barren Land,,30,Industrial,,0.1,0.1,0.1,0.1,0.2,0,-1,-1,0,0,none,#ffffff,6.8,0,25.5,0,0,0,0
+665,30311,31,Barren Land,,30,Industrial,,0.1,0.1,0.1,0.1,0.2,0,-1,-1,1,0.15,low,#e5f5e0,19.94699743,0,37.24298855,1.6,0,0,0
+666,30312,31,Barren Land,,30,Industrial,,0.1,0.1,0.1,0.1,0.2,0,-1,-1,2,0.4,medium,#a1d99b,41.8586598,0,56.81463613,4.266666667,0,0,0
+667,30313,31,Barren Land,,30,Industrial,,0.1,0.1,0.1,0.1,0.2,0,-1,-1,3,0.66,high,#31a354,64.64678868,0,77.16914961,7.04,0,0,0
+668,30410,41,Deciduous Forest,,30,Industrial,,-1,0.1,-1,-1,0.2,0,-1,-1,0,0,none,#ffffff,85.88498714,0,96.08994273,8.8,0,0,0
+669,30411,41,Deciduous Forest,,30,Industrial,,-1,0.1,-1,-1,0.2,0,-1,-1,1,0.15,low,#e5f5e0,85.88498714,0,96.08994273,8.8,0,0,0
+670,30412,41,Deciduous Forest,,30,Industrial,,-1,0.1,-1,-1,0.2,0,-1,-1,2,0.4,medium,#a1d99b,85.88498714,0,96.08994273,8.8,0,0,0
+671,30413,41,Deciduous Forest,,30,Industrial,,-1,0.1,-1,-1,0.2,0,-1,-1,3,0.66,high,#31a354,85.88498714,0,96.08994273,8.8,0,0,0
+672,30420,42,Evergreen Forest,,30,Industrial,,-1,0.1,-1,-1,0.2,0,-1,-1,0,0,none,#ffffff,105.6849871,0,96.08994273,14.4,0,0,0
+673,30421,42,Evergreen Forest,,30,Industrial,,-1,0.1,-1,-1,0.2,0,-1,-1,1,0.15,low,#e5f5e0,105.6849871,0,96.08994273,14.4,0,0,0
+674,30422,42,Evergreen Forest,,30,Industrial,,-1,0.1,-1,-1,0.2,0,-1,-1,2,0.4,medium,#a1d99b,105.6849871,0,96.08994273,14.4,0,0,0
+675,30423,42,Evergreen Forest,,30,Industrial,,-1,0.1,-1,-1,0.2,0,-1,-1,3,0.66,high,#31a354,105.6849871,0,96.08994273,14.4,0,0,0
+676,30430,43,Mixed Forest,,30,Industrial,,-1,0.1,-1,-1,0.2,0,-1,-1,0,0,none,#ffffff,91.76997429,0,119.1798855,8.8,0,0,0
+677,30431,43,Mixed Forest,,30,Industrial,,-1,0.1,-1,-1,0.2,0,-1,-1,1,0.15,low,#e5f5e0,91.76997429,0,119.1798855,8.8,0,0,0
+678,30432,43,Mixed Forest,,30,Industrial,,-1,0.1,-1,-1,0.2,0,-1,-1,2,0.4,medium,#a1d99b,91.76997429,0,119.1798855,8.8,0,0,0
+679,30433,43,Mixed Forest,,30,Industrial,,-1,0.1,-1,-1,0.2,0,-1,-1,3,0.66,high,#31a354,91.76997429,0,119.1798855,8.8,0,0,0
+680,30520,52,Shrub/Scrub,,30,Industrial,,0.1,0.1,0.1,0.1,0.2,0,-1,-1,0,0,none,#ffffff,47.875,0,68.15477645,0,0,0,0
+681,30521,52,Shrub/Scrub,,30,Industrial,,0.1,0.1,0.1,0.1,0.2,0,-1,-1,1,0.15,low,#e5f5e0,54.86074743,0,73.49954853,1.6,0,0,0
+682,30522,52,Shrub/Scrub,,30,Industrial,,0.1,0.1,0.1,0.1,0.2,0,-1,-1,2,0.4,medium,#a1d99b,66.5036598,0,82.407502,4.266666667,0,0,0
+683,30523,52,Shrub/Scrub,,30,Industrial,,0.1,0.1,0.1,0.1,0.2,0,-1,-1,3,0.66,high,#31a354,78.61228868,0,91.6717736,7.04,0,0,0
+684,30710,71,Herbaceuous,,30,Industrial,,0.1,0.1,0.1,0.1,0.2,0,-1,-1,0,0,none,#ffffff,10.10660117,8,98.79264417,0,0,0,0
+685,30711,71,Herbaceuous,,30,Industrial,,0.1,0.1,0.1,0.1,0.2,0,-1,-1,1,0.15,low,#e5f5e0,22.75760842,6.8,99.54173609,1.6,0,0,0
+686,30712,71,Herbaceuous,,30,Industrial,,0.1,0.1,0.1,0.1,0.2,0,-1,-1,2,0.4,medium,#a1d99b,43.84262051,4.8,100.7902226,4.266666667,0,0,0
+687,30713,71,Herbaceuous,,30,Industrial,,0.1,0.1,0.1,0.1,0.2,0,-1,-1,3,0.66,high,#31a354,65.77103307,2.72,102.0886486,7.04,0,0,0
+688,30810,81,Hay/Pasture,,30,Industrial,,0.1,0.1,0.1,0.1,0.2,0,-1,-1,0,0,none,#ffffff,10.10660117,8,98.79264417,0,0,0,0
+689,30811,81,Hay/Pasture,,30,Industrial,,0.1,0.1,0.1,0.1,0.2,0,-1,-1,1,0.15,low,#e5f5e0,22.75760842,6.8,99.54173609,1.6,0,0,0
+690,30812,81,Hay/Pasture,,30,Industrial,,0.1,0.1,0.1,0.1,0.2,0,-1,-1,2,0.4,medium,#a1d99b,43.84262051,4.8,100.7902226,4.266666667,0,0,0
+691,30813,81,Hay/Pasture,,30,Industrial,,0.1,0.1,0.1,0.1,0.2,0,-1,-1,3,0.66,high,#31a354,65.77103307,2.72,102.0886486,7.04,0,0,0
+692,30820,82,Cultivated Crops,,30,Industrial,,0.1,0.1,0.1,-1,-1,0,-1,-1,0,0,none,#ffffff,4.793840162,0,65.75263422,0,0,0,0
+693,30821,82,Cultivated Crops,,30,Industrial,,0.1,0.1,0.1,-1,-1,0,-1,-1,1,0.15,low,#e5f5e0,18.24176156,0,71.45772764,1.6,0,0,0
+694,30822,82,Cultivated Crops,,30,Industrial,,0.1,0.1,0.1,-1,-1,0,-1,-1,2,0.4,medium,#a1d99b,40.6549639,0,80.96621666,4.266666667,0,0,0
+695,30823,82,Cultivated Crops,,30,Industrial,,0.1,0.1,0.1,-1,-1,0,-1,-1,3,0.66,high,#31a354,63.96469433,0,90.85504525,7.04,0,0,0
+696,30900,90,Woody Wetlands,,30,Industrial,,0.1,0.1,-1,-1,0.2,0,-1,-1,0,0,none,#ffffff,33.5,0,259,0,0,0,0
+697,30901,90,Woody Wetlands,,30,Industrial,,0.1,0.1,-1,-1,0.2,0,-1,-1,1,0.15,low,#e5f5e0,42.64199743,0,235.7179885,1.6,0,0,0
+698,30902,90,Woody Wetlands,,30,Industrial,,0.1,0.1,-1,-1,0.2,0,-1,-1,2,0.4,medium,#a1d99b,57.8786598,0,196.9146361,4.266666667,0,0,0
+699,30903,90,Woody Wetlands,,30,Industrial,,0.1,0.1,-1,-1,0.2,0,-1,-1,3,0.66,high,#31a354,73.72478868,0,156.5591496,7.04,0,0,0
+700,30950,95,Emergent Herbaceuous Wetlands,,30,Industrial,,0.1,0.1,-1,-1,0.2,0,-1,-1,0,0,none,#ffffff,33.5,0,259,0,0,0,0
+701,30951,95,Emergent Herbaceuous Wetlands,,30,Industrial,,0.1,0.1,-1,-1,0.2,0,-1,-1,1,0.15,low,#e5f5e0,42.64199743,0,235.7179885,1.6,0,0,0
+702,30952,95,Emergent Herbaceuous Wetlands,,30,Industrial,,0.1,0.1,-1,-1,0.2,0,-1,-1,2,0.4,medium,#a1d99b,57.8786598,0,196.9146361,4.266666667,0,0,0
+703,30953,95,Emergent Herbaceuous Wetlands,,30,Industrial,,0.1,0.1,-1,-1,0.2,0,-1,-1,3,0.66,high,#31a354,73.72478868,0,156.5591496,7.04,0,0,0
+704,41110,11,Open Water,,41,Institutional,Private,-1,-1,-1,-1,-1,0,-1,-1,0,0,none,#ffffff,0,0,0,0,0,0,0
+705,41111,11,Open Water,,41,Institutional,Private,-1,-1,-1,-1,-1,0,-1,-1,1,0.15,low,#e5f5e0,14.16699743,0,15.56798855,1.6,0,0,0
+706,41112,11,Open Water,,41,Institutional,Private,-1,-1,-1,-1,-1,0,-1,-1,2,0.4,medium,#a1d99b,37.7786598,0,41.51463613,4.266666667,0,0,0
+707,41113,11,Open Water,,41,Institutional,Private,-1,-1,-1,-1,-1,0,-1,-1,3,0.66,high,#31a354,62.33478868,0,68.49914961,7.04,0,0,0
+708,41120,12,Perennial Ice/Snow,,41,Institutional,Private,-1,-1,-1,-1,-1,-1,-1,-1,0,0,none,#ffffff,0,0,0,0,0,0,0
+709,41121,12,Perennial Ice/Snow,,41,Institutional,Private,-1,-1,-1,-1,-1,-1,-1,-1,1,0.15,low,#e5f5e0,14.16699743,0,15.56798855,1.6,0,0,0
+710,41122,12,Perennial Ice/Snow,,41,Institutional,Private,-1,-1,-1,-1,-1,-1,-1,-1,2,0.4,medium,#a1d99b,37.7786598,0,41.51463613,4.266666667,0,0,0
+711,41123,12,Perennial Ice/Snow,,41,Institutional,Private,-1,-1,-1,-1,-1,-1,-1,-1,3,0.66,high,#31a354,62.33478868,0,68.49914961,7.04,0,0,0
+712,41210,21,"Developed, Open Space","20% trees, 60% grass, and 10% buildings and 10% bare soil",41,Institutional,Private,0.6,0.4,0.4,0.3,0.8,0,-1,-1,0,0,none,#ffffff,25.49986095,4.08,79.01411479,1.76,51.81402439,212.31,37.03522039
+713,41211,21,"Developed, Open Space","20% trees, 60% grass, and 10% buildings and 10% bare soil",41,Institutional,Private,0.6,0.4,0.4,0.3,0.8,0,-1,-1,1,0.15,low,#e5f5e0,35.84187923,3.468,82.72998612,3.096,51.81402439,212.31,37.03522039
+714,41212,21,"Developed, Open Space","20% trees, 60% grass, and 10% buildings and 10% bare soil",41,Institutional,Private,0.6,0.4,0.4,0.3,0.8,0,-1,-1,2,0.4,medium,#a1d99b,53.07857637,2.448,88.923105,5.322666667,51.81402439,212.31,37.03522039
+715,41213,21,"Developed, Open Space","20% trees, 60% grass, and 10% buildings and 10% bare soil",41,Institutional,Private,0.6,0.4,0.4,0.3,0.8,0,-1,-1,3,0.66,high,#31a354,71.0047414,1.3872,95.36394864,7.6384,51.81402439,212.31,37.03522039
+716,41220,22,"Developed, Low Intensity","20% trees, 40% grass, and 40% buildings",41,Institutional,Private,0.6,0.4,0.4,0.3,0.8,-1,-1,-1,0,0,none,#ffffff,20.90844667,3.52,72.06732319,0.61,207.2560976,849.24,147.1338816
+717,41221,22,"Developed, Low Intensity","20% trees, 40% grass, and 40% buildings",41,Institutional,Private,0.6,0.4,0.4,0.3,0.8,-1,-1,-1,1,0.15,low,#e5f5e0,31.9391771,2.992,76.82521326,2.1185,207.2560976,849.24,147.1338816
+718,41222,22,"Developed, Low Intensity","20% trees, 40% grass, and 40% buildings",41,Institutional,Private,0.6,0.4,0.4,0.3,0.8,-1,-1,-1,2,0.4,medium,#a1d99b,50.32372781,2.112,84.75503004,4.632666667,207.2560976,849.24,147.1338816
+719,41223,22,"Developed, Low Intensity","20% trees, 40% grass, and 40% buildings",41,Institutional,Private,0.6,0.4,0.4,0.3,0.8,-1,-1,-1,3,0.66,high,#31a354,69.44366054,1.1968,93.0020395,7.2474,207.2560976,849.24,147.1338816
+720,41230,23,"Developed, Medium Intensity","15% trees, 35% grass, and 50% buildings",41,Institutional,Private,0.6,0.4,0.4,0.3,0.8,-1,-1,-1,0,0,none,#ffffff,17.69813636,3.08,61.93838294,0.36,234.070122,954.85,720.4716833
+721,41231,23,"Developed, Medium Intensity","15% trees, 35% grass, and 50% buildings",41,Institutional,Private,0.6,0.4,0.4,0.3,0.8,-1,-1,-1,1,0.15,low,#e5f5e0,29.21041333,2.618,68.21561405,1.906,234.070122,954.85,720.4716833
+722,41232,23,"Developed, Medium Intensity","15% trees, 35% grass, and 50% buildings",41,Institutional,Private,0.6,0.4,0.4,0.3,0.8,-1,-1,-1,2,0.4,medium,#a1d99b,48.39754162,1.848,78.67766589,4.482666667,234.070122,954.85,720.4716833
+723,41233,23,"Developed, Medium Intensity","15% trees, 35% grass, and 50% buildings",41,Institutional,Private,0.6,0.4,0.4,0.3,0.8,-1,-1,-1,3,0.66,high,#31a354,68.35215504,1.0472,89.55819981,7.1624,234.070122,954.85,720.4716833
+724,41240,24,"Developed, High Intensity","10% trees, 20% grass, and 70% buildings",41,Institutional,Private,0.6,0.4,0.4,0.3,0.8,-1,-1,-1,0,0,none,#ffffff,10.98142029,1.76,44.78642515,0.245,267.9065041,3418.485,1805.616283
+725,41241,24,"Developed, High Intensity","10% trees, 20% grass, and 70% buildings",41,Institutional,Private,0.6,0.4,0.4,0.3,0.8,-1,-1,-1,1,0.15,low,#e5f5e0,23.50120467,1.496,53.63644993,1.80825,267.9065041,3418.485,1805.616283
+726,41242,24,"Developed, High Intensity","10% trees, 20% grass, and 70% buildings",41,Institutional,Private,0.6,0.4,0.4,0.3,0.8,-1,-1,-1,2,0.4,medium,#a1d99b,44.36751198,1.056,68.38649122,4.413666667,267.9065041,3418.485,1805.616283
+727,41243,24,"Developed, High Intensity","10% trees, 20% grass, and 70% buildings",41,Institutional,Private,0.6,0.4,0.4,0.3,0.8,-1,-1,-1,3,0.66,high,#31a354,66.06847158,0.5984,83.72653416,7.1233,267.9065041,3418.485,1805.616283
+728,41310,31,Barren Land,,41,Institutional,Private,0.6,0.4,0.4,0.3,0.8,0,-1,-1,0,0,none,#ffffff,6.8,0,25.5,0,0,0,0
+729,41311,31,Barren Land,,41,Institutional,Private,0.6,0.4,0.4,0.3,0.8,0,-1,-1,1,0.15,low,#e5f5e0,19.94699743,0,37.24298855,1.6,0,0,0
+730,41312,31,Barren Land,,41,Institutional,Private,0.6,0.4,0.4,0.3,0.8,0,-1,-1,2,0.4,medium,#a1d99b,41.8586598,0,56.81463613,4.266666667,0,0,0
+731,41313,31,Barren Land,,41,Institutional,Private,0.6,0.4,0.4,0.3,0.8,0,-1,-1,3,0.66,high,#31a354,64.64678868,0,77.16914961,7.04,0,0,0
+732,41410,41,Deciduous Forest,,41,Institutional,Private,-1,0.4,-1,-1,0.8,0,-1,-1,0,0,none,#ffffff,85.88498714,0,96.08994273,8.8,0,0,0
+733,41411,41,Deciduous Forest,,41,Institutional,Private,-1,0.4,-1,-1,0.8,0,-1,-1,1,0.15,low,#e5f5e0,85.88498714,0,96.08994273,8.8,0,0,0
+734,41412,41,Deciduous Forest,,41,Institutional,Private,-1,0.4,-1,-1,0.8,0,-1,-1,2,0.4,medium,#a1d99b,85.88498714,0,96.08994273,8.8,0,0,0
+735,41413,41,Deciduous Forest,,41,Institutional,Private,-1,0.4,-1,-1,0.8,0,-1,-1,3,0.66,high,#31a354,85.88498714,0,96.08994273,8.8,0,0,0
+736,41420,42,Evergreen Forest,,41,Institutional,Private,-1,0.4,-1,-1,0.8,0,-1,-1,0,0,none,#ffffff,105.6849871,0,96.08994273,14.4,0,0,0
+737,41421,42,Evergreen Forest,,41,Institutional,Private,-1,0.4,-1,-1,0.8,0,-1,-1,1,0.15,low,#e5f5e0,105.6849871,0,96.08994273,14.4,0,0,0
+738,41422,42,Evergreen Forest,,41,Institutional,Private,-1,0.4,-1,-1,0.8,0,-1,-1,2,0.4,medium,#a1d99b,105.6849871,0,96.08994273,14.4,0,0,0
+739,41423,42,Evergreen Forest,,41,Institutional,Private,-1,0.4,-1,-1,0.8,0,-1,-1,3,0.66,high,#31a354,105.6849871,0,96.08994273,14.4,0,0,0
+740,41430,43,Mixed Forest,,41,Institutional,Private,-1,0.4,-1,-1,0.8,0,-1,-1,0,0,none,#ffffff,91.76997429,0,119.1798855,8.8,0,0,0
+741,41431,43,Mixed Forest,,41,Institutional,Private,-1,0.4,-1,-1,0.8,0,-1,-1,1,0.15,low,#e5f5e0,91.76997429,0,119.1798855,8.8,0,0,0
+742,41432,43,Mixed Forest,,41,Institutional,Private,-1,0.4,-1,-1,0.8,0,-1,-1,2,0.4,medium,#a1d99b,91.76997429,0,119.1798855,8.8,0,0,0
+743,41433,43,Mixed Forest,,41,Institutional,Private,-1,0.4,-1,-1,0.8,0,-1,-1,3,0.66,high,#31a354,91.76997429,0,119.1798855,8.8,0,0,0
+744,41520,52,Shrub/Scrub,,41,Institutional,Private,0.6,0.4,0.4,0.3,0.8,0,-1,-1,0,0,none,#ffffff,47.875,0,68.15477645,0,0,0,0
+745,41521,52,Shrub/Scrub,,41,Institutional,Private,0.6,0.4,0.4,0.3,0.8,0,-1,-1,1,0.15,low,#e5f5e0,54.86074743,0,73.49954853,1.6,0,0,0
+746,41522,52,Shrub/Scrub,,41,Institutional,Private,0.6,0.4,0.4,0.3,0.8,0,-1,-1,2,0.4,medium,#a1d99b,66.5036598,0,82.407502,4.266666667,0,0,0
+747,41523,52,Shrub/Scrub,,41,Institutional,Private,0.6,0.4,0.4,0.3,0.8,0,-1,-1,3,0.66,high,#31a354,78.61228868,0,91.6717736,7.04,0,0,0
+748,41710,71,Herbaceuous,,41,Institutional,Private,0.6,0.4,0.4,0.3,0.8,0,-1,-1,0,0,none,#ffffff,10.10660117,8,98.79264417,0,0,0,0
+749,41711,71,Herbaceuous,,41,Institutional,Private,0.6,0.4,0.4,0.3,0.8,0,-1,-1,1,0.15,low,#e5f5e0,22.75760842,6.8,99.54173609,1.6,0,0,0
+750,41712,71,Herbaceuous,,41,Institutional,Private,0.6,0.4,0.4,0.3,0.8,0,-1,-1,2,0.4,medium,#a1d99b,43.84262051,4.8,100.7902226,4.266666667,0,0,0
+751,41713,71,Herbaceuous,,41,Institutional,Private,0.6,0.4,0.4,0.3,0.8,0,-1,-1,3,0.66,high,#31a354,65.77103307,2.72,102.0886486,7.04,0,0,0
+752,41810,81,Hay/Pasture,,41,Institutional,Private,0.6,0.4,0.4,0.3,0.8,0,-1,-1,0,0,none,#ffffff,10.10660117,8,98.79264417,0,0,0,0
+753,41811,81,Hay/Pasture,,41,Institutional,Private,0.6,0.4,0.4,0.3,0.8,0,-1,-1,1,0.15,low,#e5f5e0,22.75760842,6.8,99.54173609,1.6,0,0,0
+754,41812,81,Hay/Pasture,,41,Institutional,Private,0.6,0.4,0.4,0.3,0.8,0,-1,-1,2,0.4,medium,#a1d99b,43.84262051,4.8,100.7902226,4.266666667,0,0,0
+755,41813,81,Hay/Pasture,,41,Institutional,Private,0.6,0.4,0.4,0.3,0.8,0,-1,-1,3,0.66,high,#31a354,65.77103307,2.72,102.0886486,7.04,0,0,0
+756,41820,82,Cultivated Crops,,41,Institutional,Private,0.6,0.4,0.4,-1,-1,0,-1,-1,0,0,none,#ffffff,4.793840162,0,65.75263422,0,0,0,0
+757,41821,82,Cultivated Crops,,41,Institutional,Private,0.6,0.4,0.4,-1,-1,0,-1,-1,1,0.15,low,#e5f5e0,18.24176156,0,71.45772764,1.6,0,0,0
+758,41822,82,Cultivated Crops,,41,Institutional,Private,0.6,0.4,0.4,-1,-1,0,-1,-1,2,0.4,medium,#a1d99b,40.6549639,0,80.96621666,4.266666667,0,0,0
+759,41823,82,Cultivated Crops,,41,Institutional,Private,0.6,0.4,0.4,-1,-1,0,-1,-1,3,0.66,high,#31a354,63.96469433,0,90.85504525,7.04,0,0,0
+760,41900,90,Woody Wetlands,,41,Institutional,Private,0.6,0.4,-1,-1,0.8,0,-1,-1,0,0,none,#ffffff,33.5,0,259,0,0,0,0
+761,41901,90,Woody Wetlands,,41,Institutional,Private,0.6,0.4,-1,-1,0.8,0,-1,-1,1,0.15,low,#e5f5e0,42.64199743,0,235.7179885,1.6,0,0,0
+762,41902,90,Woody Wetlands,,41,Institutional,Private,0.6,0.4,-1,-1,0.8,0,-1,-1,2,0.4,medium,#a1d99b,57.8786598,0,196.9146361,4.266666667,0,0,0
+763,41903,90,Woody Wetlands,,41,Institutional,Private,0.6,0.4,-1,-1,0.8,0,-1,-1,3,0.66,high,#31a354,73.72478868,0,156.5591496,7.04,0,0,0
+764,41950,95,Emergent Herbaceuous Wetlands,,41,Institutional,Private,0.6,0.4,-1,-1,0.8,0,-1,-1,0,0,none,#ffffff,33.5,0,259,0,0,0,0
+765,41951,95,Emergent Herbaceuous Wetlands,,41,Institutional,Private,0.6,0.4,-1,-1,0.8,0,-1,-1,1,0.15,low,#e5f5e0,42.64199743,0,235.7179885,1.6,0,0,0
+766,41952,95,Emergent Herbaceuous Wetlands,,41,Institutional,Private,0.6,0.4,-1,-1,0.8,0,-1,-1,2,0.4,medium,#a1d99b,57.8786598,0,196.9146361,4.266666667,0,0,0
+767,41953,95,Emergent Herbaceuous Wetlands,,41,Institutional,Private,0.6,0.4,-1,-1,0.8,0,-1,-1,3,0.66,high,#31a354,73.72478868,0,156.5591496,7.04,0,0,0
+768,42110,11,Open Water,,42,Institutional,Public,-1,-1,-1,-1,-1,-1,-1,-1,0,0,none,#ffffff,0,0,0,0,0,0,0
+769,42111,11,Open Water,,42,Institutional,Public,-1,-1,-1,-1,-1,-1,-1,-1,1,0.15,low,#e5f5e0,14.16699743,0,15.56798855,1.6,0,0,0
+770,42112,11,Open Water,,42,Institutional,Public,-1,-1,-1,-1,-1,-1,-1,-1,2,0.4,medium,#a1d99b,37.7786598,0,41.51463613,4.266666667,0,0,0
+771,42113,11,Open Water,,42,Institutional,Public,-1,-1,-1,-1,-1,-1,-1,-1,3,0.66,high,#31a354,62.33478868,0,68.49914961,7.04,0,0,0
+772,42120,12,Perennial Ice/Snow,,42,Institutional,Public,-1,-1,-1,-1,-1,-1,-1,-1,0,0,none,#ffffff,0,0,0,0,0,0,0
+773,42121,12,Perennial Ice/Snow,,42,Institutional,Public,-1,-1,-1,-1,-1,-1,-1,-1,1,0.15,low,#e5f5e0,14.16699743,0,15.56798855,1.6,0,0,0
+774,42122,12,Perennial Ice/Snow,,42,Institutional,Public,-1,-1,-1,-1,-1,-1,-1,-1,2,0.4,medium,#a1d99b,37.7786598,0,41.51463613,4.266666667,0,0,0
+775,42123,12,Perennial Ice/Snow,,42,Institutional,Public,-1,-1,-1,-1,-1,-1,-1,-1,3,0.66,high,#31a354,62.33478868,0,68.49914961,7.04,0,0,0
+776,42210,21,"Developed, Open Space","20% trees, 60% grass, and 10% buildings and 10% bare soil",42,Institutional,Public,0.6,0.4,0.4,0.3,0.8,-1,-1,-1,0,0,none,#ffffff,25.49986095,4.08,79.01411479,1.76,51.81402439,212.31,37.03522039
+777,42211,21,"Developed, Open Space","20% trees, 60% grass, and 10% buildings and 10% bare soil",42,Institutional,Public,0.6,0.4,0.4,0.3,0.8,-1,-1,-1,1,0.15,low,#e5f5e0,35.84187923,3.468,82.72998612,3.096,51.81402439,212.31,37.03522039
+778,42212,21,"Developed, Open Space","20% trees, 60% grass, and 10% buildings and 10% bare soil",42,Institutional,Public,0.6,0.4,0.4,0.3,0.8,-1,-1,-1,2,0.4,medium,#a1d99b,53.07857637,2.448,88.923105,5.322666667,51.81402439,212.31,37.03522039
+779,42213,21,"Developed, Open Space","20% trees, 60% grass, and 10% buildings and 10% bare soil",42,Institutional,Public,0.6,0.4,0.4,0.3,0.8,-1,-1,-1,3,0.66,high,#31a354,71.0047414,1.3872,95.36394864,7.6384,51.81402439,212.31,37.03522039
+780,42220,22,"Developed, Low Intensity","20% trees, 40% grass, and 40% buildings",42,Institutional,Public,0.6,0.4,0.4,0.3,0.8,-1,-1,-1,0,0,none,#ffffff,20.90844667,3.52,72.06732319,0.61,207.2560976,849.24,147.1338816
+781,42221,22,"Developed, Low Intensity","20% trees, 40% grass, and 40% buildings",42,Institutional,Public,0.6,0.4,0.4,0.3,0.8,-1,-1,-1,1,0.15,low,#e5f5e0,31.9391771,2.992,76.82521326,2.1185,207.2560976,849.24,147.1338816
+782,42222,22,"Developed, Low Intensity","20% trees, 40% grass, and 40% buildings",42,Institutional,Public,0.6,0.4,0.4,0.3,0.8,-1,-1,-1,2,0.4,medium,#a1d99b,50.32372781,2.112,84.75503004,4.632666667,207.2560976,849.24,147.1338816
+783,42223,22,"Developed, Low Intensity","20% trees, 40% grass, and 40% buildings",42,Institutional,Public,0.6,0.4,0.4,0.3,0.8,-1,-1,-1,3,0.66,high,#31a354,69.44366054,1.1968,93.0020395,7.2474,207.2560976,849.24,147.1338816
+784,42230,23,"Developed, Medium Intensity","15% trees, 35% grass, and 50% buildings",42,Institutional,Public,0.6,0.4,0.4,0.3,0.8,-1,-1,-1,0,0,none,#ffffff,17.69813636,3.08,61.93838294,0.36,234.070122,954.85,720.4716833
+785,42231,23,"Developed, Medium Intensity","15% trees, 35% grass, and 50% buildings",42,Institutional,Public,0.6,0.4,0.4,0.3,0.8,-1,-1,-1,1,0.15,low,#e5f5e0,29.21041333,2.618,68.21561405,1.906,234.070122,954.85,720.4716833
+786,42232,23,"Developed, Medium Intensity","15% trees, 35% grass, and 50% buildings",42,Institutional,Public,0.6,0.4,0.4,0.3,0.8,-1,-1,-1,2,0.4,medium,#a1d99b,48.39754162,1.848,78.67766589,4.482666667,234.070122,954.85,720.4716833
+787,42233,23,"Developed, Medium Intensity","15% trees, 35% grass, and 50% buildings",42,Institutional,Public,0.6,0.4,0.4,0.3,0.8,-1,-1,-1,3,0.66,high,#31a354,68.35215504,1.0472,89.55819981,7.1624,234.070122,954.85,720.4716833
+788,42240,24,"Developed, High Intensity","10% trees, 20% grass, and 70% buildings",42,Institutional,Public,0.6,0.4,0.4,0.3,0.8,-1,-1,-1,0,0,none,#ffffff,10.98142029,1.76,44.78642515,0.245,267.9065041,3418.485,1805.616283
+789,42241,24,"Developed, High Intensity","10% trees, 20% grass, and 70% buildings",42,Institutional,Public,0.6,0.4,0.4,0.3,0.8,-1,-1,-1,1,0.15,low,#e5f5e0,23.50120467,1.496,53.63644993,1.80825,267.9065041,3418.485,1805.616283
+790,42242,24,"Developed, High Intensity","10% trees, 20% grass, and 70% buildings",42,Institutional,Public,0.6,0.4,0.4,0.3,0.8,-1,-1,-1,2,0.4,medium,#a1d99b,44.36751198,1.056,68.38649122,4.413666667,267.9065041,3418.485,1805.616283
+791,42243,24,"Developed, High Intensity","10% trees, 20% grass, and 70% buildings",42,Institutional,Public,0.6,0.4,0.4,0.3,0.8,-1,-1,-1,3,0.66,high,#31a354,66.06847158,0.5984,83.72653416,7.1233,267.9065041,3418.485,1805.616283
+792,42310,31,Barren Land,,42,Institutional,Public,0.6,0.4,0.4,0.3,0.8,-1,-1,-1,0,0,none,#ffffff,6.8,0,25.5,0,0,0,0
+793,42311,31,Barren Land,,42,Institutional,Public,0.6,0.4,0.4,0.3,0.8,-1,-1,-1,1,0.15,low,#e5f5e0,19.94699743,0,37.24298855,1.6,0,0,0
+794,42312,31,Barren Land,,42,Institutional,Public,0.6,0.4,0.4,0.3,0.8,-1,-1,-1,2,0.4,medium,#a1d99b,41.8586598,0,56.81463613,4.266666667,0,0,0
+795,42313,31,Barren Land,,42,Institutional,Public,0.6,0.4,0.4,0.3,0.8,-1,-1,-1,3,0.66,high,#31a354,64.64678868,0,77.16914961,7.04,0,0,0
+796,42410,41,Deciduous Forest,,42,Institutional,Public,-1,0.4,-1,-1,0.8,-1,-1,-1,0,0,none,#ffffff,85.88498714,0,96.08994273,8.8,0,0,0
+797,42411,41,Deciduous Forest,,42,Institutional,Public,-1,0.4,-1,-1,0.8,-1,-1,-1,1,0.15,low,#e5f5e0,85.88498714,0,96.08994273,8.8,0,0,0
+798,42412,41,Deciduous Forest,,42,Institutional,Public,-1,0.4,-1,-1,0.8,-1,-1,-1,2,0.4,medium,#a1d99b,85.88498714,0,96.08994273,8.8,0,0,0
+799,42413,41,Deciduous Forest,,42,Institutional,Public,-1,0.4,-1,-1,0.8,-1,-1,-1,3,0.66,high,#31a354,85.88498714,0,96.08994273,8.8,0,0,0
+800,42420,42,Evergreen Forest,,42,Institutional,Public,-1,0.4,-1,-1,0.8,-1,-1,-1,0,0,none,#ffffff,105.6849871,0,96.08994273,14.4,0,0,0
+801,42421,42,Evergreen Forest,,42,Institutional,Public,-1,0.4,-1,-1,0.8,-1,-1,-1,1,0.15,low,#e5f5e0,105.6849871,0,96.08994273,14.4,0,0,0
+802,42422,42,Evergreen Forest,,42,Institutional,Public,-1,0.4,-1,-1,0.8,-1,-1,-1,2,0.4,medium,#a1d99b,105.6849871,0,96.08994273,14.4,0,0,0
+803,42423,42,Evergreen Forest,,42,Institutional,Public,-1,0.4,-1,-1,0.8,-1,-1,-1,3,0.66,high,#31a354,105.6849871,0,96.08994273,14.4,0,0,0
+804,42430,43,Mixed Forest,,42,Institutional,Public,-1,0.4,-1,-1,0.8,-1,-1,-1,0,0,none,#ffffff,91.76997429,0,119.1798855,8.8,0,0,0
+805,42431,43,Mixed Forest,,42,Institutional,Public,-1,0.4,-1,-1,0.8,-1,-1,-1,1,0.15,low,#e5f5e0,91.76997429,0,119.1798855,8.8,0,0,0
+806,42432,43,Mixed Forest,,42,Institutional,Public,-1,0.4,-1,-1,0.8,-1,-1,-1,2,0.4,medium,#a1d99b,91.76997429,0,119.1798855,8.8,0,0,0
+807,42433,43,Mixed Forest,,42,Institutional,Public,-1,0.4,-1,-1,0.8,-1,-1,-1,3,0.66,high,#31a354,91.76997429,0,119.1798855,8.8,0,0,0
+808,42520,52,Shrub/Scrub,,42,Institutional,Public,0.6,0.4,0.4,0.3,0.8,-1,-1,-1,0,0,none,#ffffff,47.875,0,68.15477645,0,0,0,0
+809,42521,52,Shrub/Scrub,,42,Institutional,Public,0.6,0.4,0.4,0.3,0.8,-1,-1,-1,1,0.15,low,#e5f5e0,54.86074743,0,73.49954853,1.6,0,0,0
+810,42522,52,Shrub/Scrub,,42,Institutional,Public,0.6,0.4,0.4,0.3,0.8,-1,-1,-1,2,0.4,medium,#a1d99b,66.5036598,0,82.407502,4.266666667,0,0,0
+811,42523,52,Shrub/Scrub,,42,Institutional,Public,0.6,0.4,0.4,0.3,0.8,-1,-1,-1,3,0.66,high,#31a354,78.61228868,0,91.6717736,7.04,0,0,0
+812,42710,71,Herbaceuous,,42,Institutional,Public,0.6,0.4,0.4,0.3,0.8,-1,-1,-1,0,0,none,#ffffff,10.10660117,8,98.79264417,0,0,0,0
+813,42711,71,Herbaceuous,,42,Institutional,Public,0.6,0.4,0.4,0.3,0.8,-1,-1,-1,1,0.15,low,#e5f5e0,22.75760842,6.8,99.54173609,1.6,0,0,0
+814,42712,71,Herbaceuous,,42,Institutional,Public,0.6,0.4,0.4,0.3,0.8,-1,-1,-1,2,0.4,medium,#a1d99b,43.84262051,4.8,100.7902226,4.266666667,0,0,0
+815,42713,71,Herbaceuous,,42,Institutional,Public,0.6,0.4,0.4,0.3,0.8,-1,-1,-1,3,0.66,high,#31a354,65.77103307,2.72,102.0886486,7.04,0,0,0
+816,42810,81,Hay/Pasture,,42,Institutional,Public,0.6,0.4,0.4,0.3,0.8,-1,-1,-1,0,0,none,#ffffff,10.10660117,8,98.79264417,0,0,0,0
+817,42811,81,Hay/Pasture,,42,Institutional,Public,0.6,0.4,0.4,0.3,0.8,-1,-1,-1,1,0.15,low,#e5f5e0,22.75760842,6.8,99.54173609,1.6,0,0,0
+818,42812,81,Hay/Pasture,,42,Institutional,Public,0.6,0.4,0.4,0.3,0.8,-1,-1,-1,2,0.4,medium,#a1d99b,43.84262051,4.8,100.7902226,4.266666667,0,0,0
+819,42813,81,Hay/Pasture,,42,Institutional,Public,0.6,0.4,0.4,0.3,0.8,-1,-1,-1,3,0.66,high,#31a354,65.77103307,2.72,102.0886486,7.04,0,0,0
+820,42820,82,Cultivated Crops,,42,Institutional,Public,0.6,0.4,0.4,-1,-1,-1,-1,-1,0,0,none,#ffffff,4.793840162,0,65.75263422,0,0,0,0
+821,42821,82,Cultivated Crops,,42,Institutional,Public,0.6,0.4,0.4,-1,-1,-1,-1,-1,1,0.15,low,#e5f5e0,18.24176156,0,71.45772764,1.6,0,0,0
+822,42822,82,Cultivated Crops,,42,Institutional,Public,0.6,0.4,0.4,-1,-1,-1,-1,-1,2,0.4,medium,#a1d99b,40.6549639,0,80.96621666,4.266666667,0,0,0
+823,42823,82,Cultivated Crops,,42,Institutional,Public,0.6,0.4,0.4,-1,-1,-1,-1,-1,3,0.66,high,#31a354,63.96469433,0,90.85504525,7.04,0,0,0
+824,42900,90,Woody Wetlands,,42,Institutional,Public,0.6,0.4,-1,-1,0.8,-1,-1,-1,0,0,none,#ffffff,33.5,0,259,0,0,0,0
+825,42901,90,Woody Wetlands,,42,Institutional,Public,0.6,0.4,-1,-1,0.8,-1,-1,-1,1,0.15,low,#e5f5e0,42.64199743,0,235.7179885,1.6,0,0,0
+826,42902,90,Woody Wetlands,,42,Institutional,Public,0.6,0.4,-1,-1,0.8,-1,-1,-1,2,0.4,medium,#a1d99b,57.8786598,0,196.9146361,4.266666667,0,0,0
+827,42903,90,Woody Wetlands,,42,Institutional,Public,0.6,0.4,-1,-1,0.8,-1,-1,-1,3,0.66,high,#31a354,73.72478868,0,156.5591496,7.04,0,0,0
+828,42950,95,Emergent Herbaceuous Wetlands,,42,Institutional,Public,0.6,0.4,-1,-1,0.8,-1,-1,-1,0,0,none,#ffffff,33.5,0,259,0,0,0,0
+829,42951,95,Emergent Herbaceuous Wetlands,,42,Institutional,Public,0.6,0.4,-1,-1,0.8,-1,-1,-1,1,0.15,low,#e5f5e0,42.64199743,0,235.7179885,1.6,0,0,0
+830,42952,95,Emergent Herbaceuous Wetlands,,42,Institutional,Public,0.6,0.4,-1,-1,0.8,-1,-1,-1,2,0.4,medium,#a1d99b,57.8786598,0,196.9146361,4.266666667,0,0,0
+831,42953,95,Emergent Herbaceuous Wetlands,,42,Institutional,Public,0.6,0.4,-1,-1,0.8,-1,-1,-1,3,0.66,high,#31a354,73.72478868,0,156.5591496,7.04,0,0,0
+832,51110,11,Open Water,,51,Transportation,Airport,-1,-1,-1,-1,-1,0,-1,-1,0,0,none,#ffffff,0,0,0,0,0,0,0
+833,51111,11,Open Water,,51,Transportation,Airport,-1,-1,-1,-1,-1,0,-1,-1,1,0.15,low,#e5f5e0,14.16699743,0,15.56798855,1.6,0,0,0
+834,51112,11,Open Water,,51,Transportation,Airport,-1,-1,-1,-1,-1,0,-1,-1,2,0.4,medium,#a1d99b,37.7786598,0,41.51463613,4.266666667,0,0,0
+835,51113,11,Open Water,,51,Transportation,Airport,-1,-1,-1,-1,-1,0,-1,-1,3,0.66,high,#31a354,62.33478868,0,68.49914961,7.04,0,0,0
+836,51120,12,Perennial Ice/Snow,,51,Transportation,Airport,-1,-1,-1,-1,-1,-1,-1,-1,0,0,none,#ffffff,0,0,0,0,0,0,0
+837,51121,12,Perennial Ice/Snow,,51,Transportation,Airport,-1,-1,-1,-1,-1,-1,-1,-1,1,0.15,low,#e5f5e0,14.16699743,0,15.56798855,1.6,0,0,0
+838,51122,12,Perennial Ice/Snow,,51,Transportation,Airport,-1,-1,-1,-1,-1,-1,-1,-1,2,0.4,medium,#a1d99b,37.7786598,0,41.51463613,4.266666667,0,0,0
+839,51123,12,Perennial Ice/Snow,,51,Transportation,Airport,-1,-1,-1,-1,-1,-1,-1,-1,3,0.66,high,#31a354,62.33478868,0,68.49914961,7.04,0,0,0
+840,51210,21,"Developed, Open Space","20% trees, 60% grass, and 10% buildings and 10% bare soil",51,Transportation,Airport,-1,-1,-1,-1,1,0,-1,-1,0,0,none,#ffffff,25.49986095,4.08,79.01411479,1.76,51.81402439,212.31,37.03522039
+841,51211,21,"Developed, Open Space","20% trees, 60% grass, and 10% buildings and 10% bare soil",51,Transportation,Airport,-1,-1,-1,-1,1,0,-1,-1,1,0.15,low,#e5f5e0,35.84187923,3.468,82.72998612,3.096,51.81402439,212.31,37.03522039
+842,51212,21,"Developed, Open Space","20% trees, 60% grass, and 10% buildings and 10% bare soil",51,Transportation,Airport,-1,-1,-1,-1,1,0,-1,-1,2,0.4,medium,#a1d99b,53.07857637,2.448,88.923105,5.322666667,51.81402439,212.31,37.03522039
+843,51213,21,"Developed, Open Space","20% trees, 60% grass, and 10% buildings and 10% bare soil",51,Transportation,Airport,-1,-1,-1,-1,1,0,-1,-1,3,0.66,high,#31a354,71.0047414,1.3872,95.36394864,7.6384,51.81402439,212.31,37.03522039
+844,51220,22,"Developed, Low Intensity","20% trees, 40% grass, and 40% buildings",51,Transportation,Airport,-1,-1,-1,-1,1,-1,-1,-1,0,0,none,#ffffff,20.90844667,3.52,72.06732319,0.61,207.2560976,849.24,147.1338816
+845,51221,22,"Developed, Low Intensity","20% trees, 40% grass, and 40% buildings",51,Transportation,Airport,-1,-1,-1,-1,1,-1,-1,-1,1,0.15,low,#e5f5e0,31.9391771,2.992,76.82521326,2.1185,207.2560976,849.24,147.1338816
+846,51222,22,"Developed, Low Intensity","20% trees, 40% grass, and 40% buildings",51,Transportation,Airport,-1,-1,-1,-1,1,-1,-1,-1,2,0.4,medium,#a1d99b,50.32372781,2.112,84.75503004,4.632666667,207.2560976,849.24,147.1338816
+847,51223,22,"Developed, Low Intensity","20% trees, 40% grass, and 40% buildings",51,Transportation,Airport,-1,-1,-1,-1,1,-1,-1,-1,3,0.66,high,#31a354,69.44366054,1.1968,93.0020395,7.2474,207.2560976,849.24,147.1338816
+848,51230,23,"Developed, Medium Intensity","15% trees, 35% grass, and 50% buildings",51,Transportation,Airport,-1,-1,-1,-1,1,-1,-1,-1,0,0,none,#ffffff,17.69813636,3.08,61.93838294,0.36,234.070122,954.85,720.4716833
+849,51231,23,"Developed, Medium Intensity","15% trees, 35% grass, and 50% buildings",51,Transportation,Airport,-1,-1,-1,-1,1,-1,-1,-1,1,0.15,low,#e5f5e0,29.21041333,2.618,68.21561405,1.906,234.070122,954.85,720.4716833
+850,51232,23,"Developed, Medium Intensity","15% trees, 35% grass, and 50% buildings",51,Transportation,Airport,-1,-1,-1,-1,1,-1,-1,-1,2,0.4,medium,#a1d99b,48.39754162,1.848,78.67766589,4.482666667,234.070122,954.85,720.4716833
+851,51233,23,"Developed, Medium Intensity","15% trees, 35% grass, and 50% buildings",51,Transportation,Airport,-1,-1,-1,-1,1,-1,-1,-1,3,0.66,high,#31a354,68.35215504,1.0472,89.55819981,7.1624,234.070122,954.85,720.4716833
+852,51240,24,"Developed, High Intensity","10% trees, 20% grass, and 70% buildings",51,Transportation,Airport,-1,-1,-1,-1,1,-1,-1,-1,0,0,none,#ffffff,10.98142029,1.76,44.78642515,0.245,267.9065041,3418.485,1805.616283
+853,51241,24,"Developed, High Intensity","10% trees, 20% grass, and 70% buildings",51,Transportation,Airport,-1,-1,-1,-1,1,-1,-1,-1,1,0.15,low,#e5f5e0,23.50120467,1.496,53.63644993,1.80825,267.9065041,3418.485,1805.616283
+854,51242,24,"Developed, High Intensity","10% trees, 20% grass, and 70% buildings",51,Transportation,Airport,-1,-1,-1,-1,1,-1,-1,-1,2,0.4,medium,#a1d99b,44.36751198,1.056,68.38649122,4.413666667,267.9065041,3418.485,1805.616283
+855,51243,24,"Developed, High Intensity","10% trees, 20% grass, and 70% buildings",51,Transportation,Airport,-1,-1,-1,-1,1,-1,-1,-1,3,0.66,high,#31a354,66.06847158,0.5984,83.72653416,7.1233,267.9065041,3418.485,1805.616283
+856,51310,31,Barren Land,,51,Transportation,Airport,-1,-1,-1,-1,1,0,-1,-1,0,0,none,#ffffff,6.8,0,25.5,0,0,0,0
+857,51311,31,Barren Land,,51,Transportation,Airport,-1,-1,-1,-1,1,0,-1,-1,1,0.15,low,#e5f5e0,19.94699743,0,37.24298855,1.6,0,0,0
+858,51312,31,Barren Land,,51,Transportation,Airport,-1,-1,-1,-1,1,0,-1,-1,2,0.4,medium,#a1d99b,41.8586598,0,56.81463613,4.266666667,0,0,0
+859,51313,31,Barren Land,,51,Transportation,Airport,-1,-1,-1,-1,1,0,-1,-1,3,0.66,high,#31a354,64.64678868,0,77.16914961,7.04,0,0,0
+860,51410,41,Deciduous Forest,,51,Transportation,Airport,-1,-1,-1,-1,1,0,-1,-1,0,0,none,#ffffff,85.88498714,0,96.08994273,8.8,0,0,0
+861,51411,41,Deciduous Forest,,51,Transportation,Airport,-1,-1,-1,-1,1,0,-1,-1,1,0.15,low,#e5f5e0,85.88498714,0,96.08994273,8.8,0,0,0
+862,51412,41,Deciduous Forest,,51,Transportation,Airport,-1,-1,-1,-1,1,0,-1,-1,2,0.4,medium,#a1d99b,85.88498714,0,96.08994273,8.8,0,0,0
+863,51413,41,Deciduous Forest,,51,Transportation,Airport,-1,-1,-1,-1,1,0,-1,-1,3,0.66,high,#31a354,85.88498714,0,96.08994273,8.8,0,0,0
+864,51420,42,Evergreen Forest,,51,Transportation,Airport,-1,-1,-1,-1,1,0,-1,-1,0,0,none,#ffffff,105.6849871,0,96.08994273,14.4,0,0,0
+865,51421,42,Evergreen Forest,,51,Transportation,Airport,-1,-1,-1,-1,1,0,-1,-1,1,0.15,low,#e5f5e0,105.6849871,0,96.08994273,14.4,0,0,0
+866,51422,42,Evergreen Forest,,51,Transportation,Airport,-1,-1,-1,-1,1,0,-1,-1,2,0.4,medium,#a1d99b,105.6849871,0,96.08994273,14.4,0,0,0
+867,51423,42,Evergreen Forest,,51,Transportation,Airport,-1,-1,-1,-1,1,0,-1,-1,3,0.66,high,#31a354,105.6849871,0,96.08994273,14.4,0,0,0
+868,51430,43,Mixed Forest,,51,Transportation,Airport,-1,-1,-1,-1,1,0,-1,-1,0,0,none,#ffffff,91.76997429,0,119.1798855,8.8,0,0,0
+869,51431,43,Mixed Forest,,51,Transportation,Airport,-1,-1,-1,-1,1,0,-1,-1,1,0.15,low,#e5f5e0,91.76997429,0,119.1798855,8.8,0,0,0
+870,51432,43,Mixed Forest,,51,Transportation,Airport,-1,-1,-1,-1,1,0,-1,-1,2,0.4,medium,#a1d99b,91.76997429,0,119.1798855,8.8,0,0,0
+871,51433,43,Mixed Forest,,51,Transportation,Airport,-1,-1,-1,-1,1,0,-1,-1,3,0.66,high,#31a354,91.76997429,0,119.1798855,8.8,0,0,0
+872,51520,52,Shrub/Scrub,,51,Transportation,Airport,-1,-1,-1,-1,1,0,-1,-1,0,0,none,#ffffff,47.875,0,68.15477645,0,0,0,0
+873,51521,52,Shrub/Scrub,,51,Transportation,Airport,-1,-1,-1,-1,1,0,-1,-1,1,0.15,low,#e5f5e0,54.86074743,0,73.49954853,1.6,0,0,0
+874,51522,52,Shrub/Scrub,,51,Transportation,Airport,-1,-1,-1,-1,1,0,-1,-1,2,0.4,medium,#a1d99b,66.5036598,0,82.407502,4.266666667,0,0,0
+875,51523,52,Shrub/Scrub,,51,Transportation,Airport,-1,-1,-1,-1,1,0,-1,-1,3,0.66,high,#31a354,78.61228868,0,91.6717736,7.04,0,0,0
+876,51710,71,Herbaceuous,,51,Transportation,Airport,-1,-1,-1,-1,1,0,-1,-1,0,0,none,#ffffff,10.10660117,8,98.79264417,0,0,0,0
+877,51711,71,Herbaceuous,,51,Transportation,Airport,-1,-1,-1,-1,1,0,-1,-1,1,0.15,low,#e5f5e0,22.75760842,6.8,99.54173609,1.6,0,0,0
+878,51712,71,Herbaceuous,,51,Transportation,Airport,-1,-1,-1,-1,1,0,-1,-1,2,0.4,medium,#a1d99b,43.84262051,4.8,100.7902226,4.266666667,0,0,0
+879,51713,71,Herbaceuous,,51,Transportation,Airport,-1,-1,-1,-1,1,0,-1,-1,3,0.66,high,#31a354,65.77103307,2.72,102.0886486,7.04,0,0,0
+880,51810,81,Hay/Pasture,,51,Transportation,Airport,-1,-1,-1,-1,1,0,-1,-1,0,0,none,#ffffff,10.10660117,8,98.79264417,0,0,0,0
+881,51811,81,Hay/Pasture,,51,Transportation,Airport,-1,-1,-1,-1,1,0,-1,-1,1,0.15,low,#e5f5e0,22.75760842,6.8,99.54173609,1.6,0,0,0
+882,51812,81,Hay/Pasture,,51,Transportation,Airport,-1,-1,-1,-1,1,0,-1,-1,2,0.4,medium,#a1d99b,43.84262051,4.8,100.7902226,4.266666667,0,0,0
+883,51813,81,Hay/Pasture,,51,Transportation,Airport,-1,-1,-1,-1,1,0,-1,-1,3,0.66,high,#31a354,65.77103307,2.72,102.0886486,7.04,0,0,0
+884,51820,82,Cultivated Crops,,51,Transportation,Airport,-1,-1,-1,-1,-1,0,-1,-1,0,0,none,#ffffff,4.793840162,0,65.75263422,0,0,0,0
+885,51821,82,Cultivated Crops,,51,Transportation,Airport,-1,-1,-1,-1,-1,0,-1,-1,1,0.15,low,#e5f5e0,18.24176156,0,71.45772764,1.6,0,0,0
+886,51822,82,Cultivated Crops,,51,Transportation,Airport,-1,-1,-1,-1,-1,0,-1,-1,2,0.4,medium,#a1d99b,40.6549639,0,80.96621666,4.266666667,0,0,0
+887,51823,82,Cultivated Crops,,51,Transportation,Airport,-1,-1,-1,-1,-1,0,-1,-1,3,0.66,high,#31a354,63.96469433,0,90.85504525,7.04,0,0,0
+888,51900,90,Woody Wetlands,,51,Transportation,Airport,-1,-1,-1,-1,1,0,-1,-1,0,0,none,#ffffff,33.5,0,259,0,0,0,0
+889,51901,90,Woody Wetlands,,51,Transportation,Airport,-1,-1,-1,-1,1,0,-1,-1,1,0.15,low,#e5f5e0,42.64199743,0,235.7179885,1.6,0,0,0
+890,51902,90,Woody Wetlands,,51,Transportation,Airport,-1,-1,-1,-1,1,0,-1,-1,2,0.4,medium,#a1d99b,57.8786598,0,196.9146361,4.266666667,0,0,0
+891,51903,90,Woody Wetlands,,51,Transportation,Airport,-1,-1,-1,-1,1,0,-1,-1,3,0.66,high,#31a354,73.72478868,0,156.5591496,7.04,0,0,0
+892,51950,95,Emergent Herbaceuous Wetlands,,51,Transportation,Airport,-1,-1,-1,-1,1,0,-1,-1,0,0,none,#ffffff,33.5,0,259,0,0,0,0
+893,51951,95,Emergent Herbaceuous Wetlands,,51,Transportation,Airport,-1,-1,-1,-1,1,0,-1,-1,1,0.15,low,#e5f5e0,42.64199743,0,235.7179885,1.6,0,0,0
+894,51952,95,Emergent Herbaceuous Wetlands,,51,Transportation,Airport,-1,-1,-1,-1,1,0,-1,-1,2,0.4,medium,#a1d99b,57.8786598,0,196.9146361,4.266666667,0,0,0
+895,51953,95,Emergent Herbaceuous Wetlands,,51,Transportation,Airport,-1,-1,-1,-1,1,0,-1,-1,3,0.66,high,#31a354,73.72478868,0,156.5591496,7.04,0,0,0
+896,52110,11,Open Water,,52,Transportation,Road and Rail,-1,-1,-1,-1,-1,0,-1,-1,0,0,none,#ffffff,0,0,0,0,0,0,0
+897,52111,11,Open Water,,52,Transportation,Road and Rail,-1,-1,-1,-1,-1,0,-1,-1,1,0.15,low,#e5f5e0,14.16699743,0,15.56798855,1.6,0,0,0
+898,52112,11,Open Water,,52,Transportation,Road and Rail,-1,-1,-1,-1,-1,0,-1,-1,2,0.4,medium,#a1d99b,37.7786598,0,41.51463613,4.266666667,0,0,0
+899,52113,11,Open Water,,52,Transportation,Road and Rail,-1,-1,-1,-1,-1,0,-1,-1,3,0.66,high,#31a354,62.33478868,0,68.49914961,7.04,0,0,0
+900,52120,12,Perennial Ice/Snow,,52,Transportation,Road and Rail,-1,-1,-1,-1,-1,-1,-1,-1,0,0,none,#ffffff,0,0,0,0,0,0,0
+901,52121,12,Perennial Ice/Snow,,52,Transportation,Road and Rail,-1,-1,-1,-1,-1,-1,-1,-1,1,0.15,low,#e5f5e0,14.16699743,0,15.56798855,1.6,0,0,0
+902,52122,12,Perennial Ice/Snow,,52,Transportation,Road and Rail,-1,-1,-1,-1,-1,-1,-1,-1,2,0.4,medium,#a1d99b,37.7786598,0,41.51463613,4.266666667,0,0,0
+903,52123,12,Perennial Ice/Snow,,52,Transportation,Road and Rail,-1,-1,-1,-1,-1,-1,-1,-1,3,0.66,high,#31a354,62.33478868,0,68.49914961,7.04,0,0,0
+904,52210,21,"Developed, Open Space","20% trees, 60% grass, and 10% buildings and 10% bare soil",52,Transportation,Road and Rail,-1,-1,-1,-1,1,0,-1,-1,0,0,none,#ffffff,25.49986095,4.08,79.01411479,1.76,51.81402439,212.31,37.03522039
+905,52211,21,"Developed, Open Space","20% trees, 60% grass, and 10% buildings and 10% bare soil",52,Transportation,Road and Rail,-1,-1,-1,-1,1,0,-1,-1,1,0.15,low,#e5f5e0,35.84187923,3.468,82.72998612,3.096,51.81402439,212.31,37.03522039
+906,52212,21,"Developed, Open Space","20% trees, 60% grass, and 10% buildings and 10% bare soil",52,Transportation,Road and Rail,-1,-1,-1,-1,1,0,-1,-1,2,0.4,medium,#a1d99b,53.07857637,2.448,88.923105,5.322666667,51.81402439,212.31,37.03522039
+907,52213,21,"Developed, Open Space","20% trees, 60% grass, and 10% buildings and 10% bare soil",52,Transportation,Road and Rail,-1,-1,-1,-1,1,0,-1,-1,3,0.66,high,#31a354,71.0047414,1.3872,95.36394864,7.6384,51.81402439,212.31,37.03522039
+908,52220,22,"Developed, Low Intensity","20% trees, 40% grass, and 40% buildings",52,Transportation,Road and Rail,-1,-1,-1,-1,1,-1,-1,-1,0,0,none,#ffffff,20.90844667,3.52,72.06732319,0.61,207.2560976,849.24,147.1338816
+909,52221,22,"Developed, Low Intensity","20% trees, 40% grass, and 40% buildings",52,Transportation,Road and Rail,-1,-1,-1,-1,1,-1,-1,-1,1,0.15,low,#e5f5e0,31.9391771,2.992,76.82521326,2.1185,207.2560976,849.24,147.1338816
+910,52222,22,"Developed, Low Intensity","20% trees, 40% grass, and 40% buildings",52,Transportation,Road and Rail,-1,-1,-1,-1,1,-1,-1,-1,2,0.4,medium,#a1d99b,50.32372781,2.112,84.75503004,4.632666667,207.2560976,849.24,147.1338816
+911,52223,22,"Developed, Low Intensity","20% trees, 40% grass, and 40% buildings",52,Transportation,Road and Rail,-1,-1,-1,-1,1,-1,-1,-1,3,0.66,high,#31a354,69.44366054,1.1968,93.0020395,7.2474,207.2560976,849.24,147.1338816
+912,52230,23,"Developed, Medium Intensity","15% trees, 35% grass, and 50% buildings",52,Transportation,Road and Rail,-1,-1,-1,-1,1,-1,-1,-1,0,0,none,#ffffff,17.69813636,3.08,61.93838294,0.36,234.070122,954.85,720.4716833
+913,52231,23,"Developed, Medium Intensity","15% trees, 35% grass, and 50% buildings",52,Transportation,Road and Rail,-1,-1,-1,-1,1,-1,-1,-1,1,0.15,low,#e5f5e0,29.21041333,2.618,68.21561405,1.906,234.070122,954.85,720.4716833
+914,52232,23,"Developed, Medium Intensity","15% trees, 35% grass, and 50% buildings",52,Transportation,Road and Rail,-1,-1,-1,-1,1,-1,-1,-1,2,0.4,medium,#a1d99b,48.39754162,1.848,78.67766589,4.482666667,234.070122,954.85,720.4716833
+915,52233,23,"Developed, Medium Intensity","15% trees, 35% grass, and 50% buildings",52,Transportation,Road and Rail,-1,-1,-1,-1,1,-1,-1,-1,3,0.66,high,#31a354,68.35215504,1.0472,89.55819981,7.1624,234.070122,954.85,720.4716833
+916,52240,24,"Developed, High Intensity","10% trees, 20% grass, and 70% buildings",52,Transportation,Road and Rail,-1,-1,-1,-1,1,-1,-1,-1,0,0,none,#ffffff,10.98142029,1.76,44.78642515,0.245,267.9065041,3418.485,1805.616283
+917,52241,24,"Developed, High Intensity","10% trees, 20% grass, and 70% buildings",52,Transportation,Road and Rail,-1,-1,-1,-1,1,-1,-1,-1,1,0.15,low,#e5f5e0,23.50120467,1.496,53.63644993,1.80825,267.9065041,3418.485,1805.616283
+918,52242,24,"Developed, High Intensity","10% trees, 20% grass, and 70% buildings",52,Transportation,Road and Rail,-1,-1,-1,-1,1,-1,-1,-1,2,0.4,medium,#a1d99b,44.36751198,1.056,68.38649122,4.413666667,267.9065041,3418.485,1805.616283
+919,52243,24,"Developed, High Intensity","10% trees, 20% grass, and 70% buildings",52,Transportation,Road and Rail,-1,-1,-1,-1,1,-1,-1,-1,3,0.66,high,#31a354,66.06847158,0.5984,83.72653416,7.1233,267.9065041,3418.485,1805.616283
+920,52310,31,Barren Land,,52,Transportation,Road and Rail,-1,-1,-1,-1,1,0,-1,-1,0,0,none,#ffffff,6.8,0,25.5,0,0,0,0
+921,52311,31,Barren Land,,52,Transportation,Road and Rail,-1,-1,-1,-1,1,0,-1,-1,1,0.15,low,#e5f5e0,19.94699743,0,37.24298855,1.6,0,0,0
+922,52312,31,Barren Land,,52,Transportation,Road and Rail,-1,-1,-1,-1,1,0,-1,-1,2,0.4,medium,#a1d99b,41.8586598,0,56.81463613,4.266666667,0,0,0
+923,52313,31,Barren Land,,52,Transportation,Road and Rail,-1,-1,-1,-1,1,0,-1,-1,3,0.66,high,#31a354,64.64678868,0,77.16914961,7.04,0,0,0
+924,52410,41,Deciduous Forest,,52,Transportation,Road and Rail,-1,-1,-1,-1,1,0,-1,-1,0,0,none,#ffffff,85.88498714,0,96.08994273,8.8,0,0,0
+925,52411,41,Deciduous Forest,,52,Transportation,Road and Rail,-1,-1,-1,-1,1,0,-1,-1,1,0.15,low,#e5f5e0,85.88498714,0,96.08994273,8.8,0,0,0
+926,52412,41,Deciduous Forest,,52,Transportation,Road and Rail,-1,-1,-1,-1,1,0,-1,-1,2,0.4,medium,#a1d99b,85.88498714,0,96.08994273,8.8,0,0,0
+927,52413,41,Deciduous Forest,,52,Transportation,Road and Rail,-1,-1,-1,-1,1,0,-1,-1,3,0.66,high,#31a354,85.88498714,0,96.08994273,8.8,0,0,0
+928,52420,42,Evergreen Forest,,52,Transportation,Road and Rail,-1,-1,-1,-1,1,0,-1,-1,0,0,none,#ffffff,105.6849871,0,96.08994273,14.4,0,0,0
+929,52421,42,Evergreen Forest,,52,Transportation,Road and Rail,-1,-1,-1,-1,1,0,-1,-1,1,0.15,low,#e5f5e0,105.6849871,0,96.08994273,14.4,0,0,0
+930,52422,42,Evergreen Forest,,52,Transportation,Road and Rail,-1,-1,-1,-1,1,0,-1,-1,2,0.4,medium,#a1d99b,105.6849871,0,96.08994273,14.4,0,0,0
+931,52423,42,Evergreen Forest,,52,Transportation,Road and Rail,-1,-1,-1,-1,1,0,-1,-1,3,0.66,high,#31a354,105.6849871,0,96.08994273,14.4,0,0,0
+932,52430,43,Mixed Forest,,52,Transportation,Road and Rail,-1,-1,-1,-1,1,0,-1,-1,0,0,none,#ffffff,91.76997429,0,119.1798855,8.8,0,0,0
+933,52431,43,Mixed Forest,,52,Transportation,Road and Rail,-1,-1,-1,-1,1,0,-1,-1,1,0.15,low,#e5f5e0,91.76997429,0,119.1798855,8.8,0,0,0
+934,52432,43,Mixed Forest,,52,Transportation,Road and Rail,-1,-1,-1,-1,1,0,-1,-1,2,0.4,medium,#a1d99b,91.76997429,0,119.1798855,8.8,0,0,0
+935,52433,43,Mixed Forest,,52,Transportation,Road and Rail,-1,-1,-1,-1,1,0,-1,-1,3,0.66,high,#31a354,91.76997429,0,119.1798855,8.8,0,0,0
+936,52520,52,Shrub/Scrub,,52,Transportation,Road and Rail,-1,-1,-1,-1,1,0,-1,-1,0,0,none,#ffffff,47.875,0,68.15477645,0,0,0,0
+937,52521,52,Shrub/Scrub,,52,Transportation,Road and Rail,-1,-1,-1,-1,1,0,-1,-1,1,0.15,low,#e5f5e0,54.86074743,0,73.49954853,1.6,0,0,0
+938,52522,52,Shrub/Scrub,,52,Transportation,Road and Rail,-1,-1,-1,-1,1,0,-1,-1,2,0.4,medium,#a1d99b,66.5036598,0,82.407502,4.266666667,0,0,0
+939,52523,52,Shrub/Scrub,,52,Transportation,Road and Rail,-1,-1,-1,-1,1,0,-1,-1,3,0.66,high,#31a354,78.61228868,0,91.6717736,7.04,0,0,0
+940,52710,71,Herbaceuous,,52,Transportation,Road and Rail,-1,-1,-1,-1,1,0,-1,-1,0,0,none,#ffffff,10.10660117,8,98.79264417,0,0,0,0
+941,52711,71,Herbaceuous,,52,Transportation,Road and Rail,-1,-1,-1,-1,1,0,-1,-1,1,0.15,low,#e5f5e0,22.75760842,6.8,99.54173609,1.6,0,0,0
+942,52712,71,Herbaceuous,,52,Transportation,Road and Rail,-1,-1,-1,-1,1,0,-1,-1,2,0.4,medium,#a1d99b,43.84262051,4.8,100.7902226,4.266666667,0,0,0
+943,52713,71,Herbaceuous,,52,Transportation,Road and Rail,-1,-1,-1,-1,1,0,-1,-1,3,0.66,high,#31a354,65.77103307,2.72,102.0886486,7.04,0,0,0
+944,52810,81,Hay/Pasture,,52,Transportation,Road and Rail,-1,-1,-1,-1,1,0,-1,-1,0,0,none,#ffffff,10.10660117,8,98.79264417,0,0,0,0
+945,52811,81,Hay/Pasture,,52,Transportation,Road and Rail,-1,-1,-1,-1,1,0,-1,-1,1,0.15,low,#e5f5e0,22.75760842,6.8,99.54173609,1.6,0,0,0
+946,52812,81,Hay/Pasture,,52,Transportation,Road and Rail,-1,-1,-1,-1,1,0,-1,-1,2,0.4,medium,#a1d99b,43.84262051,4.8,100.7902226,4.266666667,0,0,0
+947,52813,81,Hay/Pasture,,52,Transportation,Road and Rail,-1,-1,-1,-1,1,0,-1,-1,3,0.66,high,#31a354,65.77103307,2.72,102.0886486,7.04,0,0,0
+948,52820,82,Cultivated Crops,,52,Transportation,Road and Rail,-1,-1,-1,-1,-1,0,-1,-1,0,0,none,#ffffff,4.793840162,0,65.75263422,0,0,0,0
+949,52821,82,Cultivated Crops,,52,Transportation,Road and Rail,-1,-1,-1,-1,-1,0,-1,-1,1,0.15,low,#e5f5e0,18.24176156,0,71.45772764,1.6,0,0,0
+950,52822,82,Cultivated Crops,,52,Transportation,Road and Rail,-1,-1,-1,-1,-1,0,-1,-1,2,0.4,medium,#a1d99b,40.6549639,0,80.96621666,4.266666667,0,0,0
+951,52823,82,Cultivated Crops,,52,Transportation,Road and Rail,-1,-1,-1,-1,-1,0,-1,-1,3,0.66,high,#31a354,63.96469433,0,90.85504525,7.04,0,0,0
+952,52900,90,Woody Wetlands,,52,Transportation,Road and Rail,-1,-1,-1,-1,1,0,-1,-1,0,0,none,#ffffff,33.5,0,259,0,0,0,0
+953,52901,90,Woody Wetlands,,52,Transportation,Road and Rail,-1,-1,-1,-1,1,0,-1,-1,1,0.15,low,#e5f5e0,42.64199743,0,235.7179885,1.6,0,0,0
+954,52902,90,Woody Wetlands,,52,Transportation,Road and Rail,-1,-1,-1,-1,1,0,-1,-1,2,0.4,medium,#a1d99b,57.8786598,0,196.9146361,4.266666667,0,0,0
+955,52903,90,Woody Wetlands,,52,Transportation,Road and Rail,-1,-1,-1,-1,1,0,-1,-1,3,0.66,high,#31a354,73.72478868,0,156.5591496,7.04,0,0,0
+956,52950,95,Emergent Herbaceuous Wetlands,,52,Transportation,Road and Rail,-1,-1,-1,-1,1,0,-1,-1,0,0,none,#ffffff,33.5,0,259,0,0,0,0
+957,52951,95,Emergent Herbaceuous Wetlands,,52,Transportation,Road and Rail,-1,-1,-1,-1,1,0,-1,-1,1,0.15,low,#e5f5e0,42.64199743,0,235.7179885,1.6,0,0,0
+958,52952,95,Emergent Herbaceuous Wetlands,,52,Transportation,Road and Rail,-1,-1,-1,-1,1,0,-1,-1,2,0.4,medium,#a1d99b,57.8786598,0,196.9146361,4.266666667,0,0,0
+959,52953,95,Emergent Herbaceuous Wetlands,,52,Transportation,Road and Rail,-1,-1,-1,-1,1,0,-1,-1,3,0.66,high,#31a354,73.72478868,0,156.5591496,7.04,0,0,0
+960,53110,11,Open Water,,53,Transportation,Other,-1,-1,-1,-1,-1,0,-1,-1,0,0,none,#ffffff,0,0,0,0,0,0,0
+961,53111,11,Open Water,,53,Transportation,Other,-1,-1,-1,-1,-1,0,-1,-1,1,0.15,low,#e5f5e0,14.16699743,0,15.56798855,1.6,0,0,0
+962,53112,11,Open Water,,53,Transportation,Other,-1,-1,-1,-1,-1,0,-1,-1,2,0.4,medium,#a1d99b,37.7786598,0,41.51463613,4.266666667,0,0,0
+963,53113,11,Open Water,,53,Transportation,Other,-1,-1,-1,-1,-1,0,-1,-1,3,0.66,high,#31a354,62.33478868,0,68.49914961,7.04,0,0,0
+964,53120,12,Perennial Ice/Snow,,53,Transportation,Other,-1,-1,-1,-1,-1,-1,-1,-1,0,0,none,#ffffff,0,0,0,0,0,0,0
+965,53121,12,Perennial Ice/Snow,,53,Transportation,Other,-1,-1,-1,-1,-1,-1,-1,-1,1,0.15,low,#e5f5e0,14.16699743,0,15.56798855,1.6,0,0,0
+966,53122,12,Perennial Ice/Snow,,53,Transportation,Other,-1,-1,-1,-1,-1,-1,-1,-1,2,0.4,medium,#a1d99b,37.7786598,0,41.51463613,4.266666667,0,0,0
+967,53123,12,Perennial Ice/Snow,,53,Transportation,Other,-1,-1,-1,-1,-1,-1,-1,-1,3,0.66,high,#31a354,62.33478868,0,68.49914961,7.04,0,0,0
+968,53210,21,"Developed, Open Space","20% trees, 60% grass, and 10% buildings and 10% bare soil",53,Transportation,Other,-1,-1,-1,-1,1,0,-1,-1,0,0,none,#ffffff,25.49986095,4.08,79.01411479,1.76,51.81402439,212.31,37.03522039
+969,53211,21,"Developed, Open Space","20% trees, 60% grass, and 10% buildings and 10% bare soil",53,Transportation,Other,-1,-1,-1,-1,1,0,-1,-1,1,0.15,low,#e5f5e0,35.84187923,3.468,82.72998612,3.096,51.81402439,212.31,37.03522039
+970,53212,21,"Developed, Open Space","20% trees, 60% grass, and 10% buildings and 10% bare soil",53,Transportation,Other,-1,-1,-1,-1,1,0,-1,-1,2,0.4,medium,#a1d99b,53.07857637,2.448,88.923105,5.322666667,51.81402439,212.31,37.03522039
+971,53213,21,"Developed, Open Space","20% trees, 60% grass, and 10% buildings and 10% bare soil",53,Transportation,Other,-1,-1,-1,-1,1,0,-1,-1,3,0.66,high,#31a354,71.0047414,1.3872,95.36394864,7.6384,51.81402439,212.31,37.03522039
+972,53220,22,"Developed, Low Intensity","20% trees, 40% grass, and 40% buildings",53,Transportation,Other,-1,-1,-1,-1,1,-1,-1,-1,0,0,none,#ffffff,20.90844667,3.52,72.06732319,0.61,207.2560976,849.24,147.1338816
+973,53221,22,"Developed, Low Intensity","20% trees, 40% grass, and 40% buildings",53,Transportation,Other,-1,-1,-1,-1,1,-1,-1,-1,1,0.15,low,#e5f5e0,31.9391771,2.992,76.82521326,2.1185,207.2560976,849.24,147.1338816
+974,53222,22,"Developed, Low Intensity","20% trees, 40% grass, and 40% buildings",53,Transportation,Other,-1,-1,-1,-1,1,-1,-1,-1,2,0.4,medium,#a1d99b,50.32372781,2.112,84.75503004,4.632666667,207.2560976,849.24,147.1338816
+975,53223,22,"Developed, Low Intensity","20% trees, 40% grass, and 40% buildings",53,Transportation,Other,-1,-1,-1,-1,1,-1,-1,-1,3,0.66,high,#31a354,69.44366054,1.1968,93.0020395,7.2474,207.2560976,849.24,147.1338816
+976,53230,23,"Developed, Medium Intensity","15% trees, 35% grass, and 50% buildings",53,Transportation,Other,-1,-1,-1,-1,1,-1,-1,-1,0,0,none,#ffffff,17.69813636,3.08,61.93838294,0.36,234.070122,954.85,720.4716833
+977,53231,23,"Developed, Medium Intensity","15% trees, 35% grass, and 50% buildings",53,Transportation,Other,-1,-1,-1,-1,1,-1,-1,-1,1,0.15,low,#e5f5e0,29.21041333,2.618,68.21561405,1.906,234.070122,954.85,720.4716833
+978,53232,23,"Developed, Medium Intensity","15% trees, 35% grass, and 50% buildings",53,Transportation,Other,-1,-1,-1,-1,1,-1,-1,-1,2,0.4,medium,#a1d99b,48.39754162,1.848,78.67766589,4.482666667,234.070122,954.85,720.4716833
+979,53233,23,"Developed, Medium Intensity","15% trees, 35% grass, and 50% buildings",53,Transportation,Other,-1,-1,-1,-1,1,-1,-1,-1,3,0.66,high,#31a354,68.35215504,1.0472,89.55819981,7.1624,234.070122,954.85,720.4716833
+980,53240,24,"Developed, High Intensity","10% trees, 20% grass, and 70% buildings",53,Transportation,Other,-1,-1,-1,-1,1,-1,-1,-1,0,0,none,#ffffff,10.98142029,1.76,44.78642515,0.245,267.9065041,3418.485,1805.616283
+981,53241,24,"Developed, High Intensity","10% trees, 20% grass, and 70% buildings",53,Transportation,Other,-1,-1,-1,-1,1,-1,-1,-1,1,0.15,low,#e5f5e0,23.50120467,1.496,53.63644993,1.80825,267.9065041,3418.485,1805.616283
+982,53242,24,"Developed, High Intensity","10% trees, 20% grass, and 70% buildings",53,Transportation,Other,-1,-1,-1,-1,1,-1,-1,-1,2,0.4,medium,#a1d99b,44.36751198,1.056,68.38649122,4.413666667,267.9065041,3418.485,1805.616283
+983,53243,24,"Developed, High Intensity","10% trees, 20% grass, and 70% buildings",53,Transportation,Other,-1,-1,-1,-1,1,-1,-1,-1,3,0.66,high,#31a354,66.06847158,0.5984,83.72653416,7.1233,267.9065041,3418.485,1805.616283
+984,53310,31,Barren Land,,53,Transportation,Other,-1,-1,-1,-1,1,0,-1,-1,0,0,none,#ffffff,6.8,0,25.5,0,0,0,0
+985,53311,31,Barren Land,,53,Transportation,Other,-1,-1,-1,-1,1,0,-1,-1,1,0.15,low,#e5f5e0,19.94699743,0,37.24298855,1.6,0,0,0
+986,53312,31,Barren Land,,53,Transportation,Other,-1,-1,-1,-1,1,0,-1,-1,2,0.4,medium,#a1d99b,41.8586598,0,56.81463613,4.266666667,0,0,0
+987,53313,31,Barren Land,,53,Transportation,Other,-1,-1,-1,-1,1,0,-1,-1,3,0.66,high,#31a354,64.64678868,0,77.16914961,7.04,0,0,0
+988,53410,41,Deciduous Forest,,53,Transportation,Other,-1,-1,-1,-1,1,0,-1,-1,0,0,none,#ffffff,85.88498714,0,96.08994273,8.8,0,0,0
+989,53411,41,Deciduous Forest,,53,Transportation,Other,-1,-1,-1,-1,1,0,-1,-1,1,0.15,low,#e5f5e0,85.88498714,0,96.08994273,8.8,0,0,0
+990,53412,41,Deciduous Forest,,53,Transportation,Other,-1,-1,-1,-1,1,0,-1,-1,2,0.4,medium,#a1d99b,85.88498714,0,96.08994273,8.8,0,0,0
+991,53413,41,Deciduous Forest,,53,Transportation,Other,-1,-1,-1,-1,1,0,-1,-1,3,0.66,high,#31a354,85.88498714,0,96.08994273,8.8,0,0,0
+992,53420,42,Evergreen Forest,,53,Transportation,Other,-1,-1,-1,-1,1,0,-1,-1,0,0,none,#ffffff,105.6849871,0,96.08994273,14.4,0,0,0
+993,53421,42,Evergreen Forest,,53,Transportation,Other,-1,-1,-1,-1,1,0,-1,-1,1,0.15,low,#e5f5e0,105.6849871,0,96.08994273,14.4,0,0,0
+994,53422,42,Evergreen Forest,,53,Transportation,Other,-1,-1,-1,-1,1,0,-1,-1,2,0.4,medium,#a1d99b,105.6849871,0,96.08994273,14.4,0,0,0
+995,53423,42,Evergreen Forest,,53,Transportation,Other,-1,-1,-1,-1,1,0,-1,-1,3,0.66,high,#31a354,105.6849871,0,96.08994273,14.4,0,0,0
+996,53430,43,Mixed Forest,,53,Transportation,Other,-1,-1,-1,-1,1,0,-1,-1,0,0,none,#ffffff,91.76997429,0,119.1798855,8.8,0,0,0
+997,53431,43,Mixed Forest,,53,Transportation,Other,-1,-1,-1,-1,1,0,-1,-1,1,0.15,low,#e5f5e0,91.76997429,0,119.1798855,8.8,0,0,0
+998,53432,43,Mixed Forest,,53,Transportation,Other,-1,-1,-1,-1,1,0,-1,-1,2,0.4,medium,#a1d99b,91.76997429,0,119.1798855,8.8,0,0,0
+999,53433,43,Mixed Forest,,53,Transportation,Other,-1,-1,-1,-1,1,0,-1,-1,3,0.66,high,#31a354,91.76997429,0,119.1798855,8.8,0,0,0
+1000,53520,52,Shrub/Scrub,,53,Transportation,Other,-1,-1,-1,-1,1,0,-1,-1,0,0,none,#ffffff,47.875,0,68.15477645,0,0,0,0
+1001,53521,52,Shrub/Scrub,,53,Transportation,Other,-1,-1,-1,-1,1,0,-1,-1,1,0.15,low,#e5f5e0,54.86074743,0,73.49954853,1.6,0,0,0
+1002,53522,52,Shrub/Scrub,,53,Transportation,Other,-1,-1,-1,-1,1,0,-1,-1,2,0.4,medium,#a1d99b,66.5036598,0,82.407502,4.266666667,0,0,0
+1003,53523,52,Shrub/Scrub,,53,Transportation,Other,-1,-1,-1,-1,1,0,-1,-1,3,0.66,high,#31a354,78.61228868,0,91.6717736,7.04,0,0,0
+1004,53710,71,Herbaceuous,,53,Transportation,Other,-1,-1,-1,-1,1,0,-1,-1,0,0,none,#ffffff,10.10660117,8,98.79264417,0,0,0,0
+1005,53711,71,Herbaceuous,,53,Transportation,Other,-1,-1,-1,-1,1,0,-1,-1,1,0.15,low,#e5f5e0,22.75760842,6.8,99.54173609,1.6,0,0,0
+1006,53712,71,Herbaceuous,,53,Transportation,Other,-1,-1,-1,-1,1,0,-1,-1,2,0.4,medium,#a1d99b,43.84262051,4.8,100.7902226,4.266666667,0,0,0
+1007,53713,71,Herbaceuous,,53,Transportation,Other,-1,-1,-1,-1,1,0,-1,-1,3,0.66,high,#31a354,65.77103307,2.72,102.0886486,7.04,0,0,0
+1008,53810,81,Hay/Pasture,,53,Transportation,Other,-1,-1,-1,-1,1,0,-1,-1,0,0,none,#ffffff,10.10660117,8,98.79264417,0,0,0,0
+1009,53811,81,Hay/Pasture,,53,Transportation,Other,-1,-1,-1,-1,1,0,-1,-1,1,0.15,low,#e5f5e0,22.75760842,6.8,99.54173609,1.6,0,0,0
+1010,53812,81,Hay/Pasture,,53,Transportation,Other,-1,-1,-1,-1,1,0,-1,-1,2,0.4,medium,#a1d99b,43.84262051,4.8,100.7902226,4.266666667,0,0,0
+1011,53813,81,Hay/Pasture,,53,Transportation,Other,-1,-1,-1,-1,1,0,-1,-1,3,0.66,high,#31a354,65.77103307,2.72,102.0886486,7.04,0,0,0
+1012,53820,82,Cultivated Crops,,53,Transportation,Other,-1,-1,-1,-1,-1,0,-1,-1,0,0,none,#ffffff,4.793840162,0,65.75263422,0,0,0,0
+1013,53821,82,Cultivated Crops,,53,Transportation,Other,-1,-1,-1,-1,-1,0,-1,-1,1,0.15,low,#e5f5e0,18.24176156,0,71.45772764,1.6,0,0,0
+1014,53822,82,Cultivated Crops,,53,Transportation,Other,-1,-1,-1,-1,-1,0,-1,-1,2,0.4,medium,#a1d99b,40.6549639,0,80.96621666,4.266666667,0,0,0
+1015,53823,82,Cultivated Crops,,53,Transportation,Other,-1,-1,-1,-1,-1,0,-1,-1,3,0.66,high,#31a354,63.96469433,0,90.85504525,7.04,0,0,0
+1016,53900,90,Woody Wetlands,,53,Transportation,Other,-1,-1,-1,-1,1,0,-1,-1,0,0,none,#ffffff,33.5,0,259,0,0,0,0
+1017,53901,90,Woody Wetlands,,53,Transportation,Other,-1,-1,-1,-1,1,0,-1,-1,1,0.15,low,#e5f5e0,42.64199743,0,235.7179885,1.6,0,0,0
+1018,53902,90,Woody Wetlands,,53,Transportation,Other,-1,-1,-1,-1,1,0,-1,-1,2,0.4,medium,#a1d99b,57.8786598,0,196.9146361,4.266666667,0,0,0
+1019,53903,90,Woody Wetlands,,53,Transportation,Other,-1,-1,-1,-1,1,0,-1,-1,3,0.66,high,#31a354,73.72478868,0,156.5591496,7.04,0,0,0
+1020,53950,95,Emergent Herbaceuous Wetlands,,53,Transportation,Other,-1,-1,-1,-1,1,0,-1,-1,0,0,none,#ffffff,33.5,0,259,0,0,0,0
+1021,53951,95,Emergent Herbaceuous Wetlands,,53,Transportation,Other,-1,-1,-1,-1,1,0,-1,-1,1,0.15,low,#e5f5e0,42.64199743,0,235.7179885,1.6,0,0,0
+1022,53952,95,Emergent Herbaceuous Wetlands,,53,Transportation,Other,-1,-1,-1,-1,1,0,-1,-1,2,0.4,medium,#a1d99b,57.8786598,0,196.9146361,4.266666667,0,0,0
+1023,53953,95,Emergent Herbaceuous Wetlands,,53,Transportation,Other,-1,-1,-1,-1,1,0,-1,-1,3,0.66,high,#31a354,73.72478868,0,156.5591496,7.04,0,0,0
+1024,60110,11,Open Water,,60,Other Development,,-1,-1,-1,-1,-1,-1,-1,-1,0,0,none,#ffffff,0,0,0,0,0,0,0
+1025,60111,11,Open Water,,60,Other Development,,-1,-1,-1,-1,-1,-1,-1,-1,1,0.15,low,#e5f5e0,14.16699743,0,15.56798855,1.6,0,0,0
+1026,60112,11,Open Water,,60,Other Development,,-1,-1,-1,-1,-1,-1,-1,-1,2,0.4,medium,#a1d99b,37.7786598,0,41.51463613,4.266666667,0,0,0
+1027,60113,11,Open Water,,60,Other Development,,-1,-1,-1,-1,-1,-1,-1,-1,3,0.66,high,#31a354,62.33478868,0,68.49914961,7.04,0,0,0
+1028,60120,12,Perennial Ice/Snow,,60,Other Development,,-1,-1,-1,-1,-1,-1,-1,-1,0,0,none,#ffffff,0,0,0,0,0,0,0
+1029,60121,12,Perennial Ice/Snow,,60,Other Development,,-1,-1,-1,-1,-1,-1,-1,-1,1,0.15,low,#e5f5e0,14.16699743,0,15.56798855,1.6,0,0,0
+1030,60122,12,Perennial Ice/Snow,,60,Other Development,,-1,-1,-1,-1,-1,-1,-1,-1,2,0.4,medium,#a1d99b,37.7786598,0,41.51463613,4.266666667,0,0,0
+1031,60123,12,Perennial Ice/Snow,,60,Other Development,,-1,-1,-1,-1,-1,-1,-1,-1,3,0.66,high,#31a354,62.33478868,0,68.49914961,7.04,0,0,0
+1032,60210,21,"Developed, Open Space","20% trees, 60% grass, and 10% buildings and 10% bare soil",60,Other Development,,-1,-1,-1,-1,-1,-1,-1,-1,0,0,none,#ffffff,25.49986095,4.08,79.01411479,1.76,51.81402439,212.31,37.03522039
+1033,60211,21,"Developed, Open Space","20% trees, 60% grass, and 10% buildings and 10% bare soil",60,Other Development,,-1,-1,-1,-1,-1,-1,-1,-1,1,0.15,low,#e5f5e0,35.84187923,3.468,82.72998612,3.096,51.81402439,212.31,37.03522039
+1034,60212,21,"Developed, Open Space","20% trees, 60% grass, and 10% buildings and 10% bare soil",60,Other Development,,-1,-1,-1,-1,-1,-1,-1,-1,2,0.4,medium,#a1d99b,53.07857637,2.448,88.923105,5.322666667,51.81402439,212.31,37.03522039
+1035,60213,21,"Developed, Open Space","20% trees, 60% grass, and 10% buildings and 10% bare soil",60,Other Development,,-1,-1,-1,-1,-1,-1,-1,-1,3,0.66,high,#31a354,71.0047414,1.3872,95.36394864,7.6384,51.81402439,212.31,37.03522039
+1036,60220,22,"Developed, Low Intensity","20% trees, 40% grass, and 40% buildings",60,Other Development,,-1,-1,-1,-1,-1,-1,-1,-1,0,0,none,#ffffff,20.90844667,3.52,72.06732319,0.61,207.2560976,849.24,147.1338816
+1037,60221,22,"Developed, Low Intensity","20% trees, 40% grass, and 40% buildings",60,Other Development,,-1,-1,-1,-1,-1,-1,-1,-1,1,0.15,low,#e5f5e0,31.9391771,2.992,76.82521326,2.1185,207.2560976,849.24,147.1338816
+1038,60222,22,"Developed, Low Intensity","20% trees, 40% grass, and 40% buildings",60,Other Development,,-1,-1,-1,-1,-1,-1,-1,-1,2,0.4,medium,#a1d99b,50.32372781,2.112,84.75503004,4.632666667,207.2560976,849.24,147.1338816
+1039,60223,22,"Developed, Low Intensity","20% trees, 40% grass, and 40% buildings",60,Other Development,,-1,-1,-1,-1,-1,-1,-1,-1,3,0.66,high,#31a354,69.44366054,1.1968,93.0020395,7.2474,207.2560976,849.24,147.1338816
+1040,60230,23,"Developed, Medium Intensity","15% trees, 35% grass, and 50% buildings",60,Other Development,,-1,-1,-1,-1,-1,-1,-1,-1,0,0,none,#ffffff,17.69813636,3.08,61.93838294,0.36,234.070122,954.85,720.4716833
+1041,60231,23,"Developed, Medium Intensity","15% trees, 35% grass, and 50% buildings",60,Other Development,,-1,-1,-1,-1,-1,-1,-1,-1,1,0.15,low,#e5f5e0,29.21041333,2.618,68.21561405,1.906,234.070122,954.85,720.4716833
+1042,60232,23,"Developed, Medium Intensity","15% trees, 35% grass, and 50% buildings",60,Other Development,,-1,-1,-1,-1,-1,-1,-1,-1,2,0.4,medium,#a1d99b,48.39754162,1.848,78.67766589,4.482666667,234.070122,954.85,720.4716833
+1043,60233,23,"Developed, Medium Intensity","15% trees, 35% grass, and 50% buildings",60,Other Development,,-1,-1,-1,-1,-1,-1,-1,-1,3,0.66,high,#31a354,68.35215504,1.0472,89.55819981,7.1624,234.070122,954.85,720.4716833
+1044,60240,24,"Developed, High Intensity","10% trees, 20% grass, and 70% buildings",60,Other Development,,-1,-1,-1,-1,-1,-1,-1,-1,0,0,none,#ffffff,10.98142029,1.76,44.78642515,0.245,267.9065041,3418.485,1805.616283
+1045,60241,24,"Developed, High Intensity","10% trees, 20% grass, and 70% buildings",60,Other Development,,-1,-1,-1,-1,-1,-1,-1,-1,1,0.15,low,#e5f5e0,23.50120467,1.496,53.63644993,1.80825,267.9065041,3418.485,1805.616283
+1046,60242,24,"Developed, High Intensity","10% trees, 20% grass, and 70% buildings",60,Other Development,,-1,-1,-1,-1,-1,-1,-1,-1,2,0.4,medium,#a1d99b,44.36751198,1.056,68.38649122,4.413666667,267.9065041,3418.485,1805.616283
+1047,60243,24,"Developed, High Intensity","10% trees, 20% grass, and 70% buildings",60,Other Development,,-1,-1,-1,-1,-1,-1,-1,-1,3,0.66,high,#31a354,66.06847158,0.5984,83.72653416,7.1233,267.9065041,3418.485,1805.616283
+1048,60310,31,Barren Land,,60,Other Development,,-1,-1,-1,-1,-1,-1,-1,-1,0,0,none,#ffffff,6.8,0,25.5,0,0,0,0
+1049,60311,31,Barren Land,,60,Other Development,,-1,-1,-1,-1,-1,-1,-1,-1,1,0.15,low,#e5f5e0,19.94699743,0,37.24298855,1.6,0,0,0
+1050,60312,31,Barren Land,,60,Other Development,,-1,-1,-1,-1,-1,-1,-1,-1,2,0.4,medium,#a1d99b,41.8586598,0,56.81463613,4.266666667,0,0,0
+1051,60313,31,Barren Land,,60,Other Development,,-1,-1,-1,-1,-1,-1,-1,-1,3,0.66,high,#31a354,64.64678868,0,77.16914961,7.04,0,0,0
+1052,60410,41,Deciduous Forest,,60,Other Development,,-1,-1,-1,-1,-1,-1,-1,-1,0,0,none,#ffffff,85.88498714,0,96.08994273,8.8,0,0,0
+1053,60411,41,Deciduous Forest,,60,Other Development,,-1,-1,-1,-1,-1,-1,-1,-1,1,0.15,low,#e5f5e0,85.88498714,0,96.08994273,8.8,0,0,0
+1054,60412,41,Deciduous Forest,,60,Other Development,,-1,-1,-1,-1,-1,-1,-1,-1,2,0.4,medium,#a1d99b,85.88498714,0,96.08994273,8.8,0,0,0
+1055,60413,41,Deciduous Forest,,60,Other Development,,-1,-1,-1,-1,-1,-1,-1,-1,3,0.66,high,#31a354,85.88498714,0,96.08994273,8.8,0,0,0
+1056,60420,42,Evergreen Forest,,60,Other Development,,-1,-1,-1,-1,-1,-1,-1,-1,0,0,none,#ffffff,105.6849871,0,96.08994273,14.4,0,0,0
+1057,60421,42,Evergreen Forest,,60,Other Development,,-1,-1,-1,-1,-1,-1,-1,-1,1,0.15,low,#e5f5e0,105.6849871,0,96.08994273,14.4,0,0,0
+1058,60422,42,Evergreen Forest,,60,Other Development,,-1,-1,-1,-1,-1,-1,-1,-1,2,0.4,medium,#a1d99b,105.6849871,0,96.08994273,14.4,0,0,0
+1059,60423,42,Evergreen Forest,,60,Other Development,,-1,-1,-1,-1,-1,-1,-1,-1,3,0.66,high,#31a354,105.6849871,0,96.08994273,14.4,0,0,0
+1060,60430,43,Mixed Forest,,60,Other Development,,-1,-1,-1,-1,-1,-1,-1,-1,0,0,none,#ffffff,91.76997429,0,119.1798855,8.8,0,0,0
+1061,60431,43,Mixed Forest,,60,Other Development,,-1,-1,-1,-1,-1,-1,-1,-1,1,0.15,low,#e5f5e0,91.76997429,0,119.1798855,8.8,0,0,0
+1062,60432,43,Mixed Forest,,60,Other Development,,-1,-1,-1,-1,-1,-1,-1,-1,2,0.4,medium,#a1d99b,91.76997429,0,119.1798855,8.8,0,0,0
+1063,60433,43,Mixed Forest,,60,Other Development,,-1,-1,-1,-1,-1,-1,-1,-1,3,0.66,high,#31a354,91.76997429,0,119.1798855,8.8,0,0,0
+1064,60520,52,Shrub/Scrub,,60,Other Development,,-1,-1,-1,-1,-1,-1,-1,-1,0,0,none,#ffffff,47.875,0,68.15477645,0,0,0,0
+1065,60521,52,Shrub/Scrub,,60,Other Development,,-1,-1,-1,-1,-1,-1,-1,-1,1,0.15,low,#e5f5e0,54.86074743,0,73.49954853,1.6,0,0,0
+1066,60522,52,Shrub/Scrub,,60,Other Development,,-1,-1,-1,-1,-1,-1,-1,-1,2,0.4,medium,#a1d99b,66.5036598,0,82.407502,4.266666667,0,0,0
+1067,60523,52,Shrub/Scrub,,60,Other Development,,-1,-1,-1,-1,-1,-1,-1,-1,3,0.66,high,#31a354,78.61228868,0,91.6717736,7.04,0,0,0
+1068,60710,71,Herbaceuous,,60,Other Development,,-1,-1,-1,-1,-1,-1,-1,-1,0,0,none,#ffffff,10.10660117,8,98.79264417,0,0,0,0
+1069,60711,71,Herbaceuous,,60,Other Development,,-1,-1,-1,-1,-1,-1,-1,-1,1,0.15,low,#e5f5e0,22.75760842,6.8,99.54173609,1.6,0,0,0
+1070,60712,71,Herbaceuous,,60,Other Development,,-1,-1,-1,-1,-1,-1,-1,-1,2,0.4,medium,#a1d99b,43.84262051,4.8,100.7902226,4.266666667,0,0,0
+1071,60713,71,Herbaceuous,,60,Other Development,,-1,-1,-1,-1,-1,-1,-1,-1,3,0.66,high,#31a354,65.77103307,2.72,102.0886486,7.04,0,0,0
+1072,60810,81,Hay/Pasture,,60,Other Development,,-1,-1,-1,-1,-1,-1,-1,-1,0,0,none,#ffffff,10.10660117,8,98.79264417,0,0,0,0
+1073,60811,81,Hay/Pasture,,60,Other Development,,-1,-1,-1,-1,-1,-1,-1,-1,1,0.15,low,#e5f5e0,22.75760842,6.8,99.54173609,1.6,0,0,0
+1074,60812,81,Hay/Pasture,,60,Other Development,,-1,-1,-1,-1,-1,-1,-1,-1,2,0.4,medium,#a1d99b,43.84262051,4.8,100.7902226,4.266666667,0,0,0
+1075,60813,81,Hay/Pasture,,60,Other Development,,-1,-1,-1,-1,-1,-1,-1,-1,3,0.66,high,#31a354,65.77103307,2.72,102.0886486,7.04,0,0,0
+1076,60820,82,Cultivated Crops,,60,Other Development,,-1,-1,-1,-1,-1,-1,-1,-1,0,0,none,#ffffff,4.793840162,0,65.75263422,0,0,0,0
+1077,60821,82,Cultivated Crops,,60,Other Development,,-1,-1,-1,-1,-1,-1,-1,-1,1,0.15,low,#e5f5e0,18.24176156,0,71.45772764,1.6,0,0,0
+1078,60822,82,Cultivated Crops,,60,Other Development,,-1,-1,-1,-1,-1,-1,-1,-1,2,0.4,medium,#a1d99b,40.6549639,0,80.96621666,4.266666667,0,0,0
+1079,60823,82,Cultivated Crops,,60,Other Development,,-1,-1,-1,-1,-1,-1,-1,-1,3,0.66,high,#31a354,63.96469433,0,90.85504525,7.04,0,0,0
+1080,60900,90,Woody Wetlands,,60,Other Development,,-1,-1,-1,-1,-1,-1,-1,-1,0,0,none,#ffffff,33.5,0,259,0,0,0,0
+1081,60901,90,Woody Wetlands,,60,Other Development,,-1,-1,-1,-1,-1,-1,-1,-1,1,0.15,low,#e5f5e0,42.64199743,0,235.7179885,1.6,0,0,0
+1082,60902,90,Woody Wetlands,,60,Other Development,,-1,-1,-1,-1,-1,-1,-1,-1,2,0.4,medium,#a1d99b,57.8786598,0,196.9146361,4.266666667,0,0,0
+1083,60903,90,Woody Wetlands,,60,Other Development,,-1,-1,-1,-1,-1,-1,-1,-1,3,0.66,high,#31a354,73.72478868,0,156.5591496,7.04,0,0,0
+1084,60950,95,Emergent Herbaceuous Wetlands,,60,Other Development,,-1,-1,-1,-1,-1,-1,-1,-1,0,0,none,#ffffff,33.5,0,259,0,0,0,0
+1085,60951,95,Emergent Herbaceuous Wetlands,,60,Other Development,,-1,-1,-1,-1,-1,-1,-1,-1,1,0.15,low,#e5f5e0,42.64199743,0,235.7179885,1.6,0,0,0
+1086,60952,95,Emergent Herbaceuous Wetlands,,60,Other Development,,-1,-1,-1,-1,-1,-1,-1,-1,2,0.4,medium,#a1d99b,57.8786598,0,196.9146361,4.266666667,0,0,0
+1087,60953,95,Emergent Herbaceuous Wetlands,,60,Other Development,,-1,-1,-1,-1,-1,-1,-1,-1,3,0.66,high,#31a354,73.72478868,0,156.5591496,7.04,0,0,0
+1088,70110,11,Open Water,,70,Agriculture,,-1,-1,-1,-1,-1,0,-1,-1,0,0,none,#ffffff,0,0,0,0,0,0,0
+1089,70111,11,Open Water,,70,Agriculture,,-1,-1,-1,-1,-1,0,-1,-1,1,0.15,low,#e5f5e0,14.16699743,0,15.56798855,1.6,0,0,0
+1090,70112,11,Open Water,,70,Agriculture,,-1,-1,-1,-1,-1,0,-1,-1,2,0.4,medium,#a1d99b,37.7786598,0,41.51463613,4.266666667,0,0,0
+1091,70113,11,Open Water,,70,Agriculture,,-1,-1,-1,-1,-1,0,-1,-1,3,0.66,high,#31a354,62.33478868,0,68.49914961,7.04,0,0,0
+1092,70120,12,Perennial Ice/Snow,,70,Agriculture,,-1,-1,-1,-1,-1,-1,-1,-1,0,0,none,#ffffff,0,0,0,0,0,0,0
+1093,70121,12,Perennial Ice/Snow,,70,Agriculture,,-1,-1,-1,-1,-1,-1,-1,-1,1,0.15,low,#e5f5e0,14.16699743,0,15.56798855,1.6,0,0,0
+1094,70122,12,Perennial Ice/Snow,,70,Agriculture,,-1,-1,-1,-1,-1,-1,-1,-1,2,0.4,medium,#a1d99b,37.7786598,0,41.51463613,4.266666667,0,0,0
+1095,70123,12,Perennial Ice/Snow,,70,Agriculture,,-1,-1,-1,-1,-1,-1,-1,-1,3,0.66,high,#31a354,62.33478868,0,68.49914961,7.04,0,0,0
+1096,70210,21,"Developed, Open Space","20% trees, 60% grass, and 10% buildings and 10% bare soil",70,Agriculture,,1,1,1,0,-1,0,-1,-1,0,0,none,#ffffff,25.49986095,4.08,79.01411479,1.76,51.81402439,212.31,37.03522039
+1097,70211,21,"Developed, Open Space","20% trees, 60% grass, and 10% buildings and 10% bare soil",70,Agriculture,,1,1,1,0,-1,0,-1,-1,1,0.15,low,#e5f5e0,35.84187923,3.468,82.72998612,3.096,51.81402439,212.31,37.03522039
+1098,70212,21,"Developed, Open Space","20% trees, 60% grass, and 10% buildings and 10% bare soil",70,Agriculture,,1,1,1,0,-1,0,-1,-1,2,0.4,medium,#a1d99b,53.07857637,2.448,88.923105,5.322666667,51.81402439,212.31,37.03522039
+1099,70213,21,"Developed, Open Space","20% trees, 60% grass, and 10% buildings and 10% bare soil",70,Agriculture,,1,1,1,0,-1,0,-1,-1,3,0.66,high,#31a354,71.0047414,1.3872,95.36394864,7.6384,51.81402439,212.31,37.03522039
+1100,70220,22,"Developed, Low Intensity","20% trees, 40% grass, and 40% buildings",70,Agriculture,,1,1,1,0,-1,-1,-1,-1,0,0,none,#ffffff,20.90844667,3.52,72.06732319,0.61,207.2560976,849.24,147.1338816
+1101,70221,22,"Developed, Low Intensity","20% trees, 40% grass, and 40% buildings",70,Agriculture,,1,1,1,0,-1,-1,-1,-1,1,0.15,low,#e5f5e0,31.9391771,2.992,76.82521326,2.1185,207.2560976,849.24,147.1338816
+1102,70222,22,"Developed, Low Intensity","20% trees, 40% grass, and 40% buildings",70,Agriculture,,1,1,1,0,-1,-1,-1,-1,2,0.4,medium,#a1d99b,50.32372781,2.112,84.75503004,4.632666667,207.2560976,849.24,147.1338816
+1103,70223,22,"Developed, Low Intensity","20% trees, 40% grass, and 40% buildings",70,Agriculture,,1,1,1,0,-1,-1,-1,-1,3,0.66,high,#31a354,69.44366054,1.1968,93.0020395,7.2474,207.2560976,849.24,147.1338816
+1104,70230,23,"Developed, Medium Intensity","15% trees, 35% grass, and 50% buildings",70,Agriculture,,1,1,1,0,-1,-1,-1,-1,0,0,none,#ffffff,17.69813636,3.08,61.93838294,0.36,234.070122,954.85,720.4716833
+1105,70231,23,"Developed, Medium Intensity","15% trees, 35% grass, and 50% buildings",70,Agriculture,,1,1,1,0,-1,-1,-1,-1,1,0.15,low,#e5f5e0,29.21041333,2.618,68.21561405,1.906,234.070122,954.85,720.4716833
+1106,70232,23,"Developed, Medium Intensity","15% trees, 35% grass, and 50% buildings",70,Agriculture,,1,1,1,0,-1,-1,-1,-1,2,0.4,medium,#a1d99b,48.39754162,1.848,78.67766589,4.482666667,234.070122,954.85,720.4716833
+1107,70233,23,"Developed, Medium Intensity","15% trees, 35% grass, and 50% buildings",70,Agriculture,,1,1,1,0,-1,-1,-1,-1,3,0.66,high,#31a354,68.35215504,1.0472,89.55819981,7.1624,234.070122,954.85,720.4716833
+1108,70240,24,"Developed, High Intensity","10% trees, 20% grass, and 70% buildings",70,Agriculture,,1,1,1,0,-1,-1,-1,-1,0,0,none,#ffffff,10.98142029,1.76,44.78642515,0.245,267.9065041,3418.485,1805.616283
+1109,70241,24,"Developed, High Intensity","10% trees, 20% grass, and 70% buildings",70,Agriculture,,1,1,1,0,-1,-1,-1,-1,1,0.15,low,#e5f5e0,23.50120467,1.496,53.63644993,1.80825,267.9065041,3418.485,1805.616283
+1110,70242,24,"Developed, High Intensity","10% trees, 20% grass, and 70% buildings",70,Agriculture,,1,1,1,0,-1,-1,-1,-1,2,0.4,medium,#a1d99b,44.36751198,1.056,68.38649122,4.413666667,267.9065041,3418.485,1805.616283
+1111,70243,24,"Developed, High Intensity","10% trees, 20% grass, and 70% buildings",70,Agriculture,,1,1,1,0,-1,-1,-1,-1,3,0.66,high,#31a354,66.06847158,0.5984,83.72653416,7.1233,267.9065041,3418.485,1805.616283
+1112,70310,31,Barren Land,,70,Agriculture,,1,1,1,0,-1,0,-1,-1,0,0,none,#ffffff,6.8,0,25.5,0,0,0,0
+1113,70311,31,Barren Land,,70,Agriculture,,1,1,1,0,-1,0,-1,-1,1,0.15,low,#e5f5e0,19.94699743,0,37.24298855,1.6,0,0,0
+1114,70312,31,Barren Land,,70,Agriculture,,1,1,1,0,-1,0,-1,-1,2,0.4,medium,#a1d99b,41.8586598,0,56.81463613,4.266666667,0,0,0
+1115,70313,31,Barren Land,,70,Agriculture,,1,1,1,0,-1,0,-1,-1,3,0.66,high,#31a354,64.64678868,0,77.16914961,7.04,0,0,0
+1116,70410,41,Deciduous Forest,,70,Agriculture,,-1,1,-1,-1,-1,0,-1,-1,0,0,none,#ffffff,85.88498714,0,96.08994273,8.8,0,0,0
+1117,70411,41,Deciduous Forest,,70,Agriculture,,-1,1,-1,-1,-1,0,-1,-1,1,0.15,low,#e5f5e0,85.88498714,0,96.08994273,8.8,0,0,0
+1118,70412,41,Deciduous Forest,,70,Agriculture,,-1,1,-1,-1,-1,0,-1,-1,2,0.4,medium,#a1d99b,85.88498714,0,96.08994273,8.8,0,0,0
+1119,70413,41,Deciduous Forest,,70,Agriculture,,-1,1,-1,-1,-1,0,-1,-1,3,0.66,high,#31a354,85.88498714,0,96.08994273,8.8,0,0,0
+1120,70420,42,Evergreen Forest,,70,Agriculture,,-1,1,-1,-1,-1,0,-1,-1,0,0,none,#ffffff,105.6849871,0,96.08994273,14.4,0,0,0
+1121,70421,42,Evergreen Forest,,70,Agriculture,,-1,1,-1,-1,-1,0,-1,-1,1,0.15,low,#e5f5e0,105.6849871,0,96.08994273,14.4,0,0,0
+1122,70422,42,Evergreen Forest,,70,Agriculture,,-1,1,-1,-1,-1,0,-1,-1,2,0.4,medium,#a1d99b,105.6849871,0,96.08994273,14.4,0,0,0
+1123,70423,42,Evergreen Forest,,70,Agriculture,,-1,1,-1,-1,-1,0,-1,-1,3,0.66,high,#31a354,105.6849871,0,96.08994273,14.4,0,0,0
+1124,70430,43,Mixed Forest,,70,Agriculture,,-1,1,-1,-1,-1,0,-1,-1,0,0,none,#ffffff,91.76997429,0,119.1798855,8.8,0,0,0
+1125,70431,43,Mixed Forest,,70,Agriculture,,-1,1,-1,-1,-1,0,-1,-1,1,0.15,low,#e5f5e0,91.76997429,0,119.1798855,8.8,0,0,0
+1126,70432,43,Mixed Forest,,70,Agriculture,,-1,1,-1,-1,-1,0,-1,-1,2,0.4,medium,#a1d99b,91.76997429,0,119.1798855,8.8,0,0,0
+1127,70433,43,Mixed Forest,,70,Agriculture,,-1,1,-1,-1,-1,0,-1,-1,3,0.66,high,#31a354,91.76997429,0,119.1798855,8.8,0,0,0
+1128,70520,52,Shrub/Scrub,,70,Agriculture,,1,1,1,0,-1,0,-1,-1,0,0,none,#ffffff,47.875,0,68.15477645,0,0,0,0
+1129,70521,52,Shrub/Scrub,,70,Agriculture,,1,1,1,0,-1,0,-1,-1,1,0.15,low,#e5f5e0,54.86074743,0,73.49954853,1.6,0,0,0
+1130,70522,52,Shrub/Scrub,,70,Agriculture,,1,1,1,0,-1,0,-1,-1,2,0.4,medium,#a1d99b,66.5036598,0,82.407502,4.266666667,0,0,0
+1131,70523,52,Shrub/Scrub,,70,Agriculture,,1,1,1,0,-1,0,-1,-1,3,0.66,high,#31a354,78.61228868,0,91.6717736,7.04,0,0,0
+1132,70710,71,Herbaceuous,,70,Agriculture,,1,1,1,0,-1,0,-1,-1,0,0,none,#ffffff,10.10660117,8,98.79264417,0,0,0,0
+1133,70711,71,Herbaceuous,,70,Agriculture,,1,1,1,0,-1,0,-1,-1,1,0.15,low,#e5f5e0,22.75760842,6.8,99.54173609,1.6,0,0,0
+1134,70712,71,Herbaceuous,,70,Agriculture,,1,1,1,0,-1,0,-1,-1,2,0.4,medium,#a1d99b,43.84262051,4.8,100.7902226,4.266666667,0,0,0
+1135,70713,71,Herbaceuous,,70,Agriculture,,1,1,1,0,-1,0,-1,-1,3,0.66,high,#31a354,65.77103307,2.72,102.0886486,7.04,0,0,0
+1136,70810,81,Hay/Pasture,,70,Agriculture,,1,1,1,0,-1,0,-1,-1,0,0,none,#ffffff,10.10660117,8,98.79264417,0,0,0,0
+1137,70811,81,Hay/Pasture,,70,Agriculture,,1,1,1,0,-1,0,-1,-1,1,0.15,low,#e5f5e0,22.75760842,6.8,99.54173609,1.6,0,0,0
+1138,70812,81,Hay/Pasture,,70,Agriculture,,1,1,1,0,-1,0,-1,-1,2,0.4,medium,#a1d99b,43.84262051,4.8,100.7902226,4.266666667,0,0,0
+1139,70813,81,Hay/Pasture,,70,Agriculture,,1,1,1,0,-1,0,-1,-1,3,0.66,high,#31a354,65.77103307,2.72,102.0886486,7.04,0,0,0
+1140,70820,82,Cultivated Crops,,70,Agriculture,,1,1,1,-1,-1,0,-1,-1,0,0,none,#ffffff,4.793840162,0,65.75263422,0,0,0,0
+1141,70821,82,Cultivated Crops,,70,Agriculture,,1,1,1,-1,-1,0,-1,-1,1,0.15,low,#e5f5e0,18.24176156,0,71.45772764,1.6,0,0,0
+1142,70822,82,Cultivated Crops,,70,Agriculture,,1,1,1,-1,-1,0,-1,-1,2,0.4,medium,#a1d99b,40.6549639,0,80.96621666,4.266666667,0,0,0
+1143,70823,82,Cultivated Crops,,70,Agriculture,,1,1,1,-1,-1,0,-1,-1,3,0.66,high,#31a354,63.96469433,0,90.85504525,7.04,0,0,0
+1144,70900,90,Woody Wetlands,,70,Agriculture,,1,1,-1,-1,-1,0,-1,-1,0,0,none,#ffffff,33.5,0,259,0,0,0,0
+1145,70901,90,Woody Wetlands,,70,Agriculture,,1,1,-1,-1,-1,0,-1,-1,1,0.15,low,#e5f5e0,42.64199743,0,235.7179885,1.6,0,0,0
+1146,70902,90,Woody Wetlands,,70,Agriculture,,1,1,-1,-1,-1,0,-1,-1,2,0.4,medium,#a1d99b,57.8786598,0,196.9146361,4.266666667,0,0,0
+1147,70903,90,Woody Wetlands,,70,Agriculture,,1,1,-1,-1,-1,0,-1,-1,3,0.66,high,#31a354,73.72478868,0,156.5591496,7.04,0,0,0
+1148,70950,95,Emergent Herbaceuous Wetlands,,70,Agriculture,,1,1,-1,-1,-1,0,-1,-1,0,0,none,#ffffff,33.5,0,259,0,0,0,0
+1149,70951,95,Emergent Herbaceuous Wetlands,,70,Agriculture,,1,1,-1,-1,-1,0,-1,-1,1,0.15,low,#e5f5e0,42.64199743,0,235.7179885,1.6,0,0,0
+1150,70952,95,Emergent Herbaceuous Wetlands,,70,Agriculture,,1,1,-1,-1,-1,0,-1,-1,2,0.4,medium,#a1d99b,57.8786598,0,196.9146361,4.266666667,0,0,0
+1151,70953,95,Emergent Herbaceuous Wetlands,,70,Agriculture,,1,1,-1,-1,-1,0,-1,-1,3,0.66,high,#31a354,73.72478868,0,156.5591496,7.04,0,0,0
+1152,80110,11,Open Water,,80,Rangeland,,-1,-1,-1,-1,-1,0,1,-1,0,0,none,#ffffff,0,0,0,0,0,0,0
+1153,80111,11,Open Water,,80,Rangeland,,-1,-1,-1,-1,-1,0,1,-1,1,0.15,low,#e5f5e0,14.16699743,0,15.56798855,1.6,0,0,0
+1154,80112,11,Open Water,,80,Rangeland,,-1,-1,-1,-1,-1,0,1,-1,2,0.4,medium,#a1d99b,37.7786598,0,41.51463613,4.266666667,0,0,0
+1155,80113,11,Open Water,,80,Rangeland,,-1,-1,-1,-1,-1,0,1,-1,3,0.66,high,#31a354,62.33478868,0,68.49914961,7.04,0,0,0
+1156,80120,12,Perennial Ice/Snow,,80,Rangeland,,-1,-1,-1,-1,-1,-1,-1,-1,0,0,none,#ffffff,0,0,0,0,0,0,0
+1157,80121,12,Perennial Ice/Snow,,80,Rangeland,,-1,-1,-1,-1,-1,-1,-1,-1,1,0.15,low,#e5f5e0,14.16699743,0,15.56798855,1.6,0,0,0
+1158,80122,12,Perennial Ice/Snow,,80,Rangeland,,-1,-1,-1,-1,-1,-1,-1,-1,2,0.4,medium,#a1d99b,37.7786598,0,41.51463613,4.266666667,0,0,0
+1159,80123,12,Perennial Ice/Snow,,80,Rangeland,,-1,-1,-1,-1,-1,-1,-1,-1,3,0.66,high,#31a354,62.33478868,0,68.49914961,7.04,0,0,0
+1160,80210,21,"Developed, Open Space","20% trees, 60% grass, and 10% buildings and 10% bare soil",80,Rangeland,,-1,-1,-1,0.5,0.3,0,1,-1,0,0,none,#ffffff,25.49986095,4.08,79.01411479,1.76,51.81402439,212.31,37.03522039
+1161,80211,21,"Developed, Open Space","20% trees, 60% grass, and 10% buildings and 10% bare soil",80,Rangeland,,-1,-1,-1,0.5,0.3,0,1,-1,1,0.15,low,#e5f5e0,35.84187923,3.468,82.72998612,3.096,51.81402439,212.31,37.03522039
+1162,80212,21,"Developed, Open Space","20% trees, 60% grass, and 10% buildings and 10% bare soil",80,Rangeland,,-1,-1,-1,0.5,0.3,0,1,-1,2,0.4,medium,#a1d99b,53.07857637,2.448,88.923105,5.322666667,51.81402439,212.31,37.03522039
+1163,80213,21,"Developed, Open Space","20% trees, 60% grass, and 10% buildings and 10% bare soil",80,Rangeland,,-1,-1,-1,0.5,0.3,0,1,-1,3,0.66,high,#31a354,71.0047414,1.3872,95.36394864,7.6384,51.81402439,212.31,37.03522039
+1164,80220,22,"Developed, Low Intensity","20% trees, 40% grass, and 40% buildings",80,Rangeland,,-1,-1,-1,0.5,0.3,-1,1,-1,0,0,none,#ffffff,20.90844667,3.52,72.06732319,0.61,207.2560976,849.24,147.1338816
+1165,80221,22,"Developed, Low Intensity","20% trees, 40% grass, and 40% buildings",80,Rangeland,,-1,-1,-1,0.5,0.3,-1,1,-1,1,0.15,low,#e5f5e0,31.9391771,2.992,76.82521326,2.1185,207.2560976,849.24,147.1338816
+1166,80222,22,"Developed, Low Intensity","20% trees, 40% grass, and 40% buildings",80,Rangeland,,-1,-1,-1,0.5,0.3,-1,1,-1,2,0.4,medium,#a1d99b,50.32372781,2.112,84.75503004,4.632666667,207.2560976,849.24,147.1338816
+1167,80223,22,"Developed, Low Intensity","20% trees, 40% grass, and 40% buildings",80,Rangeland,,-1,-1,-1,0.5,0.3,-1,1,-1,3,0.66,high,#31a354,69.44366054,1.1968,93.0020395,7.2474,207.2560976,849.24,147.1338816
+1168,80230,23,"Developed, Medium Intensity","15% trees, 35% grass, and 50% buildings",80,Rangeland,,-1,-1,-1,0.5,0.3,-1,1,-1,0,0,none,#ffffff,17.69813636,3.08,61.93838294,0.36,234.070122,954.85,720.4716833
+1169,80231,23,"Developed, Medium Intensity","15% trees, 35% grass, and 50% buildings",80,Rangeland,,-1,-1,-1,0.5,0.3,-1,1,-1,1,0.15,low,#e5f5e0,29.21041333,2.618,68.21561405,1.906,234.070122,954.85,720.4716833
+1170,80232,23,"Developed, Medium Intensity","15% trees, 35% grass, and 50% buildings",80,Rangeland,,-1,-1,-1,0.5,0.3,-1,1,-1,2,0.4,medium,#a1d99b,48.39754162,1.848,78.67766589,4.482666667,234.070122,954.85,720.4716833
+1171,80233,23,"Developed, Medium Intensity","15% trees, 35% grass, and 50% buildings",80,Rangeland,,-1,-1,-1,0.5,0.3,-1,1,-1,3,0.66,high,#31a354,68.35215504,1.0472,89.55819981,7.1624,234.070122,954.85,720.4716833
+1172,80240,24,"Developed, High Intensity","10% trees, 20% grass, and 70% buildings",80,Rangeland,,-1,-1,-1,0.5,0.3,-1,1,-1,0,0,none,#ffffff,10.98142029,1.76,44.78642515,0.245,267.9065041,3418.485,1805.616283
+1173,80241,24,"Developed, High Intensity","10% trees, 20% grass, and 70% buildings",80,Rangeland,,-1,-1,-1,0.5,0.3,-1,1,-1,1,0.15,low,#e5f5e0,23.50120467,1.496,53.63644993,1.80825,267.9065041,3418.485,1805.616283
+1174,80242,24,"Developed, High Intensity","10% trees, 20% grass, and 70% buildings",80,Rangeland,,-1,-1,-1,0.5,0.3,-1,1,-1,2,0.4,medium,#a1d99b,44.36751198,1.056,68.38649122,4.413666667,267.9065041,3418.485,1805.616283
+1175,80243,24,"Developed, High Intensity","10% trees, 20% grass, and 70% buildings",80,Rangeland,,-1,-1,-1,0.5,0.3,-1,1,-1,3,0.66,high,#31a354,66.06847158,0.5984,83.72653416,7.1233,267.9065041,3418.485,1805.616283
+1176,80310,31,Barren Land,,80,Rangeland,,-1,-1,-1,0.5,0.3,0,1,-1,0,0,none,#ffffff,6.8,0,25.5,0,0,0,0
+1177,80311,31,Barren Land,,80,Rangeland,,-1,-1,-1,0.5,0.3,0,1,-1,1,0.15,low,#e5f5e0,19.94699743,0,37.24298855,1.6,0,0,0
+1178,80312,31,Barren Land,,80,Rangeland,,-1,-1,-1,0.5,0.3,0,1,-1,2,0.4,medium,#a1d99b,41.8586598,0,56.81463613,4.266666667,0,0,0
+1179,80313,31,Barren Land,,80,Rangeland,,-1,-1,-1,0.5,0.3,0,1,-1,3,0.66,high,#31a354,64.64678868,0,77.16914961,7.04,0,0,0
+1180,80410,41,Deciduous Forest,,80,Rangeland,,-1,-1,-1,-1,0.3,0,1,-1,0,0,none,#ffffff,85.88498714,0,96.08994273,8.8,0,0,0
+1181,80411,41,Deciduous Forest,,80,Rangeland,,-1,-1,-1,-1,0.3,0,1,-1,1,0.15,low,#e5f5e0,85.88498714,0,96.08994273,8.8,0,0,0
+1182,80412,41,Deciduous Forest,,80,Rangeland,,-1,-1,-1,-1,0.3,0,1,-1,2,0.4,medium,#a1d99b,85.88498714,0,96.08994273,8.8,0,0,0
+1183,80413,41,Deciduous Forest,,80,Rangeland,,-1,-1,-1,-1,0.3,0,1,-1,3,0.66,high,#31a354,85.88498714,0,96.08994273,8.8,0,0,0
+1184,80420,42,Evergreen Forest,,80,Rangeland,,-1,-1,-1,-1,0.3,0,1,-1,0,0,none,#ffffff,105.6849871,0,96.08994273,14.4,0,0,0
+1185,80421,42,Evergreen Forest,,80,Rangeland,,-1,-1,-1,-1,0.3,0,1,-1,1,0.15,low,#e5f5e0,105.6849871,0,96.08994273,14.4,0,0,0
+1186,80422,42,Evergreen Forest,,80,Rangeland,,-1,-1,-1,-1,0.3,0,1,-1,2,0.4,medium,#a1d99b,105.6849871,0,96.08994273,14.4,0,0,0
+1187,80423,42,Evergreen Forest,,80,Rangeland,,-1,-1,-1,-1,0.3,0,1,-1,3,0.66,high,#31a354,105.6849871,0,96.08994273,14.4,0,0,0
+1188,80430,43,Mixed Forest,,80,Rangeland,,-1,-1,-1,-1,0.3,0,1,-1,0,0,none,#ffffff,91.76997429,0,119.1798855,8.8,0,0,0
+1189,80431,43,Mixed Forest,,80,Rangeland,,-1,-1,-1,-1,0.3,0,1,-1,1,0.15,low,#e5f5e0,91.76997429,0,119.1798855,8.8,0,0,0
+1190,80432,43,Mixed Forest,,80,Rangeland,,-1,-1,-1,-1,0.3,0,1,-1,2,0.4,medium,#a1d99b,91.76997429,0,119.1798855,8.8,0,0,0
+1191,80433,43,Mixed Forest,,80,Rangeland,,-1,-1,-1,-1,0.3,0,1,-1,3,0.66,high,#31a354,91.76997429,0,119.1798855,8.8,0,0,0
+1192,80520,52,Shrub/Scrub,,80,Rangeland,,-1,-1,-1,0.5,0.3,0,1,-1,0,0,none,#ffffff,47.875,0,68.15477645,0,0,0,0
+1193,80521,52,Shrub/Scrub,,80,Rangeland,,-1,-1,-1,0.5,0.3,0,1,-1,1,0.15,low,#e5f5e0,54.86074743,0,73.49954853,1.6,0,0,0
+1194,80522,52,Shrub/Scrub,,80,Rangeland,,-1,-1,-1,0.5,0.3,0,1,-1,2,0.4,medium,#a1d99b,66.5036598,0,82.407502,4.266666667,0,0,0
+1195,80523,52,Shrub/Scrub,,80,Rangeland,,-1,-1,-1,0.5,0.3,0,1,-1,3,0.66,high,#31a354,78.61228868,0,91.6717736,7.04,0,0,0
+1196,80710,71,Herbaceuous,,80,Rangeland,,-1,-1,-1,0.5,0.3,0,1,-1,0,0,none,#ffffff,10.10660117,8,98.79264417,0,0,0,0
+1197,80711,71,Herbaceuous,,80,Rangeland,,-1,-1,-1,0.5,0.3,0,1,-1,1,0.15,low,#e5f5e0,22.75760842,6.8,99.54173609,1.6,0,0,0
+1198,80712,71,Herbaceuous,,80,Rangeland,,-1,-1,-1,0.5,0.3,0,1,-1,2,0.4,medium,#a1d99b,43.84262051,4.8,100.7902226,4.266666667,0,0,0
+1199,80713,71,Herbaceuous,,80,Rangeland,,-1,-1,-1,0.5,0.3,0,1,-1,3,0.66,high,#31a354,65.77103307,2.72,102.0886486,7.04,0,0,0
+1200,80810,81,Hay/Pasture,,80,Rangeland,,-1,-1,-1,0.5,0.3,0,1,-1,0,0,none,#ffffff,10.10660117,8,98.79264417,0,0,0,0
+1201,80811,81,Hay/Pasture,,80,Rangeland,,-1,-1,-1,0.5,0.3,0,1,-1,1,0.15,low,#e5f5e0,22.75760842,6.8,99.54173609,1.6,0,0,0
+1202,80812,81,Hay/Pasture,,80,Rangeland,,-1,-1,-1,0.5,0.3,0,1,-1,2,0.4,medium,#a1d99b,43.84262051,4.8,100.7902226,4.266666667,0,0,0
+1203,80813,81,Hay/Pasture,,80,Rangeland,,-1,-1,-1,0.5,0.3,0,1,-1,3,0.66,high,#31a354,65.77103307,2.72,102.0886486,7.04,0,0,0
+1204,80820,82,Cultivated Crops,,80,Rangeland,,-1,-1,-1,-1,-1,0,1,-1,0,0,none,#ffffff,4.793840162,0,65.75263422,0,0,0,0
+1205,80821,82,Cultivated Crops,,80,Rangeland,,-1,-1,-1,-1,-1,0,1,-1,1,0.15,low,#e5f5e0,18.24176156,0,71.45772764,1.6,0,0,0
+1206,80822,82,Cultivated Crops,,80,Rangeland,,-1,-1,-1,-1,-1,0,1,-1,2,0.4,medium,#a1d99b,40.6549639,0,80.96621666,4.266666667,0,0,0
+1207,80823,82,Cultivated Crops,,80,Rangeland,,-1,-1,-1,-1,-1,0,1,-1,3,0.66,high,#31a354,63.96469433,0,90.85504525,7.04,0,0,0
+1208,80900,90,Woody Wetlands,,80,Rangeland,,-1,-1,-1,-1,0.3,0,1,-1,0,0,none,#ffffff,33.5,0,259,0,0,0,0
+1209,80901,90,Woody Wetlands,,80,Rangeland,,-1,-1,-1,-1,0.3,0,1,-1,1,0.15,low,#e5f5e0,42.64199743,0,235.7179885,1.6,0,0,0
+1210,80902,90,Woody Wetlands,,80,Rangeland,,-1,-1,-1,-1,0.3,0,1,-1,2,0.4,medium,#a1d99b,57.8786598,0,196.9146361,4.266666667,0,0,0
+1211,80903,90,Woody Wetlands,,80,Rangeland,,-1,-1,-1,-1,0.3,0,1,-1,3,0.66,high,#31a354,73.72478868,0,156.5591496,7.04,0,0,0
+1212,80950,95,Emergent Herbaceuous Wetlands,,80,Rangeland,,-1,-1,-1,-1,0.3,0,1,-1,0,0,none,#ffffff,33.5,0,259,0,0,0,0
+1213,80951,95,Emergent Herbaceuous Wetlands,,80,Rangeland,,-1,-1,-1,-1,0.3,0,1,-1,1,0.15,low,#e5f5e0,42.64199743,0,235.7179885,1.6,0,0,0
+1214,80952,95,Emergent Herbaceuous Wetlands,,80,Rangeland,,-1,-1,-1,-1,0.3,0,1,-1,2,0.4,medium,#a1d99b,57.8786598,0,196.9146361,4.266666667,0,0,0
+1215,80953,95,Emergent Herbaceuous Wetlands,,80,Rangeland,,-1,-1,-1,-1,0.3,0,1,-1,3,0.66,high,#31a354,73.72478868,0,156.5591496,7.04,0,0,0
+1216,90110,11,Open Water,,90,Extractive/Mining,,-1,-1,-1,-1,-1,0,-1,-1,0,0,none,#ffffff,0,0,0,0,0,0,0
+1217,90111,11,Open Water,,90,Extractive/Mining,,-1,-1,-1,-1,-1,0,-1,-1,1,0.15,low,#e5f5e0,14.16699743,0,15.56798855,1.6,0,0,0
+1218,90112,11,Open Water,,90,Extractive/Mining,,-1,-1,-1,-1,-1,0,-1,-1,2,0.4,medium,#a1d99b,37.7786598,0,41.51463613,4.266666667,0,0,0
+1219,90113,11,Open Water,,90,Extractive/Mining,,-1,-1,-1,-1,-1,0,-1,-1,3,0.66,high,#31a354,62.33478868,0,68.49914961,7.04,0,0,0
+1220,90120,12,Perennial Ice/Snow,,90,Extractive/Mining,,-1,-1,-1,-1,-1,-1,-1,-1,0,0,none,#ffffff,0,0,0,0,0,0,0
+1221,90121,12,Perennial Ice/Snow,,90,Extractive/Mining,,-1,-1,-1,-1,-1,-1,-1,-1,1,0.15,low,#e5f5e0,14.16699743,0,15.56798855,1.6,0,0,0
+1222,90122,12,Perennial Ice/Snow,,90,Extractive/Mining,,-1,-1,-1,-1,-1,-1,-1,-1,2,0.4,medium,#a1d99b,37.7786598,0,41.51463613,4.266666667,0,0,0
+1223,90123,12,Perennial Ice/Snow,,90,Extractive/Mining,,-1,-1,-1,-1,-1,-1,-1,-1,3,0.66,high,#31a354,62.33478868,0,68.49914961,7.04,0,0,0
+1224,90210,21,"Developed, Open Space","20% trees, 60% grass, and 10% buildings and 10% bare soil",90,Extractive/Mining,,-1,-1,-1,-1,-1,0,-1,-1,0,0,none,#ffffff,25.49986095,4.08,79.01411479,1.76,51.81402439,212.31,37.03522039
+1225,90211,21,"Developed, Open Space","20% trees, 60% grass, and 10% buildings and 10% bare soil",90,Extractive/Mining,,-1,-1,-1,-1,-1,0,-1,-1,1,0.15,low,#e5f5e0,35.84187923,3.468,82.72998612,3.096,51.81402439,212.31,37.03522039
+1226,90212,21,"Developed, Open Space","20% trees, 60% grass, and 10% buildings and 10% bare soil",90,Extractive/Mining,,-1,-1,-1,-1,-1,0,-1,-1,2,0.4,medium,#a1d99b,53.07857637,2.448,88.923105,5.322666667,51.81402439,212.31,37.03522039
+1227,90213,21,"Developed, Open Space","20% trees, 60% grass, and 10% buildings and 10% bare soil",90,Extractive/Mining,,-1,-1,-1,-1,-1,0,-1,-1,3,0.66,high,#31a354,71.0047414,1.3872,95.36394864,7.6384,51.81402439,212.31,37.03522039
+1228,90220,22,"Developed, Low Intensity","20% trees, 40% grass, and 40% buildings",90,Extractive/Mining,,-1,-1,-1,-1,-1,-1,-1,-1,0,0,none,#ffffff,20.90844667,3.52,72.06732319,0.61,207.2560976,849.24,147.1338816
+1229,90221,22,"Developed, Low Intensity","20% trees, 40% grass, and 40% buildings",90,Extractive/Mining,,-1,-1,-1,-1,-1,-1,-1,-1,1,0.15,low,#e5f5e0,31.9391771,2.992,76.82521326,2.1185,207.2560976,849.24,147.1338816
+1230,90222,22,"Developed, Low Intensity","20% trees, 40% grass, and 40% buildings",90,Extractive/Mining,,-1,-1,-1,-1,-1,-1,-1,-1,2,0.4,medium,#a1d99b,50.32372781,2.112,84.75503004,4.632666667,207.2560976,849.24,147.1338816
+1231,90223,22,"Developed, Low Intensity","20% trees, 40% grass, and 40% buildings",90,Extractive/Mining,,-1,-1,-1,-1,-1,-1,-1,-1,3,0.66,high,#31a354,69.44366054,1.1968,93.0020395,7.2474,207.2560976,849.24,147.1338816
+1232,90230,23,"Developed, Medium Intensity","15% trees, 35% grass, and 50% buildings",90,Extractive/Mining,,-1,-1,-1,-1,-1,-1,-1,-1,0,0,none,#ffffff,17.69813636,3.08,61.93838294,0.36,234.070122,954.85,720.4716833
+1233,90231,23,"Developed, Medium Intensity","15% trees, 35% grass, and 50% buildings",90,Extractive/Mining,,-1,-1,-1,-1,-1,-1,-1,-1,1,0.15,low,#e5f5e0,29.21041333,2.618,68.21561405,1.906,234.070122,954.85,720.4716833
+1234,90232,23,"Developed, Medium Intensity","15% trees, 35% grass, and 50% buildings",90,Extractive/Mining,,-1,-1,-1,-1,-1,-1,-1,-1,2,0.4,medium,#a1d99b,48.39754162,1.848,78.67766589,4.482666667,234.070122,954.85,720.4716833
+1235,90233,23,"Developed, Medium Intensity","15% trees, 35% grass, and 50% buildings",90,Extractive/Mining,,-1,-1,-1,-1,-1,-1,-1,-1,3,0.66,high,#31a354,68.35215504,1.0472,89.55819981,7.1624,234.070122,954.85,720.4716833
+1236,90240,24,"Developed, High Intensity","10% trees, 20% grass, and 70% buildings",90,Extractive/Mining,,-1,-1,-1,-1,-1,-1,-1,-1,0,0,none,#ffffff,10.98142029,1.76,44.78642515,0.245,267.9065041,3418.485,1805.616283
+1237,90241,24,"Developed, High Intensity","10% trees, 20% grass, and 70% buildings",90,Extractive/Mining,,-1,-1,-1,-1,-1,-1,-1,-1,1,0.15,low,#e5f5e0,23.50120467,1.496,53.63644993,1.80825,267.9065041,3418.485,1805.616283
+1238,90242,24,"Developed, High Intensity","10% trees, 20% grass, and 70% buildings",90,Extractive/Mining,,-1,-1,-1,-1,-1,-1,-1,-1,2,0.4,medium,#a1d99b,44.36751198,1.056,68.38649122,4.413666667,267.9065041,3418.485,1805.616283
+1239,90243,24,"Developed, High Intensity","10% trees, 20% grass, and 70% buildings",90,Extractive/Mining,,-1,-1,-1,-1,-1,-1,-1,-1,3,0.66,high,#31a354,66.06847158,0.5984,83.72653416,7.1233,267.9065041,3418.485,1805.616283
+1240,90310,31,Barren Land,,90,Extractive/Mining,,-1,-1,-1,-1,-1,0,-1,-1,0,0,none,#ffffff,6.8,0,25.5,0,0,0,0
+1241,90311,31,Barren Land,,90,Extractive/Mining,,-1,-1,-1,-1,-1,0,-1,-1,1,0.15,low,#e5f5e0,19.94699743,0,37.24298855,1.6,0,0,0
+1242,90312,31,Barren Land,,90,Extractive/Mining,,-1,-1,-1,-1,-1,0,-1,-1,2,0.4,medium,#a1d99b,41.8586598,0,56.81463613,4.266666667,0,0,0
+1243,90313,31,Barren Land,,90,Extractive/Mining,,-1,-1,-1,-1,-1,0,-1,-1,3,0.66,high,#31a354,64.64678868,0,77.16914961,7.04,0,0,0
+1244,90410,41,Deciduous Forest,,90,Extractive/Mining,,-1,-1,-1,-1,-1,0,-1,-1,0,0,none,#ffffff,85.88498714,0,96.08994273,8.8,0,0,0
+1245,90411,41,Deciduous Forest,,90,Extractive/Mining,,-1,-1,-1,-1,-1,0,-1,-1,1,0.15,low,#e5f5e0,85.88498714,0,96.08994273,8.8,0,0,0
+1246,90412,41,Deciduous Forest,,90,Extractive/Mining,,-1,-1,-1,-1,-1,0,-1,-1,2,0.4,medium,#a1d99b,85.88498714,0,96.08994273,8.8,0,0,0
+1247,90413,41,Deciduous Forest,,90,Extractive/Mining,,-1,-1,-1,-1,-1,0,-1,-1,3,0.66,high,#31a354,85.88498714,0,96.08994273,8.8,0,0,0
+1248,90420,42,Evergreen Forest,,90,Extractive/Mining,,-1,-1,-1,-1,-1,0,-1,-1,0,0,none,#ffffff,105.6849871,0,96.08994273,14.4,0,0,0
+1249,90421,42,Evergreen Forest,,90,Extractive/Mining,,-1,-1,-1,-1,-1,0,-1,-1,1,0.15,low,#e5f5e0,105.6849871,0,96.08994273,14.4,0,0,0
+1250,90422,42,Evergreen Forest,,90,Extractive/Mining,,-1,-1,-1,-1,-1,0,-1,-1,2,0.4,medium,#a1d99b,105.6849871,0,96.08994273,14.4,0,0,0
+1251,90423,42,Evergreen Forest,,90,Extractive/Mining,,-1,-1,-1,-1,-1,0,-1,-1,3,0.66,high,#31a354,105.6849871,0,96.08994273,14.4,0,0,0
+1252,90430,43,Mixed Forest,,90,Extractive/Mining,,-1,-1,-1,-1,-1,0,-1,-1,0,0,none,#ffffff,91.76997429,0,119.1798855,8.8,0,0,0
+1253,90431,43,Mixed Forest,,90,Extractive/Mining,,-1,-1,-1,-1,-1,0,-1,-1,1,0.15,low,#e5f5e0,91.76997429,0,119.1798855,8.8,0,0,0
+1254,90432,43,Mixed Forest,,90,Extractive/Mining,,-1,-1,-1,-1,-1,0,-1,-1,2,0.4,medium,#a1d99b,91.76997429,0,119.1798855,8.8,0,0,0
+1255,90433,43,Mixed Forest,,90,Extractive/Mining,,-1,-1,-1,-1,-1,0,-1,-1,3,0.66,high,#31a354,91.76997429,0,119.1798855,8.8,0,0,0
+1256,90520,52,Shrub/Scrub,,90,Extractive/Mining,,-1,-1,-1,-1,-1,0,-1,-1,0,0,none,#ffffff,47.875,0,68.15477645,0,0,0,0
+1257,90521,52,Shrub/Scrub,,90,Extractive/Mining,,-1,-1,-1,-1,-1,0,-1,-1,1,0.15,low,#e5f5e0,54.86074743,0,73.49954853,1.6,0,0,0
+1258,90522,52,Shrub/Scrub,,90,Extractive/Mining,,-1,-1,-1,-1,-1,0,-1,-1,2,0.4,medium,#a1d99b,66.5036598,0,82.407502,4.266666667,0,0,0
+1259,90523,52,Shrub/Scrub,,90,Extractive/Mining,,-1,-1,-1,-1,-1,0,-1,-1,3,0.66,high,#31a354,78.61228868,0,91.6717736,7.04,0,0,0
+1260,90710,71,Herbaceuous,,90,Extractive/Mining,,-1,-1,-1,-1,-1,0,-1,-1,0,0,none,#ffffff,10.10660117,8,98.79264417,0,0,0,0
+1261,90711,71,Herbaceuous,,90,Extractive/Mining,,-1,-1,-1,-1,-1,0,-1,-1,1,0.15,low,#e5f5e0,22.75760842,6.8,99.54173609,1.6,0,0,0
+1262,90712,71,Herbaceuous,,90,Extractive/Mining,,-1,-1,-1,-1,-1,0,-1,-1,2,0.4,medium,#a1d99b,43.84262051,4.8,100.7902226,4.266666667,0,0,0
+1263,90713,71,Herbaceuous,,90,Extractive/Mining,,-1,-1,-1,-1,-1,0,-1,-1,3,0.66,high,#31a354,65.77103307,2.72,102.0886486,7.04,0,0,0
+1264,90810,81,Hay/Pasture,,90,Extractive/Mining,,-1,-1,-1,-1,-1,0,-1,-1,0,0,none,#ffffff,10.10660117,8,98.79264417,0,0,0,0
+1265,90811,81,Hay/Pasture,,90,Extractive/Mining,,-1,-1,-1,-1,-1,0,-1,-1,1,0.15,low,#e5f5e0,22.75760842,6.8,99.54173609,1.6,0,0,0
+1266,90812,81,Hay/Pasture,,90,Extractive/Mining,,-1,-1,-1,-1,-1,0,-1,-1,2,0.4,medium,#a1d99b,43.84262051,4.8,100.7902226,4.266666667,0,0,0
+1267,90813,81,Hay/Pasture,,90,Extractive/Mining,,-1,-1,-1,-1,-1,0,-1,-1,3,0.66,high,#31a354,65.77103307,2.72,102.0886486,7.04,0,0,0
+1268,90820,82,Cultivated Crops,,90,Extractive/Mining,,-1,-1,-1,-1,-1,0,-1,-1,0,0,none,#ffffff,4.793840162,0,65.75263422,0,0,0,0
+1269,90821,82,Cultivated Crops,,90,Extractive/Mining,,-1,-1,-1,-1,-1,0,-1,-1,1,0.15,low,#e5f5e0,18.24176156,0,71.45772764,1.6,0,0,0
+1270,90822,82,Cultivated Crops,,90,Extractive/Mining,,-1,-1,-1,-1,-1,0,-1,-1,2,0.4,medium,#a1d99b,40.6549639,0,80.96621666,4.266666667,0,0,0
+1271,90823,82,Cultivated Crops,,90,Extractive/Mining,,-1,-1,-1,-1,-1,0,-1,-1,3,0.66,high,#31a354,63.96469433,0,90.85504525,7.04,0,0,0
+1272,90900,90,Woody Wetlands,,90,Extractive/Mining,,-1,-1,-1,-1,-1,0,-1,-1,0,0,none,#ffffff,33.5,0,259,0,0,0,0
+1273,90901,90,Woody Wetlands,,90,Extractive/Mining,,-1,-1,-1,-1,-1,0,-1,-1,1,0.15,low,#e5f5e0,42.64199743,0,235.7179885,1.6,0,0,0
+1274,90902,90,Woody Wetlands,,90,Extractive/Mining,,-1,-1,-1,-1,-1,0,-1,-1,2,0.4,medium,#a1d99b,57.8786598,0,196.9146361,4.266666667,0,0,0
+1275,90903,90,Woody Wetlands,,90,Extractive/Mining,,-1,-1,-1,-1,-1,0,-1,-1,3,0.66,high,#31a354,73.72478868,0,156.5591496,7.04,0,0,0
+1276,90950,95,Emergent Herbaceuous Wetlands,,90,Extractive/Mining,,-1,-1,-1,-1,-1,0,-1,-1,0,0,none,#ffffff,33.5,0,259,0,0,0,0
+1277,90951,95,Emergent Herbaceuous Wetlands,,90,Extractive/Mining,,-1,-1,-1,-1,-1,0,-1,-1,1,0.15,low,#e5f5e0,42.64199743,0,235.7179885,1.6,0,0,0
+1278,90952,95,Emergent Herbaceuous Wetlands,,90,Extractive/Mining,,-1,-1,-1,-1,-1,0,-1,-1,2,0.4,medium,#a1d99b,57.8786598,0,196.9146361,4.266666667,0,0,0
+1279,90953,95,Emergent Herbaceuous Wetlands,,90,Extractive/Mining,,-1,-1,-1,-1,-1,0,-1,-1,3,0.66,high,#31a354,73.72478868,0,156.5591496,7.04,0,0,0
+1280,100110,11,Open Water,,100,Timber,,-1,-1,-1,-1,-1,0,1,-1,0,0,none,#ffffff,0,0,0,0,0,0,0
+1281,100111,11,Open Water,,100,Timber,,-1,-1,-1,-1,-1,0,1,-1,1,0.15,low,#e5f5e0,14.16699743,0,15.56798855,1.6,0,0,0
+1282,100112,11,Open Water,,100,Timber,,-1,-1,-1,-1,-1,0,1,-1,2,0.4,medium,#a1d99b,37.7786598,0,41.51463613,4.266666667,0,0,0
+1283,100113,11,Open Water,,100,Timber,,-1,-1,-1,-1,-1,0,1,-1,3,0.66,high,#31a354,62.33478868,0,68.49914961,7.04,0,0,0
+1284,100120,12,Perennial Ice/Snow,,100,Timber,,-1,-1,-1,-1,-1,-1,-1,-1,0,0,none,#ffffff,0,0,0,0,0,0,0
+1285,100121,12,Perennial Ice/Snow,,100,Timber,,-1,-1,-1,-1,-1,-1,-1,-1,1,0.15,low,#e5f5e0,14.16699743,0,15.56798855,1.6,0,0,0
+1286,100122,12,Perennial Ice/Snow,,100,Timber,,-1,-1,-1,-1,-1,-1,-1,-1,2,0.4,medium,#a1d99b,37.7786598,0,41.51463613,4.266666667,0,0,0
+1287,100123,12,Perennial Ice/Snow,,100,Timber,,-1,-1,-1,-1,-1,-1,-1,-1,3,0.66,high,#31a354,62.33478868,0,68.49914961,7.04,0,0,0
+1288,100210,21,"Developed, Open Space","20% trees, 60% grass, and 10% buildings and 10% bare soil",100,Timber,,-1,-1,-1,-1,0.3,0,1,-1,0,0,none,#ffffff,25.49986095,4.08,79.01411479,1.76,51.81402439,212.31,37.03522039
+1289,100211,21,"Developed, Open Space","20% trees, 60% grass, and 10% buildings and 10% bare soil",100,Timber,,-1,-1,-1,-1,0.3,0,1,-1,1,0.15,low,#e5f5e0,35.84187923,3.468,82.72998612,3.096,51.81402439,212.31,37.03522039
+1290,100212,21,"Developed, Open Space","20% trees, 60% grass, and 10% buildings and 10% bare soil",100,Timber,,-1,-1,-1,-1,0.3,0,1,-1,2,0.4,medium,#a1d99b,53.07857637,2.448,88.923105,5.322666667,51.81402439,212.31,37.03522039
+1291,100213,21,"Developed, Open Space","20% trees, 60% grass, and 10% buildings and 10% bare soil",100,Timber,,-1,-1,-1,-1,0.3,0,1,-1,3,0.66,high,#31a354,71.0047414,1.3872,95.36394864,7.6384,51.81402439,212.31,37.03522039
+1292,100220,22,"Developed, Low Intensity","20% trees, 40% grass, and 40% buildings",100,Timber,,-1,-1,-1,-1,0.3,-1,1,-1,0,0,none,#ffffff,20.90844667,3.52,72.06732319,0.61,207.2560976,849.24,147.1338816
+1293,100221,22,"Developed, Low Intensity","20% trees, 40% grass, and 40% buildings",100,Timber,,-1,-1,-1,-1,0.3,-1,1,-1,1,0.15,low,#e5f5e0,31.9391771,2.992,76.82521326,2.1185,207.2560976,849.24,147.1338816
+1294,100222,22,"Developed, Low Intensity","20% trees, 40% grass, and 40% buildings",100,Timber,,-1,-1,-1,-1,0.3,-1,1,-1,2,0.4,medium,#a1d99b,50.32372781,2.112,84.75503004,4.632666667,207.2560976,849.24,147.1338816
+1295,100223,22,"Developed, Low Intensity","20% trees, 40% grass, and 40% buildings",100,Timber,,-1,-1,-1,-1,0.3,-1,1,-1,3,0.66,high,#31a354,69.44366054,1.1968,93.0020395,7.2474,207.2560976,849.24,147.1338816
+1296,100230,23,"Developed, Medium Intensity","15% trees, 35% grass, and 50% buildings",100,Timber,,-1,-1,-1,-1,0.3,-1,1,-1,0,0,none,#ffffff,17.69813636,3.08,61.93838294,0.36,234.070122,954.85,720.4716833
+1297,100231,23,"Developed, Medium Intensity","15% trees, 35% grass, and 50% buildings",100,Timber,,-1,-1,-1,-1,0.3,-1,1,-1,1,0.15,low,#e5f5e0,29.21041333,2.618,68.21561405,1.906,234.070122,954.85,720.4716833
+1298,100232,23,"Developed, Medium Intensity","15% trees, 35% grass, and 50% buildings",100,Timber,,-1,-1,-1,-1,0.3,-1,1,-1,2,0.4,medium,#a1d99b,48.39754162,1.848,78.67766589,4.482666667,234.070122,954.85,720.4716833
+1299,100233,23,"Developed, Medium Intensity","15% trees, 35% grass, and 50% buildings",100,Timber,,-1,-1,-1,-1,0.3,-1,1,-1,3,0.66,high,#31a354,68.35215504,1.0472,89.55819981,7.1624,234.070122,954.85,720.4716833
+1300,100240,24,"Developed, High Intensity","10% trees, 20% grass, and 70% buildings",100,Timber,,-1,-1,-1,-1,0.3,-1,1,-1,0,0,none,#ffffff,10.98142029,1.76,44.78642515,0.245,267.9065041,3418.485,1805.616283
+1301,100241,24,"Developed, High Intensity","10% trees, 20% grass, and 70% buildings",100,Timber,,-1,-1,-1,-1,0.3,-1,1,-1,1,0.15,low,#e5f5e0,23.50120467,1.496,53.63644993,1.80825,267.9065041,3418.485,1805.616283
+1302,100242,24,"Developed, High Intensity","10% trees, 20% grass, and 70% buildings",100,Timber,,-1,-1,-1,-1,0.3,-1,1,-1,2,0.4,medium,#a1d99b,44.36751198,1.056,68.38649122,4.413666667,267.9065041,3418.485,1805.616283
+1303,100243,24,"Developed, High Intensity","10% trees, 20% grass, and 70% buildings",100,Timber,,-1,-1,-1,-1,0.3,-1,1,-1,3,0.66,high,#31a354,66.06847158,0.5984,83.72653416,7.1233,267.9065041,3418.485,1805.616283
+1304,100310,31,Barren Land,,100,Timber,,-1,-1,-1,-1,0.3,0,1,-1,0,0,none,#ffffff,6.8,0,25.5,0,0,0,0
+1305,100311,31,Barren Land,,100,Timber,,-1,-1,-1,-1,0.3,0,1,-1,1,0.15,low,#e5f5e0,19.94699743,0,37.24298855,1.6,0,0,0
+1306,100312,31,Barren Land,,100,Timber,,-1,-1,-1,-1,0.3,0,1,-1,2,0.4,medium,#a1d99b,41.8586598,0,56.81463613,4.266666667,0,0,0
+1307,100313,31,Barren Land,,100,Timber,,-1,-1,-1,-1,0.3,0,1,-1,3,0.66,high,#31a354,64.64678868,0,77.16914961,7.04,0,0,0
+1308,100410,41,Deciduous Forest,,100,Timber,,-1,-1,-1,-1,0.3,0,1,-1,0,0,none,#ffffff,85.88498714,0,96.08994273,8.8,0,0,0
+1309,100411,41,Deciduous Forest,,100,Timber,,-1,-1,-1,-1,0.3,0,1,-1,1,0.15,low,#e5f5e0,85.88498714,0,96.08994273,8.8,0,0,0
+1310,100412,41,Deciduous Forest,,100,Timber,,-1,-1,-1,-1,0.3,0,1,-1,2,0.4,medium,#a1d99b,85.88498714,0,96.08994273,8.8,0,0,0
+1311,100413,41,Deciduous Forest,,100,Timber,,-1,-1,-1,-1,0.3,0,1,-1,3,0.66,high,#31a354,85.88498714,0,96.08994273,8.8,0,0,0
+1312,100420,42,Evergreen Forest,,100,Timber,,-1,-1,-1,-1,0.3,0,1,-1,0,0,none,#ffffff,105.6849871,0,96.08994273,14.4,0,0,0
+1313,100421,42,Evergreen Forest,,100,Timber,,-1,-1,-1,-1,0.3,0,1,-1,1,0.15,low,#e5f5e0,105.6849871,0,96.08994273,14.4,0,0,0
+1314,100422,42,Evergreen Forest,,100,Timber,,-1,-1,-1,-1,0.3,0,1,-1,2,0.4,medium,#a1d99b,105.6849871,0,96.08994273,14.4,0,0,0
+1315,100423,42,Evergreen Forest,,100,Timber,,-1,-1,-1,-1,0.3,0,1,-1,3,0.66,high,#31a354,105.6849871,0,96.08994273,14.4,0,0,0
+1316,100430,43,Mixed Forest,,100,Timber,,-1,-1,-1,-1,0.3,0,1,-1,0,0,none,#ffffff,91.76997429,0,119.1798855,8.8,0,0,0
+1317,100431,43,Mixed Forest,,100,Timber,,-1,-1,-1,-1,0.3,0,1,-1,1,0.15,low,#e5f5e0,91.76997429,0,119.1798855,8.8,0,0,0
+1318,100432,43,Mixed Forest,,100,Timber,,-1,-1,-1,-1,0.3,0,1,-1,2,0.4,medium,#a1d99b,91.76997429,0,119.1798855,8.8,0,0,0
+1319,100433,43,Mixed Forest,,100,Timber,,-1,-1,-1,-1,0.3,0,1,-1,3,0.66,high,#31a354,91.76997429,0,119.1798855,8.8,0,0,0
+1320,100520,52,Shrub/Scrub,,100,Timber,,-1,-1,-1,-1,0.3,0,1,-1,0,0,none,#ffffff,47.875,0,68.15477645,0,0,0,0
+1321,100521,52,Shrub/Scrub,,100,Timber,,-1,-1,-1,-1,0.3,0,1,-1,1,0.15,low,#e5f5e0,54.86074743,0,73.49954853,1.6,0,0,0
+1322,100522,52,Shrub/Scrub,,100,Timber,,-1,-1,-1,-1,0.3,0,1,-1,2,0.4,medium,#a1d99b,66.5036598,0,82.407502,4.266666667,0,0,0
+1323,100523,52,Shrub/Scrub,,100,Timber,,-1,-1,-1,-1,0.3,0,1,-1,3,0.66,high,#31a354,78.61228868,0,91.6717736,7.04,0,0,0
+1324,100710,71,Herbaceuous,,100,Timber,,-1,-1,-1,-1,0.3,0,1,-1,0,0,none,#ffffff,10.10660117,8,98.79264417,0,0,0,0
+1325,100711,71,Herbaceuous,,100,Timber,,-1,-1,-1,-1,0.3,0,1,-1,1,0.15,low,#e5f5e0,22.75760842,6.8,99.54173609,1.6,0,0,0
+1326,100712,71,Herbaceuous,,100,Timber,,-1,-1,-1,-1,0.3,0,1,-1,2,0.4,medium,#a1d99b,43.84262051,4.8,100.7902226,4.266666667,0,0,0
+1327,100713,71,Herbaceuous,,100,Timber,,-1,-1,-1,-1,0.3,0,1,-1,3,0.66,high,#31a354,65.77103307,2.72,102.0886486,7.04,0,0,0
+1328,100810,81,Hay/Pasture,,100,Timber,,-1,-1,-1,-1,0.3,0,1,-1,0,0,none,#ffffff,10.10660117,8,98.79264417,0,0,0,0
+1329,100811,81,Hay/Pasture,,100,Timber,,-1,-1,-1,-1,0.3,0,1,-1,1,0.15,low,#e5f5e0,22.75760842,6.8,99.54173609,1.6,0,0,0
+1330,100812,81,Hay/Pasture,,100,Timber,,-1,-1,-1,-1,0.3,0,1,-1,2,0.4,medium,#a1d99b,43.84262051,4.8,100.7902226,4.266666667,0,0,0
+1331,100813,81,Hay/Pasture,,100,Timber,,-1,-1,-1,-1,0.3,0,1,-1,3,0.66,high,#31a354,65.77103307,2.72,102.0886486,7.04,0,0,0
+1332,100820,82,Cultivated Crops,,100,Timber,,-1,-1,-1,-1,-1,0,1,-1,0,0,none,#ffffff,4.793840162,0,65.75263422,0,0,0,0
+1333,100821,82,Cultivated Crops,,100,Timber,,-1,-1,-1,-1,-1,0,1,-1,1,0.15,low,#e5f5e0,18.24176156,0,71.45772764,1.6,0,0,0
+1334,100822,82,Cultivated Crops,,100,Timber,,-1,-1,-1,-1,-1,0,1,-1,2,0.4,medium,#a1d99b,40.6549639,0,80.96621666,4.266666667,0,0,0
+1335,100823,82,Cultivated Crops,,100,Timber,,-1,-1,-1,-1,-1,0,1,-1,3,0.66,high,#31a354,63.96469433,0,90.85504525,7.04,0,0,0
+1336,100900,90,Woody Wetlands,,100,Timber,,-1,-1,-1,-1,0.3,0,1,-1,0,0,none,#ffffff,33.5,0,259,0,0,0,0
+1337,100901,90,Woody Wetlands,,100,Timber,,-1,-1,-1,-1,0.3,0,1,-1,1,0.15,low,#e5f5e0,42.64199743,0,235.7179885,1.6,0,0,0
+1338,100902,90,Woody Wetlands,,100,Timber,,-1,-1,-1,-1,0.3,0,1,-1,2,0.4,medium,#a1d99b,57.8786598,0,196.9146361,4.266666667,0,0,0
+1339,100903,90,Woody Wetlands,,100,Timber,,-1,-1,-1,-1,0.3,0,1,-1,3,0.66,high,#31a354,73.72478868,0,156.5591496,7.04,0,0,0
+1340,100950,95,Emergent Herbaceuous Wetlands,,100,Timber,,-1,-1,-1,-1,0.3,0,1,-1,0,0,none,#ffffff,33.5,0,259,0,0,0,0
+1341,100951,95,Emergent Herbaceuous Wetlands,,100,Timber,,-1,-1,-1,-1,0.3,0,1,-1,1,0.15,low,#e5f5e0,42.64199743,0,235.7179885,1.6,0,0,0
+1342,100952,95,Emergent Herbaceuous Wetlands,,100,Timber,,-1,-1,-1,-1,0.3,0,1,-1,2,0.4,medium,#a1d99b,57.8786598,0,196.9146361,4.266666667,0,0,0
+1343,100953,95,Emergent Herbaceuous Wetlands,,100,Timber,,-1,-1,-1,-1,0.3,0,1,-1,3,0.66,high,#31a354,73.72478868,0,156.5591496,7.04,0,0,0
+1344,110110,11,Open Water,,110,Barren,,-1,-1,-1,-1,-1,0,-1,-1,0,0,none,#ffffff,0,0,0,0,0,0,0
+1345,110111,11,Open Water,,110,Barren,,-1,-1,-1,-1,-1,0,-1,-1,1,0.15,low,#e5f5e0,14.16699743,0,15.56798855,1.6,0,0,0
+1346,110112,11,Open Water,,110,Barren,,-1,-1,-1,-1,-1,0,-1,-1,2,0.4,medium,#a1d99b,37.7786598,0,41.51463613,4.266666667,0,0,0
+1347,110113,11,Open Water,,110,Barren,,-1,-1,-1,-1,-1,0,-1,-1,3,0.66,high,#31a354,62.33478868,0,68.49914961,7.04,0,0,0
+1348,110120,12,Perennial Ice/Snow,,110,Barren,,-1,-1,-1,-1,-1,-1,-1,-1,0,0,none,#ffffff,0,0,0,0,0,0,0
+1349,110121,12,Perennial Ice/Snow,,110,Barren,,-1,-1,-1,-1,-1,-1,-1,-1,1,0.15,low,#e5f5e0,14.16699743,0,15.56798855,1.6,0,0,0
+1350,110122,12,Perennial Ice/Snow,,110,Barren,,-1,-1,-1,-1,-1,-1,-1,-1,2,0.4,medium,#a1d99b,37.7786598,0,41.51463613,4.266666667,0,0,0
+1351,110123,12,Perennial Ice/Snow,,110,Barren,,-1,-1,-1,-1,-1,-1,-1,-1,3,0.66,high,#31a354,62.33478868,0,68.49914961,7.04,0,0,0
+1352,110210,21,"Developed, Open Space","20% trees, 60% grass, and 10% buildings and 10% bare soil",110,Barren,,-1,-1,-1,-1,-1,0,-1,-1,0,0,none,#ffffff,25.49986095,4.08,79.01411479,1.76,51.81402439,212.31,37.03522039
+1353,110211,21,"Developed, Open Space","20% trees, 60% grass, and 10% buildings and 10% bare soil",110,Barren,,-1,-1,-1,-1,-1,0,-1,-1,1,0.15,low,#e5f5e0,35.84187923,3.468,82.72998612,3.096,51.81402439,212.31,37.03522039
+1354,110212,21,"Developed, Open Space","20% trees, 60% grass, and 10% buildings and 10% bare soil",110,Barren,,-1,-1,-1,-1,-1,0,-1,-1,2,0.4,medium,#a1d99b,53.07857637,2.448,88.923105,5.322666667,51.81402439,212.31,37.03522039
+1355,110213,21,"Developed, Open Space","20% trees, 60% grass, and 10% buildings and 10% bare soil",110,Barren,,-1,-1,-1,-1,-1,0,-1,-1,3,0.66,high,#31a354,71.0047414,1.3872,95.36394864,7.6384,51.81402439,212.31,37.03522039
+1356,110220,22,"Developed, Low Intensity","20% trees, 40% grass, and 40% buildings",110,Barren,,-1,-1,-1,-1,-1,-1,-1,-1,0,0,none,#ffffff,20.90844667,3.52,72.06732319,0.61,207.2560976,849.24,147.1338816
+1357,110221,22,"Developed, Low Intensity","20% trees, 40% grass, and 40% buildings",110,Barren,,-1,-1,-1,-1,-1,-1,-1,-1,1,0.15,low,#e5f5e0,31.9391771,2.992,76.82521326,2.1185,207.2560976,849.24,147.1338816
+1358,110222,22,"Developed, Low Intensity","20% trees, 40% grass, and 40% buildings",110,Barren,,-1,-1,-1,-1,-1,-1,-1,-1,2,0.4,medium,#a1d99b,50.32372781,2.112,84.75503004,4.632666667,207.2560976,849.24,147.1338816
+1359,110223,22,"Developed, Low Intensity","20% trees, 40% grass, and 40% buildings",110,Barren,,-1,-1,-1,-1,-1,-1,-1,-1,3,0.66,high,#31a354,69.44366054,1.1968,93.0020395,7.2474,207.2560976,849.24,147.1338816
+1360,110230,23,"Developed, Medium Intensity","15% trees, 35% grass, and 50% buildings",110,Barren,,-1,-1,-1,-1,-1,-1,-1,-1,0,0,none,#ffffff,17.69813636,3.08,61.93838294,0.36,234.070122,954.85,720.4716833
+1361,110231,23,"Developed, Medium Intensity","15% trees, 35% grass, and 50% buildings",110,Barren,,-1,-1,-1,-1,-1,-1,-1,-1,1,0.15,low,#e5f5e0,29.21041333,2.618,68.21561405,1.906,234.070122,954.85,720.4716833
+1362,110232,23,"Developed, Medium Intensity","15% trees, 35% grass, and 50% buildings",110,Barren,,-1,-1,-1,-1,-1,-1,-1,-1,2,0.4,medium,#a1d99b,48.39754162,1.848,78.67766589,4.482666667,234.070122,954.85,720.4716833
+1363,110233,23,"Developed, Medium Intensity","15% trees, 35% grass, and 50% buildings",110,Barren,,-1,-1,-1,-1,-1,-1,-1,-1,3,0.66,high,#31a354,68.35215504,1.0472,89.55819981,7.1624,234.070122,954.85,720.4716833
+1364,110240,24,"Developed, High Intensity","10% trees, 20% grass, and 70% buildings",110,Barren,,-1,-1,-1,-1,-1,-1,-1,-1,0,0,none,#ffffff,10.98142029,1.76,44.78642515,0.245,267.9065041,3418.485,1805.616283
+1365,110241,24,"Developed, High Intensity","10% trees, 20% grass, and 70% buildings",110,Barren,,-1,-1,-1,-1,-1,-1,-1,-1,1,0.15,low,#e5f5e0,23.50120467,1.496,53.63644993,1.80825,267.9065041,3418.485,1805.616283
+1366,110242,24,"Developed, High Intensity","10% trees, 20% grass, and 70% buildings",110,Barren,,-1,-1,-1,-1,-1,-1,-1,-1,2,0.4,medium,#a1d99b,44.36751198,1.056,68.38649122,4.413666667,267.9065041,3418.485,1805.616283
+1367,110243,24,"Developed, High Intensity","10% trees, 20% grass, and 70% buildings",110,Barren,,-1,-1,-1,-1,-1,-1,-1,-1,3,0.66,high,#31a354,66.06847158,0.5984,83.72653416,7.1233,267.9065041,3418.485,1805.616283
+1368,110310,31,Barren Land,,110,Barren,,-1,-1,-1,-1,-1,0,-1,-1,0,0,none,#ffffff,6.8,0,25.5,0,0,0,0
+1369,110311,31,Barren Land,,110,Barren,,-1,-1,-1,-1,-1,0,-1,-1,1,0.15,low,#e5f5e0,19.94699743,0,37.24298855,1.6,0,0,0
+1370,110312,31,Barren Land,,110,Barren,,-1,-1,-1,-1,-1,0,-1,-1,2,0.4,medium,#a1d99b,41.8586598,0,56.81463613,4.266666667,0,0,0
+1371,110313,31,Barren Land,,110,Barren,,-1,-1,-1,-1,-1,0,-1,-1,3,0.66,high,#31a354,64.64678868,0,77.16914961,7.04,0,0,0
+1372,110410,41,Deciduous Forest,,110,Barren,,-1,-1,-1,-1,-1,0,-1,-1,0,0,none,#ffffff,85.88498714,0,96.08994273,8.8,0,0,0
+1373,110411,41,Deciduous Forest,,110,Barren,,-1,-1,-1,-1,-1,0,-1,-1,1,0.15,low,#e5f5e0,85.88498714,0,96.08994273,8.8,0,0,0
+1374,110412,41,Deciduous Forest,,110,Barren,,-1,-1,-1,-1,-1,0,-1,-1,2,0.4,medium,#a1d99b,85.88498714,0,96.08994273,8.8,0,0,0
+1375,110413,41,Deciduous Forest,,110,Barren,,-1,-1,-1,-1,-1,0,-1,-1,3,0.66,high,#31a354,85.88498714,0,96.08994273,8.8,0,0,0
+1376,110420,42,Evergreen Forest,,110,Barren,,-1,-1,-1,-1,-1,0,-1,-1,0,0,none,#ffffff,105.6849871,0,96.08994273,14.4,0,0,0
+1377,110421,42,Evergreen Forest,,110,Barren,,-1,-1,-1,-1,-1,0,-1,-1,1,0.15,low,#e5f5e0,105.6849871,0,96.08994273,14.4,0,0,0
+1378,110422,42,Evergreen Forest,,110,Barren,,-1,-1,-1,-1,-1,0,-1,-1,2,0.4,medium,#a1d99b,105.6849871,0,96.08994273,14.4,0,0,0
+1379,110423,42,Evergreen Forest,,110,Barren,,-1,-1,-1,-1,-1,0,-1,-1,3,0.66,high,#31a354,105.6849871,0,96.08994273,14.4,0,0,0
+1380,110430,43,Mixed Forest,,110,Barren,,-1,-1,-1,-1,-1,0,-1,-1,0,0,none,#ffffff,91.76997429,0,119.1798855,8.8,0,0,0
+1381,110431,43,Mixed Forest,,110,Barren,,-1,-1,-1,-1,-1,0,-1,-1,1,0.15,low,#e5f5e0,91.76997429,0,119.1798855,8.8,0,0,0
+1382,110432,43,Mixed Forest,,110,Barren,,-1,-1,-1,-1,-1,0,-1,-1,2,0.4,medium,#a1d99b,91.76997429,0,119.1798855,8.8,0,0,0
+1383,110433,43,Mixed Forest,,110,Barren,,-1,-1,-1,-1,-1,0,-1,-1,3,0.66,high,#31a354,91.76997429,0,119.1798855,8.8,0,0,0
+1384,110520,52,Shrub/Scrub,,110,Barren,,-1,-1,-1,-1,-1,0,-1,-1,0,0,none,#ffffff,47.875,0,68.15477645,0,0,0,0
+1385,110521,52,Shrub/Scrub,,110,Barren,,-1,-1,-1,-1,-1,0,-1,-1,1,0.15,low,#e5f5e0,54.86074743,0,73.49954853,1.6,0,0,0
+1386,110522,52,Shrub/Scrub,,110,Barren,,-1,-1,-1,-1,-1,0,-1,-1,2,0.4,medium,#a1d99b,66.5036598,0,82.407502,4.266666667,0,0,0
+1387,110523,52,Shrub/Scrub,,110,Barren,,-1,-1,-1,-1,-1,0,-1,-1,3,0.66,high,#31a354,78.61228868,0,91.6717736,7.04,0,0,0
+1388,110710,71,Herbaceuous,,110,Barren,,-1,-1,-1,-1,-1,0,-1,-1,0,0,none,#ffffff,10.10660117,8,98.79264417,0,0,0,0
+1389,110711,71,Herbaceuous,,110,Barren,,-1,-1,-1,-1,-1,0,-1,-1,1,0.15,low,#e5f5e0,22.75760842,6.8,99.54173609,1.6,0,0,0
+1390,110712,71,Herbaceuous,,110,Barren,,-1,-1,-1,-1,-1,0,-1,-1,2,0.4,medium,#a1d99b,43.84262051,4.8,100.7902226,4.266666667,0,0,0
+1391,110713,71,Herbaceuous,,110,Barren,,-1,-1,-1,-1,-1,0,-1,-1,3,0.66,high,#31a354,65.77103307,2.72,102.0886486,7.04,0,0,0
+1392,110810,81,Hay/Pasture,,110,Barren,,-1,-1,-1,-1,-1,0,-1,-1,0,0,none,#ffffff,10.10660117,8,98.79264417,0,0,0,0
+1393,110811,81,Hay/Pasture,,110,Barren,,-1,-1,-1,-1,-1,0,-1,-1,1,0.15,low,#e5f5e0,22.75760842,6.8,99.54173609,1.6,0,0,0
+1394,110812,81,Hay/Pasture,,110,Barren,,-1,-1,-1,-1,-1,0,-1,-1,2,0.4,medium,#a1d99b,43.84262051,4.8,100.7902226,4.266666667,0,0,0
+1395,110813,81,Hay/Pasture,,110,Barren,,-1,-1,-1,-1,-1,0,-1,-1,3,0.66,high,#31a354,65.77103307,2.72,102.0886486,7.04,0,0,0
+1396,110820,82,Cultivated Crops,,110,Barren,,-1,-1,-1,-1,-1,0,-1,-1,0,0,none,#ffffff,4.793840162,0,65.75263422,0,0,0,0
+1397,110821,82,Cultivated Crops,,110,Barren,,-1,-1,-1,-1,-1,0,-1,-1,1,0.15,low,#e5f5e0,18.24176156,0,71.45772764,1.6,0,0,0
+1398,110822,82,Cultivated Crops,,110,Barren,,-1,-1,-1,-1,-1,0,-1,-1,2,0.4,medium,#a1d99b,40.6549639,0,80.96621666,4.266666667,0,0,0
+1399,110823,82,Cultivated Crops,,110,Barren,,-1,-1,-1,-1,-1,0,-1,-1,3,0.66,high,#31a354,63.96469433,0,90.85504525,7.04,0,0,0
+1400,110900,90,Woody Wetlands,,110,Barren,,-1,-1,-1,-1,-1,0,-1,-1,0,0,none,#ffffff,33.5,0,259,0,0,0,0
+1401,110901,90,Woody Wetlands,,110,Barren,,-1,-1,-1,-1,-1,0,-1,-1,1,0.15,low,#e5f5e0,42.64199743,0,235.7179885,1.6,0,0,0
+1402,110902,90,Woody Wetlands,,110,Barren,,-1,-1,-1,-1,-1,0,-1,-1,2,0.4,medium,#a1d99b,57.8786598,0,196.9146361,4.266666667,0,0,0
+1403,110903,90,Woody Wetlands,,110,Barren,,-1,-1,-1,-1,-1,0,-1,-1,3,0.66,high,#31a354,73.72478868,0,156.5591496,7.04,0,0,0
+1404,110950,95,Emergent Herbaceuous Wetlands,,110,Barren,,-1,-1,-1,-1,-1,0,-1,-1,0,0,none,#ffffff,33.5,0,259,0,0,0,0
+1405,110951,95,Emergent Herbaceuous Wetlands,,110,Barren,,-1,-1,-1,-1,-1,0,-1,-1,1,0.15,low,#e5f5e0,42.64199743,0,235.7179885,1.6,0,0,0
+1406,110952,95,Emergent Herbaceuous Wetlands,,110,Barren,,-1,-1,-1,-1,-1,0,-1,-1,2,0.4,medium,#a1d99b,57.8786598,0,196.9146361,4.266666667,0,0,0
+1407,110953,95,Emergent Herbaceuous Wetlands,,110,Barren,,-1,-1,-1,-1,-1,0,-1,-1,3,0.66,high,#31a354,73.72478868,0,156.5591496,7.04,0,0,0
+1408,120110,11,Open Water,,120,Undifferentiated park,,-1,-1,-1,-1,-1,-1,1,-1,0,0,none,#ffffff,0,0,0,0,0,0,0
+1409,120111,11,Open Water,,120,Undifferentiated park,,-1,-1,-1,-1,-1,-1,1,-1,1,0.15,low,#e5f5e0,14.16699743,0,15.56798855,1.6,0,0,0
+1410,120112,11,Open Water,,120,Undifferentiated park,,-1,-1,-1,-1,-1,-1,1,-1,2,0.4,medium,#a1d99b,37.7786598,0,41.51463613,4.266666667,0,0,0
+1411,120113,11,Open Water,,120,Undifferentiated park,,-1,-1,-1,-1,-1,-1,1,-1,3,0.66,high,#31a354,62.33478868,0,68.49914961,7.04,0,0,0
+1412,120120,12,Perennial Ice/Snow,,120,Undifferentiated park,,-1,-1,-1,-1,-1,-1,-1,-1,0,0,none,#ffffff,0,0,0,0,0,0,0
+1413,120121,12,Perennial Ice/Snow,,120,Undifferentiated park,,-1,-1,-1,-1,-1,-1,-1,-1,1,0.15,low,#e5f5e0,14.16699743,0,15.56798855,1.6,0,0,0
+1414,120122,12,Perennial Ice/Snow,,120,Undifferentiated park,,-1,-1,-1,-1,-1,-1,-1,-1,2,0.4,medium,#a1d99b,37.7786598,0,41.51463613,4.266666667,0,0,0
+1415,120123,12,Perennial Ice/Snow,,120,Undifferentiated park,,-1,-1,-1,-1,-1,-1,-1,-1,3,0.66,high,#31a354,62.33478868,0,68.49914961,7.04,0,0,0
+1416,120210,21,"Developed, Open Space","20% trees, 60% grass, and 10% buildings and 10% bare soil",120,Undifferentiated park,,-1,-1,-1,0.4,0.4,-1,1,-1,0,0,none,#ffffff,25.49986095,4.08,79.01411479,1.76,51.81402439,212.31,37.03522039
+1417,120211,21,"Developed, Open Space","20% trees, 60% grass, and 10% buildings and 10% bare soil",120,Undifferentiated park,,-1,-1,-1,0.4,0.4,-1,1,-1,1,0.15,low,#e5f5e0,35.84187923,3.468,82.72998612,3.096,51.81402439,212.31,37.03522039
+1418,120212,21,"Developed, Open Space","20% trees, 60% grass, and 10% buildings and 10% bare soil",120,Undifferentiated park,,-1,-1,-1,0.4,0.4,-1,1,-1,2,0.4,medium,#a1d99b,53.07857637,2.448,88.923105,5.322666667,51.81402439,212.31,37.03522039
+1419,120213,21,"Developed, Open Space","20% trees, 60% grass, and 10% buildings and 10% bare soil",120,Undifferentiated park,,-1,-1,-1,0.4,0.4,-1,1,-1,3,0.66,high,#31a354,71.0047414,1.3872,95.36394864,7.6384,51.81402439,212.31,37.03522039
+1420,120220,22,"Developed, Low Intensity","20% trees, 40% grass, and 40% buildings",120,Undifferentiated park,,-1,-1,-1,0.4,0.4,-1,1,-1,0,0,none,#ffffff,20.90844667,3.52,72.06732319,0.61,207.2560976,849.24,147.1338816
+1421,120221,22,"Developed, Low Intensity","20% trees, 40% grass, and 40% buildings",120,Undifferentiated park,,-1,-1,-1,0.4,0.4,-1,1,-1,1,0.15,low,#e5f5e0,31.9391771,2.992,76.82521326,2.1185,207.2560976,849.24,147.1338816
+1422,120222,22,"Developed, Low Intensity","20% trees, 40% grass, and 40% buildings",120,Undifferentiated park,,-1,-1,-1,0.4,0.4,-1,1,-1,2,0.4,medium,#a1d99b,50.32372781,2.112,84.75503004,4.632666667,207.2560976,849.24,147.1338816
+1423,120223,22,"Developed, Low Intensity","20% trees, 40% grass, and 40% buildings",120,Undifferentiated park,,-1,-1,-1,0.4,0.4,-1,1,-1,3,0.66,high,#31a354,69.44366054,1.1968,93.0020395,7.2474,207.2560976,849.24,147.1338816
+1424,120230,23,"Developed, Medium Intensity","15% trees, 35% grass, and 50% buildings",120,Undifferentiated park,,-1,-1,-1,0.4,0.4,-1,1,-1,0,0,none,#ffffff,17.69813636,3.08,61.93838294,0.36,234.070122,954.85,720.4716833
+1425,120231,23,"Developed, Medium Intensity","15% trees, 35% grass, and 50% buildings",120,Undifferentiated park,,-1,-1,-1,0.4,0.4,-1,1,-1,1,0.15,low,#e5f5e0,29.21041333,2.618,68.21561405,1.906,234.070122,954.85,720.4716833
+1426,120232,23,"Developed, Medium Intensity","15% trees, 35% grass, and 50% buildings",120,Undifferentiated park,,-1,-1,-1,0.4,0.4,-1,1,-1,2,0.4,medium,#a1d99b,48.39754162,1.848,78.67766589,4.482666667,234.070122,954.85,720.4716833
+1427,120233,23,"Developed, Medium Intensity","15% trees, 35% grass, and 50% buildings",120,Undifferentiated park,,-1,-1,-1,0.4,0.4,-1,1,-1,3,0.66,high,#31a354,68.35215504,1.0472,89.55819981,7.1624,234.070122,954.85,720.4716833
+1428,120240,24,"Developed, High Intensity","10% trees, 20% grass, and 70% buildings",120,Undifferentiated park,,-1,-1,-1,0.4,0.4,-1,1,-1,0,0,none,#ffffff,10.98142029,1.76,44.78642515,0.245,267.9065041,3418.485,1805.616283
+1429,120241,24,"Developed, High Intensity","10% trees, 20% grass, and 70% buildings",120,Undifferentiated park,,-1,-1,-1,0.4,0.4,-1,1,-1,1,0.15,low,#e5f5e0,23.50120467,1.496,53.63644993,1.80825,267.9065041,3418.485,1805.616283
+1430,120242,24,"Developed, High Intensity","10% trees, 20% grass, and 70% buildings",120,Undifferentiated park,,-1,-1,-1,0.4,0.4,-1,1,-1,2,0.4,medium,#a1d99b,44.36751198,1.056,68.38649122,4.413666667,267.9065041,3418.485,1805.616283
+1431,120243,24,"Developed, High Intensity","10% trees, 20% grass, and 70% buildings",120,Undifferentiated park,,-1,-1,-1,0.4,0.4,-1,1,-1,3,0.66,high,#31a354,66.06847158,0.5984,83.72653416,7.1233,267.9065041,3418.485,1805.616283
+1432,120310,31,Barren Land,,120,Undifferentiated park,,-1,-1,-1,0.4,0.4,-1,1,-1,0,0,none,#ffffff,6.8,0,25.5,0,0,0,0
+1433,120311,31,Barren Land,,120,Undifferentiated park,,-1,-1,-1,0.4,0.4,-1,1,-1,1,0.15,low,#e5f5e0,19.94699743,0,37.24298855,1.6,0,0,0
+1434,120312,31,Barren Land,,120,Undifferentiated park,,-1,-1,-1,0.4,0.4,-1,1,-1,2,0.4,medium,#a1d99b,41.8586598,0,56.81463613,4.266666667,0,0,0
+1435,120313,31,Barren Land,,120,Undifferentiated park,,-1,-1,-1,0.4,0.4,-1,1,-1,3,0.66,high,#31a354,64.64678868,0,77.16914961,7.04,0,0,0
+1436,120410,41,Deciduous Forest,,120,Undifferentiated park,,-1,-1,-1,-1,0.4,-1,1,-1,0,0,none,#ffffff,85.88498714,0,96.08994273,8.8,0,0,0
+1437,120411,41,Deciduous Forest,,120,Undifferentiated park,,-1,-1,-1,-1,0.4,-1,1,-1,1,0.15,low,#e5f5e0,85.88498714,0,96.08994273,8.8,0,0,0
+1438,120412,41,Deciduous Forest,,120,Undifferentiated park,,-1,-1,-1,-1,0.4,-1,1,-1,2,0.4,medium,#a1d99b,85.88498714,0,96.08994273,8.8,0,0,0
+1439,120413,41,Deciduous Forest,,120,Undifferentiated park,,-1,-1,-1,-1,0.4,-1,1,-1,3,0.66,high,#31a354,85.88498714,0,96.08994273,8.8,0,0,0
+1440,120420,42,Evergreen Forest,,120,Undifferentiated park,,-1,-1,-1,-1,0.4,-1,1,-1,0,0,none,#ffffff,105.6849871,0,96.08994273,14.4,0,0,0
+1441,120421,42,Evergreen Forest,,120,Undifferentiated park,,-1,-1,-1,-1,0.4,-1,1,-1,1,0.15,low,#e5f5e0,105.6849871,0,96.08994273,14.4,0,0,0
+1442,120422,42,Evergreen Forest,,120,Undifferentiated park,,-1,-1,-1,-1,0.4,-1,1,-1,2,0.4,medium,#a1d99b,105.6849871,0,96.08994273,14.4,0,0,0
+1443,120423,42,Evergreen Forest,,120,Undifferentiated park,,-1,-1,-1,-1,0.4,-1,1,-1,3,0.66,high,#31a354,105.6849871,0,96.08994273,14.4,0,0,0
+1444,120430,43,Mixed Forest,,120,Undifferentiated park,,-1,-1,-1,-1,0.4,-1,1,-1,0,0,none,#ffffff,91.76997429,0,119.1798855,8.8,0,0,0
+1445,120431,43,Mixed Forest,,120,Undifferentiated park,,-1,-1,-1,-1,0.4,-1,1,-1,1,0.15,low,#e5f5e0,91.76997429,0,119.1798855,8.8,0,0,0
+1446,120432,43,Mixed Forest,,120,Undifferentiated park,,-1,-1,-1,-1,0.4,-1,1,-1,2,0.4,medium,#a1d99b,91.76997429,0,119.1798855,8.8,0,0,0
+1447,120433,43,Mixed Forest,,120,Undifferentiated park,,-1,-1,-1,-1,0.4,-1,1,-1,3,0.66,high,#31a354,91.76997429,0,119.1798855,8.8,0,0,0
+1448,120520,52,Shrub/Scrub,,120,Undifferentiated park,,-1,-1,-1,0.4,0.4,-1,1,-1,0,0,none,#ffffff,47.875,0,68.15477645,0,0,0,0
+1449,120521,52,Shrub/Scrub,,120,Undifferentiated park,,-1,-1,-1,0.4,0.4,-1,1,-1,1,0.15,low,#e5f5e0,54.86074743,0,73.49954853,1.6,0,0,0
+1450,120522,52,Shrub/Scrub,,120,Undifferentiated park,,-1,-1,-1,0.4,0.4,-1,1,-1,2,0.4,medium,#a1d99b,66.5036598,0,82.407502,4.266666667,0,0,0
+1451,120523,52,Shrub/Scrub,,120,Undifferentiated park,,-1,-1,-1,0.4,0.4,-1,1,-1,3,0.66,high,#31a354,78.61228868,0,91.6717736,7.04,0,0,0
+1452,120710,71,Herbaceuous,,120,Undifferentiated park,,-1,-1,-1,0.4,0.4,-1,1,-1,0,0,none,#ffffff,10.10660117,8,98.79264417,0,0,0,0
+1453,120711,71,Herbaceuous,,120,Undifferentiated park,,-1,-1,-1,0.4,0.4,-1,1,-1,1,0.15,low,#e5f5e0,22.75760842,6.8,99.54173609,1.6,0,0,0
+1454,120712,71,Herbaceuous,,120,Undifferentiated park,,-1,-1,-1,0.4,0.4,-1,1,-1,2,0.4,medium,#a1d99b,43.84262051,4.8,100.7902226,4.266666667,0,0,0
+1455,120713,71,Herbaceuous,,120,Undifferentiated park,,-1,-1,-1,0.4,0.4,-1,1,-1,3,0.66,high,#31a354,65.77103307,2.72,102.0886486,7.04,0,0,0
+1456,120810,81,Hay/Pasture,,120,Undifferentiated park,,-1,-1,-1,0.4,0.4,-1,1,-1,0,0,none,#ffffff,10.10660117,8,98.79264417,0,0,0,0
+1457,120811,81,Hay/Pasture,,120,Undifferentiated park,,-1,-1,-1,0.4,0.4,-1,1,-1,1,0.15,low,#e5f5e0,22.75760842,6.8,99.54173609,1.6,0,0,0
+1458,120812,81,Hay/Pasture,,120,Undifferentiated park,,-1,-1,-1,0.4,0.4,-1,1,-1,2,0.4,medium,#a1d99b,43.84262051,4.8,100.7902226,4.266666667,0,0,0
+1459,120813,81,Hay/Pasture,,120,Undifferentiated park,,-1,-1,-1,0.4,0.4,-1,1,-1,3,0.66,high,#31a354,65.77103307,2.72,102.0886486,7.04,0,0,0
+1460,120820,82,Cultivated Crops,,120,Undifferentiated park,,-1,-1,-1,-1,-1,-1,1,-1,0,0,none,#ffffff,4.793840162,0,65.75263422,0,0,0,0
+1461,120821,82,Cultivated Crops,,120,Undifferentiated park,,-1,-1,-1,-1,-1,-1,1,-1,1,0.15,low,#e5f5e0,18.24176156,0,71.45772764,1.6,0,0,0
+1462,120822,82,Cultivated Crops,,120,Undifferentiated park,,-1,-1,-1,-1,-1,-1,1,-1,2,0.4,medium,#a1d99b,40.6549639,0,80.96621666,4.266666667,0,0,0
+1463,120823,82,Cultivated Crops,,120,Undifferentiated park,,-1,-1,-1,-1,-1,-1,1,-1,3,0.66,high,#31a354,63.96469433,0,90.85504525,7.04,0,0,0
+1464,120900,90,Woody Wetlands,,120,Undifferentiated park,,-1,-1,-1,-1,0.4,-1,1,-1,0,0,none,#ffffff,33.5,0,259,0,0,0,0
+1465,120901,90,Woody Wetlands,,120,Undifferentiated park,,-1,-1,-1,-1,0.4,-1,1,-1,1,0.15,low,#e5f5e0,42.64199743,0,235.7179885,1.6,0,0,0
+1466,120902,90,Woody Wetlands,,120,Undifferentiated park,,-1,-1,-1,-1,0.4,-1,1,-1,2,0.4,medium,#a1d99b,57.8786598,0,196.9146361,4.266666667,0,0,0
+1467,120903,90,Woody Wetlands,,120,Undifferentiated park,,-1,-1,-1,-1,0.4,-1,1,-1,3,0.66,high,#31a354,73.72478868,0,156.5591496,7.04,0,0,0
+1468,120950,95,Emergent Herbaceuous Wetlands,,120,Undifferentiated park,,-1,-1,-1,-1,0.4,-1,1,-1,0,0,none,#ffffff,33.5,0,259,0,0,0,0
+1469,120951,95,Emergent Herbaceuous Wetlands,,120,Undifferentiated park,,-1,-1,-1,-1,0.4,-1,1,-1,1,0.15,low,#e5f5e0,42.64199743,0,235.7179885,1.6,0,0,0
+1470,120952,95,Emergent Herbaceuous Wetlands,,120,Undifferentiated park,,-1,-1,-1,-1,0.4,-1,1,-1,2,0.4,medium,#a1d99b,57.8786598,0,196.9146361,4.266666667,0,0,0
+1471,120953,95,Emergent Herbaceuous Wetlands,,120,Undifferentiated park,,-1,-1,-1,-1,0.4,-1,1,-1,3,0.66,high,#31a354,73.72478868,0,156.5591496,7.04,0,0,0
+1472,131110,11,Open Water,,131,Developed park,Urban park,-1,-1,-1,-1,-1,1,1,-1,0,0,none,#ffffff,0,0,0,0,0,0,0
+1473,131111,11,Open Water,,131,Developed park,Urban park,-1,-1,-1,-1,-1,1,1,-1,1,0.15,low,#e5f5e0,14.16699743,0,15.56798855,1.6,0,0,0
+1474,131112,11,Open Water,,131,Developed park,Urban park,-1,-1,-1,-1,-1,1,1,-1,2,0.4,medium,#a1d99b,37.7786598,0,41.51463613,4.266666667,0,0,0
+1475,131113,11,Open Water,,131,Developed park,Urban park,-1,-1,-1,-1,-1,1,1,-1,3,0.66,high,#31a354,62.33478868,0,68.49914961,7.04,0,0,0
+1476,131120,12,Perennial Ice/Snow,,131,Developed park,Urban park,-1,-1,-1,-1,-1,-1,-1,-1,0,0,none,#ffffff,0,0,0,0,0,0,0
+1477,131121,12,Perennial Ice/Snow,,131,Developed park,Urban park,-1,-1,-1,-1,-1,-1,-1,-1,1,0.15,low,#e5f5e0,14.16699743,0,15.56798855,1.6,0,0,0
+1478,131122,12,Perennial Ice/Snow,,131,Developed park,Urban park,-1,-1,-1,-1,-1,-1,-1,-1,2,0.4,medium,#a1d99b,37.7786598,0,41.51463613,4.266666667,0,0,0
+1479,131123,12,Perennial Ice/Snow,,131,Developed park,Urban park,-1,-1,-1,-1,-1,-1,-1,-1,3,0.66,high,#31a354,62.33478868,0,68.49914961,7.04,0,0,0
+1480,131210,21,"Developed, Open Space","20% trees, 60% grass, and 10% buildings and 10% bare soil",131,Developed park,Urban park,0.2,0.1,0.2,0.5,0.5,1,1,-1,0,0,none,#ffffff,25.49986095,4.08,79.01411479,1.76,51.81402439,212.31,37.03522039
+1481,131211,21,"Developed, Open Space","20% trees, 60% grass, and 10% buildings and 10% bare soil",131,Developed park,Urban park,0.2,0.1,0.2,0.5,0.5,1,1,-1,1,0.15,low,#e5f5e0,35.84187923,3.468,82.72998612,3.096,51.81402439,212.31,37.03522039
+1482,131212,21,"Developed, Open Space","20% trees, 60% grass, and 10% buildings and 10% bare soil",131,Developed park,Urban park,0.2,0.1,0.2,0.5,0.5,1,1,-1,2,0.4,medium,#a1d99b,53.07857637,2.448,88.923105,5.322666667,51.81402439,212.31,37.03522039
+1483,131213,21,"Developed, Open Space","20% trees, 60% grass, and 10% buildings and 10% bare soil",131,Developed park,Urban park,0.2,0.1,0.2,0.5,0.5,1,1,-1,3,0.66,high,#31a354,71.0047414,1.3872,95.36394864,7.6384,51.81402439,212.31,37.03522039
+1484,131220,22,"Developed, Low Intensity","20% trees, 40% grass, and 40% buildings",131,Developed park,Urban park,0.2,0.1,0.2,0.5,0.5,-1,1,-1,0,0,none,#ffffff,20.90844667,3.52,72.06732319,0.61,207.2560976,849.24,147.1338816
+1485,131221,22,"Developed, Low Intensity","20% trees, 40% grass, and 40% buildings",131,Developed park,Urban park,0.2,0.1,0.2,0.5,0.5,-1,1,-1,1,0.15,low,#e5f5e0,31.9391771,2.992,76.82521326,2.1185,207.2560976,849.24,147.1338816
+1486,131222,22,"Developed, Low Intensity","20% trees, 40% grass, and 40% buildings",131,Developed park,Urban park,0.2,0.1,0.2,0.5,0.5,-1,1,-1,2,0.4,medium,#a1d99b,50.32372781,2.112,84.75503004,4.632666667,207.2560976,849.24,147.1338816
+1487,131223,22,"Developed, Low Intensity","20% trees, 40% grass, and 40% buildings",131,Developed park,Urban park,0.2,0.1,0.2,0.5,0.5,-1,1,-1,3,0.66,high,#31a354,69.44366054,1.1968,93.0020395,7.2474,207.2560976,849.24,147.1338816
+1488,131230,23,"Developed, Medium Intensity","15% trees, 35% grass, and 50% buildings",131,Developed park,Urban park,0.2,0.1,0.2,0.5,0.5,-1,1,-1,0,0,none,#ffffff,17.69813636,3.08,61.93838294,0.36,234.070122,954.85,720.4716833
+1489,131231,23,"Developed, Medium Intensity","15% trees, 35% grass, and 50% buildings",131,Developed park,Urban park,0.2,0.1,0.2,0.5,0.5,-1,1,-1,1,0.15,low,#e5f5e0,29.21041333,2.618,68.21561405,1.906,234.070122,954.85,720.4716833
+1490,131232,23,"Developed, Medium Intensity","15% trees, 35% grass, and 50% buildings",131,Developed park,Urban park,0.2,0.1,0.2,0.5,0.5,-1,1,-1,2,0.4,medium,#a1d99b,48.39754162,1.848,78.67766589,4.482666667,234.070122,954.85,720.4716833
+1491,131233,23,"Developed, Medium Intensity","15% trees, 35% grass, and 50% buildings",131,Developed park,Urban park,0.2,0.1,0.2,0.5,0.5,-1,1,-1,3,0.66,high,#31a354,68.35215504,1.0472,89.55819981,7.1624,234.070122,954.85,720.4716833
+1492,131240,24,"Developed, High Intensity","10% trees, 20% grass, and 70% buildings",131,Developed park,Urban park,0.2,0.1,0.2,0.5,0.5,-1,1,-1,0,0,none,#ffffff,10.98142029,1.76,44.78642515,0.245,267.9065041,3418.485,1805.616283
+1493,131241,24,"Developed, High Intensity","10% trees, 20% grass, and 70% buildings",131,Developed park,Urban park,0.2,0.1,0.2,0.5,0.5,-1,1,-1,1,0.15,low,#e5f5e0,23.50120467,1.496,53.63644993,1.80825,267.9065041,3418.485,1805.616283
+1494,131242,24,"Developed, High Intensity","10% trees, 20% grass, and 70% buildings",131,Developed park,Urban park,0.2,0.1,0.2,0.5,0.5,-1,1,-1,2,0.4,medium,#a1d99b,44.36751198,1.056,68.38649122,4.413666667,267.9065041,3418.485,1805.616283
+1495,131243,24,"Developed, High Intensity","10% trees, 20% grass, and 70% buildings",131,Developed park,Urban park,0.2,0.1,0.2,0.5,0.5,-1,1,-1,3,0.66,high,#31a354,66.06847158,0.5984,83.72653416,7.1233,267.9065041,3418.485,1805.616283
+1496,131310,31,Barren Land,,131,Developed park,Urban park,0.2,0.1,0.2,0.5,0.5,1,1,-1,0,0,none,#ffffff,6.8,0,25.5,0,0,0,0
+1497,131311,31,Barren Land,,131,Developed park,Urban park,0.2,0.1,0.2,0.5,0.5,1,1,-1,1,0.15,low,#e5f5e0,19.94699743,0,37.24298855,1.6,0,0,0
+1498,131312,31,Barren Land,,131,Developed park,Urban park,0.2,0.1,0.2,0.5,0.5,1,1,-1,2,0.4,medium,#a1d99b,41.8586598,0,56.81463613,4.266666667,0,0,0
+1499,131313,31,Barren Land,,131,Developed park,Urban park,0.2,0.1,0.2,0.5,0.5,1,1,-1,3,0.66,high,#31a354,64.64678868,0,77.16914961,7.04,0,0,0
+1500,131410,41,Deciduous Forest,,131,Developed park,Urban park,-1,0.1,-1,-1,0.5,1,1,-1,0,0,none,#ffffff,85.88498714,0,96.08994273,8.8,0,0,0
+1501,131411,41,Deciduous Forest,,131,Developed park,Urban park,-1,0.1,-1,-1,0.5,1,1,-1,1,0.15,low,#e5f5e0,85.88498714,0,96.08994273,8.8,0,0,0
+1502,131412,41,Deciduous Forest,,131,Developed park,Urban park,-1,0.1,-1,-1,0.5,1,1,-1,2,0.4,medium,#a1d99b,85.88498714,0,96.08994273,8.8,0,0,0
+1503,131413,41,Deciduous Forest,,131,Developed park,Urban park,-1,0.1,-1,-1,0.5,1,1,-1,3,0.66,high,#31a354,85.88498714,0,96.08994273,8.8,0,0,0
+1504,131420,42,Evergreen Forest,,131,Developed park,Urban park,-1,0.1,-1,-1,0.5,1,1,-1,0,0,none,#ffffff,105.6849871,0,96.08994273,14.4,0,0,0
+1505,131421,42,Evergreen Forest,,131,Developed park,Urban park,-1,0.1,-1,-1,0.5,1,1,-1,1,0.15,low,#e5f5e0,105.6849871,0,96.08994273,14.4,0,0,0
+1506,131422,42,Evergreen Forest,,131,Developed park,Urban park,-1,0.1,-1,-1,0.5,1,1,-1,2,0.4,medium,#a1d99b,105.6849871,0,96.08994273,14.4,0,0,0
+1507,131423,42,Evergreen Forest,,131,Developed park,Urban park,-1,0.1,-1,-1,0.5,1,1,-1,3,0.66,high,#31a354,105.6849871,0,96.08994273,14.4,0,0,0
+1508,131430,43,Mixed Forest,,131,Developed park,Urban park,-1,0.1,-1,-1,0.5,1,1,-1,0,0,none,#ffffff,91.76997429,0,119.1798855,8.8,0,0,0
+1509,131431,43,Mixed Forest,,131,Developed park,Urban park,-1,0.1,-1,-1,0.5,1,1,-1,1,0.15,low,#e5f5e0,91.76997429,0,119.1798855,8.8,0,0,0
+1510,131432,43,Mixed Forest,,131,Developed park,Urban park,-1,0.1,-1,-1,0.5,1,1,-1,2,0.4,medium,#a1d99b,91.76997429,0,119.1798855,8.8,0,0,0
+1511,131433,43,Mixed Forest,,131,Developed park,Urban park,-1,0.1,-1,-1,0.5,1,1,-1,3,0.66,high,#31a354,91.76997429,0,119.1798855,8.8,0,0,0
+1512,131520,52,Shrub/Scrub,,131,Developed park,Urban park,0.2,0.1,0.2,0.5,0.5,1,1,-1,0,0,none,#ffffff,47.875,0,68.15477645,0,0,0,0
+1513,131521,52,Shrub/Scrub,,131,Developed park,Urban park,0.2,0.1,0.2,0.5,0.5,1,1,-1,1,0.15,low,#e5f5e0,54.86074743,0,73.49954853,1.6,0,0,0
+1514,131522,52,Shrub/Scrub,,131,Developed park,Urban park,0.2,0.1,0.2,0.5,0.5,1,1,-1,2,0.4,medium,#a1d99b,66.5036598,0,82.407502,4.266666667,0,0,0
+1515,131523,52,Shrub/Scrub,,131,Developed park,Urban park,0.2,0.1,0.2,0.5,0.5,1,1,-1,3,0.66,high,#31a354,78.61228868,0,91.6717736,7.04,0,0,0
+1516,131710,71,Herbaceuous,,131,Developed park,Urban park,0.2,0.1,0.2,0.5,0.5,1,1,-1,0,0,none,#ffffff,10.10660117,8,98.79264417,0,0,0,0
+1517,131711,71,Herbaceuous,,131,Developed park,Urban park,0.2,0.1,0.2,0.5,0.5,1,1,-1,1,0.15,low,#e5f5e0,22.75760842,6.8,99.54173609,1.6,0,0,0
+1518,131712,71,Herbaceuous,,131,Developed park,Urban park,0.2,0.1,0.2,0.5,0.5,1,1,-1,2,0.4,medium,#a1d99b,43.84262051,4.8,100.7902226,4.266666667,0,0,0
+1519,131713,71,Herbaceuous,,131,Developed park,Urban park,0.2,0.1,0.2,0.5,0.5,1,1,-1,3,0.66,high,#31a354,65.77103307,2.72,102.0886486,7.04,0,0,0
+1520,131810,81,Hay/Pasture,,131,Developed park,Urban park,0.2,0.1,0.2,0.5,0.5,1,1,-1,0,0,none,#ffffff,10.10660117,8,98.79264417,0,0,0,0
+1521,131811,81,Hay/Pasture,,131,Developed park,Urban park,0.2,0.1,0.2,0.5,0.5,1,1,-1,1,0.15,low,#e5f5e0,22.75760842,6.8,99.54173609,1.6,0,0,0
+1522,131812,81,Hay/Pasture,,131,Developed park,Urban park,0.2,0.1,0.2,0.5,0.5,1,1,-1,2,0.4,medium,#a1d99b,43.84262051,4.8,100.7902226,4.266666667,0,0,0
+1523,131813,81,Hay/Pasture,,131,Developed park,Urban park,0.2,0.1,0.2,0.5,0.5,1,1,-1,3,0.66,high,#31a354,65.77103307,2.72,102.0886486,7.04,0,0,0
+1524,131820,82,Cultivated Crops,,131,Developed park,Urban park,0.2,0.1,0.2,-1,-1,1,1,-1,0,0,none,#ffffff,4.793840162,0,65.75263422,0,0,0,0
+1525,131821,82,Cultivated Crops,,131,Developed park,Urban park,0.2,0.1,0.2,-1,-1,1,1,-1,1,0.15,low,#e5f5e0,18.24176156,0,71.45772764,1.6,0,0,0
+1526,131822,82,Cultivated Crops,,131,Developed park,Urban park,0.2,0.1,0.2,-1,-1,1,1,-1,2,0.4,medium,#a1d99b,40.6549639,0,80.96621666,4.266666667,0,0,0
+1527,131823,82,Cultivated Crops,,131,Developed park,Urban park,0.2,0.1,0.2,-1,-1,1,1,-1,3,0.66,high,#31a354,63.96469433,0,90.85504525,7.04,0,0,0
+1528,131900,90,Woody Wetlands,,131,Developed park,Urban park,0.2,0.1,-1,-1,0.5,1,1,-1,0,0,none,#ffffff,33.5,0,259,0,0,0,0
+1529,131901,90,Woody Wetlands,,131,Developed park,Urban park,0.2,0.1,-1,-1,0.5,1,1,-1,1,0.15,low,#e5f5e0,42.64199743,0,235.7179885,1.6,0,0,0
+1530,131902,90,Woody Wetlands,,131,Developed park,Urban park,0.2,0.1,-1,-1,0.5,1,1,-1,2,0.4,medium,#a1d99b,57.8786598,0,196.9146361,4.266666667,0,0,0
+1531,131903,90,Woody Wetlands,,131,Developed park,Urban park,0.2,0.1,-1,-1,0.5,1,1,-1,3,0.66,high,#31a354,73.72478868,0,156.5591496,7.04,0,0,0
+1532,131950,95,Emergent Herbaceuous Wetlands,,131,Developed park,Urban park,0.2,0.1,-1,-1,0.5,1,1,-1,0,0,none,#ffffff,33.5,0,259,0,0,0,0
+1533,131951,95,Emergent Herbaceuous Wetlands,,131,Developed park,Urban park,0.2,0.1,-1,-1,0.5,1,1,-1,1,0.15,low,#e5f5e0,42.64199743,0,235.7179885,1.6,0,0,0
+1534,131952,95,Emergent Herbaceuous Wetlands,,131,Developed park,Urban park,0.2,0.1,-1,-1,0.5,1,1,-1,2,0.4,medium,#a1d99b,57.8786598,0,196.9146361,4.266666667,0,0,0
+1535,131953,95,Emergent Herbaceuous Wetlands,,131,Developed park,Urban park,0.2,0.1,-1,-1,0.5,1,1,-1,3,0.66,high,#31a354,73.72478868,0,156.5591496,7.04,0,0,0
+1536,132110,11,Open Water,,132,Developed park,Golf course,-1,-1,-1,-1,-1,-1,1,-1,0,0,none,#ffffff,0,0,0,0,0,0,0
+1537,132111,11,Open Water,,132,Developed park,Golf course,-1,-1,-1,-1,-1,-1,1,-1,1,0.15,low,#e5f5e0,14.16699743,0,15.56798855,1.6,0,0,0
+1538,132112,11,Open Water,,132,Developed park,Golf course,-1,-1,-1,-1,-1,-1,1,-1,2,0.4,medium,#a1d99b,37.7786598,0,41.51463613,4.266666667,0,0,0
+1539,132113,11,Open Water,,132,Developed park,Golf course,-1,-1,-1,-1,-1,-1,1,-1,3,0.66,high,#31a354,62.33478868,0,68.49914961,7.04,0,0,0
+1540,132120,12,Perennial Ice/Snow,,132,Developed park,Golf course,-1,-1,-1,-1,-1,-1,-1,-1,0,0,none,#ffffff,0,0,0,0,0,0,0
+1541,132121,12,Perennial Ice/Snow,,132,Developed park,Golf course,-1,-1,-1,-1,-1,-1,-1,-1,1,0.15,low,#e5f5e0,14.16699743,0,15.56798855,1.6,0,0,0
+1542,132122,12,Perennial Ice/Snow,,132,Developed park,Golf course,-1,-1,-1,-1,-1,-1,-1,-1,2,0.4,medium,#a1d99b,37.7786598,0,41.51463613,4.266666667,0,0,0
+1543,132123,12,Perennial Ice/Snow,,132,Developed park,Golf course,-1,-1,-1,-1,-1,-1,-1,-1,3,0.66,high,#31a354,62.33478868,0,68.49914961,7.04,0,0,0
+1544,132210,21,"Developed, Open Space","20% trees, 60% grass, and 10% buildings and 10% bare soil",132,Developed park,Golf course,1,1,1,0.2,1,-1,1,-1,0,0,none,#ffffff,25.49986095,4.08,79.01411479,1.76,51.81402439,212.31,37.03522039
+1545,132211,21,"Developed, Open Space","20% trees, 60% grass, and 10% buildings and 10% bare soil",132,Developed park,Golf course,1,1,1,0.2,1,-1,1,-1,1,0.15,low,#e5f5e0,35.84187923,3.468,82.72998612,3.096,51.81402439,212.31,37.03522039
+1546,132212,21,"Developed, Open Space","20% trees, 60% grass, and 10% buildings and 10% bare soil",132,Developed park,Golf course,1,1,1,0.2,1,-1,1,-1,2,0.4,medium,#a1d99b,53.07857637,2.448,88.923105,5.322666667,51.81402439,212.31,37.03522039
+1547,132213,21,"Developed, Open Space","20% trees, 60% grass, and 10% buildings and 10% bare soil",132,Developed park,Golf course,1,1,1,0.2,1,-1,1,-1,3,0.66,high,#31a354,71.0047414,1.3872,95.36394864,7.6384,51.81402439,212.31,37.03522039
+1548,132220,22,"Developed, Low Intensity","20% trees, 40% grass, and 40% buildings",132,Developed park,Golf course,1,1,1,0.2,1,-1,1,-1,0,0,none,#ffffff,20.90844667,3.52,72.06732319,0.61,207.2560976,849.24,147.1338816
+1549,132221,22,"Developed, Low Intensity","20% trees, 40% grass, and 40% buildings",132,Developed park,Golf course,1,1,1,0.2,1,-1,1,-1,1,0.15,low,#e5f5e0,31.9391771,2.992,76.82521326,2.1185,207.2560976,849.24,147.1338816
+1550,132222,22,"Developed, Low Intensity","20% trees, 40% grass, and 40% buildings",132,Developed park,Golf course,1,1,1,0.2,1,-1,1,-1,2,0.4,medium,#a1d99b,50.32372781,2.112,84.75503004,4.632666667,207.2560976,849.24,147.1338816
+1551,132223,22,"Developed, Low Intensity","20% trees, 40% grass, and 40% buildings",132,Developed park,Golf course,1,1,1,0.2,1,-1,1,-1,3,0.66,high,#31a354,69.44366054,1.1968,93.0020395,7.2474,207.2560976,849.24,147.1338816
+1552,132230,23,"Developed, Medium Intensity","15% trees, 35% grass, and 50% buildings",132,Developed park,Golf course,1,1,1,0.2,1,-1,1,-1,0,0,none,#ffffff,17.69813636,3.08,61.93838294,0.36,234.070122,954.85,720.4716833
+1553,132231,23,"Developed, Medium Intensity","15% trees, 35% grass, and 50% buildings",132,Developed park,Golf course,1,1,1,0.2,1,-1,1,-1,1,0.15,low,#e5f5e0,29.21041333,2.618,68.21561405,1.906,234.070122,954.85,720.4716833
+1554,132232,23,"Developed, Medium Intensity","15% trees, 35% grass, and 50% buildings",132,Developed park,Golf course,1,1,1,0.2,1,-1,1,-1,2,0.4,medium,#a1d99b,48.39754162,1.848,78.67766589,4.482666667,234.070122,954.85,720.4716833
+1555,132233,23,"Developed, Medium Intensity","15% trees, 35% grass, and 50% buildings",132,Developed park,Golf course,1,1,1,0.2,1,-1,1,-1,3,0.66,high,#31a354,68.35215504,1.0472,89.55819981,7.1624,234.070122,954.85,720.4716833
+1556,132240,24,"Developed, High Intensity","10% trees, 20% grass, and 70% buildings",132,Developed park,Golf course,1,1,1,0.2,1,-1,1,-1,0,0,none,#ffffff,10.98142029,1.76,44.78642515,0.245,267.9065041,3418.485,1805.616283
+1557,132241,24,"Developed, High Intensity","10% trees, 20% grass, and 70% buildings",132,Developed park,Golf course,1,1,1,0.2,1,-1,1,-1,1,0.15,low,#e5f5e0,23.50120467,1.496,53.63644993,1.80825,267.9065041,3418.485,1805.616283
+1558,132242,24,"Developed, High Intensity","10% trees, 20% grass, and 70% buildings",132,Developed park,Golf course,1,1,1,0.2,1,-1,1,-1,2,0.4,medium,#a1d99b,44.36751198,1.056,68.38649122,4.413666667,267.9065041,3418.485,1805.616283
+1559,132243,24,"Developed, High Intensity","10% trees, 20% grass, and 70% buildings",132,Developed park,Golf course,1,1,1,0.2,1,-1,1,-1,3,0.66,high,#31a354,66.06847158,0.5984,83.72653416,7.1233,267.9065041,3418.485,1805.616283
+1560,132310,31,Barren Land,,132,Developed park,Golf course,1,1,1,0.2,1,-1,1,-1,0,0,none,#ffffff,6.8,0,25.5,0,0,0,0
+1561,132311,31,Barren Land,,132,Developed park,Golf course,1,1,1,0.2,1,-1,1,-1,1,0.15,low,#e5f5e0,19.94699743,0,37.24298855,1.6,0,0,0
+1562,132312,31,Barren Land,,132,Developed park,Golf course,1,1,1,0.2,1,-1,1,-1,2,0.4,medium,#a1d99b,41.8586598,0,56.81463613,4.266666667,0,0,0
+1563,132313,31,Barren Land,,132,Developed park,Golf course,1,1,1,0.2,1,-1,1,-1,3,0.66,high,#31a354,64.64678868,0,77.16914961,7.04,0,0,0
+1564,132410,41,Deciduous Forest,,132,Developed park,Golf course,-1,1,-1,-1,1,-1,1,-1,0,0,none,#ffffff,85.88498714,0,96.08994273,8.8,0,0,0
+1565,132411,41,Deciduous Forest,,132,Developed park,Golf course,-1,1,-1,-1,1,-1,1,-1,1,0.15,low,#e5f5e0,85.88498714,0,96.08994273,8.8,0,0,0
+1566,132412,41,Deciduous Forest,,132,Developed park,Golf course,-1,1,-1,-1,1,-1,1,-1,2,0.4,medium,#a1d99b,85.88498714,0,96.08994273,8.8,0,0,0
+1567,132413,41,Deciduous Forest,,132,Developed park,Golf course,-1,1,-1,-1,1,-1,1,-1,3,0.66,high,#31a354,85.88498714,0,96.08994273,8.8,0,0,0
+1568,132420,42,Evergreen Forest,,132,Developed park,Golf course,-1,1,-1,-1,1,-1,1,-1,0,0,none,#ffffff,105.6849871,0,96.08994273,14.4,0,0,0
+1569,132421,42,Evergreen Forest,,132,Developed park,Golf course,-1,1,-1,-1,1,-1,1,-1,1,0.15,low,#e5f5e0,105.6849871,0,96.08994273,14.4,0,0,0
+1570,132422,42,Evergreen Forest,,132,Developed park,Golf course,-1,1,-1,-1,1,-1,1,-1,2,0.4,medium,#a1d99b,105.6849871,0,96.08994273,14.4,0,0,0
+1571,132423,42,Evergreen Forest,,132,Developed park,Golf course,-1,1,-1,-1,1,-1,1,-1,3,0.66,high,#31a354,105.6849871,0,96.08994273,14.4,0,0,0
+1572,132430,43,Mixed Forest,,132,Developed park,Golf course,-1,1,-1,-1,1,-1,1,-1,0,0,none,#ffffff,91.76997429,0,119.1798855,8.8,0,0,0
+1573,132431,43,Mixed Forest,,132,Developed park,Golf course,-1,1,-1,-1,1,-1,1,-1,1,0.15,low,#e5f5e0,91.76997429,0,119.1798855,8.8,0,0,0
+1574,132432,43,Mixed Forest,,132,Developed park,Golf course,-1,1,-1,-1,1,-1,1,-1,2,0.4,medium,#a1d99b,91.76997429,0,119.1798855,8.8,0,0,0
+1575,132433,43,Mixed Forest,,132,Developed park,Golf course,-1,1,-1,-1,1,-1,1,-1,3,0.66,high,#31a354,91.76997429,0,119.1798855,8.8,0,0,0
+1576,132520,52,Shrub/Scrub,,132,Developed park,Golf course,1,1,1,0.2,1,-1,1,-1,0,0,none,#ffffff,47.875,0,68.15477645,0,0,0,0
+1577,132521,52,Shrub/Scrub,,132,Developed park,Golf course,1,1,1,0.2,1,-1,1,-1,1,0.15,low,#e5f5e0,54.86074743,0,73.49954853,1.6,0,0,0
+1578,132522,52,Shrub/Scrub,,132,Developed park,Golf course,1,1,1,0.2,1,-1,1,-1,2,0.4,medium,#a1d99b,66.5036598,0,82.407502,4.266666667,0,0,0
+1579,132523,52,Shrub/Scrub,,132,Developed park,Golf course,1,1,1,0.2,1,-1,1,-1,3,0.66,high,#31a354,78.61228868,0,91.6717736,7.04,0,0,0
+1580,132710,71,Herbaceuous,,132,Developed park,Golf course,1,1,1,0.2,1,-1,1,-1,0,0,none,#ffffff,10.10660117,8,98.79264417,0,0,0,0
+1581,132711,71,Herbaceuous,,132,Developed park,Golf course,1,1,1,0.2,1,-1,1,-1,1,0.15,low,#e5f5e0,22.75760842,6.8,99.54173609,1.6,0,0,0
+1582,132712,71,Herbaceuous,,132,Developed park,Golf course,1,1,1,0.2,1,-1,1,-1,2,0.4,medium,#a1d99b,43.84262051,4.8,100.7902226,4.266666667,0,0,0
+1583,132713,71,Herbaceuous,,132,Developed park,Golf course,1,1,1,0.2,1,-1,1,-1,3,0.66,high,#31a354,65.77103307,2.72,102.0886486,7.04,0,0,0
+1584,132810,81,Hay/Pasture,,132,Developed park,Golf course,1,1,1,0.2,1,-1,1,-1,0,0,none,#ffffff,10.10660117,8,98.79264417,0,0,0,0
+1585,132811,81,Hay/Pasture,,132,Developed park,Golf course,1,1,1,0.2,1,-1,1,-1,1,0.15,low,#e5f5e0,22.75760842,6.8,99.54173609,1.6,0,0,0
+1586,132812,81,Hay/Pasture,,132,Developed park,Golf course,1,1,1,0.2,1,-1,1,-1,2,0.4,medium,#a1d99b,43.84262051,4.8,100.7902226,4.266666667,0,0,0
+1587,132813,81,Hay/Pasture,,132,Developed park,Golf course,1,1,1,0.2,1,-1,1,-1,3,0.66,high,#31a354,65.77103307,2.72,102.0886486,7.04,0,0,0
+1588,132820,82,Cultivated Crops,,132,Developed park,Golf course,1,1,1,-1,-1,-1,1,-1,0,0,none,#ffffff,4.793840162,0,65.75263422,0,0,0,0
+1589,132821,82,Cultivated Crops,,132,Developed park,Golf course,1,1,1,-1,-1,-1,1,-1,1,0.15,low,#e5f5e0,18.24176156,0,71.45772764,1.6,0,0,0
+1590,132822,82,Cultivated Crops,,132,Developed park,Golf course,1,1,1,-1,-1,-1,1,-1,2,0.4,medium,#a1d99b,40.6549639,0,80.96621666,4.266666667,0,0,0
+1591,132823,82,Cultivated Crops,,132,Developed park,Golf course,1,1,1,-1,-1,-1,1,-1,3,0.66,high,#31a354,63.96469433,0,90.85504525,7.04,0,0,0
+1592,132900,90,Woody Wetlands,,132,Developed park,Golf course,1,1,-1,-1,1,-1,1,-1,0,0,none,#ffffff,33.5,0,259,0,0,0,0
+1593,132901,90,Woody Wetlands,,132,Developed park,Golf course,1,1,-1,-1,1,-1,1,-1,1,0.15,low,#e5f5e0,42.64199743,0,235.7179885,1.6,0,0,0
+1594,132902,90,Woody Wetlands,,132,Developed park,Golf course,1,1,-1,-1,1,-1,1,-1,2,0.4,medium,#a1d99b,57.8786598,0,196.9146361,4.266666667,0,0,0
+1595,132903,90,Woody Wetlands,,132,Developed park,Golf course,1,1,-1,-1,1,-1,1,-1,3,0.66,high,#31a354,73.72478868,0,156.5591496,7.04,0,0,0
+1596,132950,95,Emergent Herbaceuous Wetlands,,132,Developed park,Golf course,1,1,-1,-1,1,-1,1,-1,0,0,none,#ffffff,33.5,0,259,0,0,0,0
+1597,132951,95,Emergent Herbaceuous Wetlands,,132,Developed park,Golf course,1,1,-1,-1,1,-1,1,-1,1,0.15,low,#e5f5e0,42.64199743,0,235.7179885,1.6,0,0,0
+1598,132952,95,Emergent Herbaceuous Wetlands,,132,Developed park,Golf course,1,1,-1,-1,1,-1,1,-1,2,0.4,medium,#a1d99b,57.8786598,0,196.9146361,4.266666667,0,0,0
+1599,132953,95,Emergent Herbaceuous Wetlands,,132,Developed park,Golf course,1,1,-1,-1,1,-1,1,-1,3,0.66,high,#31a354,73.72478868,0,156.5591496,7.04,0,0,0
+1600,133110,11,Open Water,,133,Developed park,Resort/ski area,-1,-1,-1,-1,-1,-1,1,-1,0,0,none,#ffffff,0,0,0,0,0,0,0
+1601,133111,11,Open Water,,133,Developed park,Resort/ski area,-1,-1,-1,-1,-1,-1,1,-1,1,0.15,low,#e5f5e0,14.16699743,0,15.56798855,1.6,0,0,0
+1602,133112,11,Open Water,,133,Developed park,Resort/ski area,-1,-1,-1,-1,-1,-1,1,-1,2,0.4,medium,#a1d99b,37.7786598,0,41.51463613,4.266666667,0,0,0
+1603,133113,11,Open Water,,133,Developed park,Resort/ski area,-1,-1,-1,-1,-1,-1,1,-1,3,0.66,high,#31a354,62.33478868,0,68.49914961,7.04,0,0,0
+1604,133120,12,Perennial Ice/Snow,,133,Developed park,Resort/ski area,-1,-1,-1,-1,-1,-1,-1,-1,0,0,none,#ffffff,0,0,0,0,0,0,0
+1605,133121,12,Perennial Ice/Snow,,133,Developed park,Resort/ski area,-1,-1,-1,-1,-1,-1,-1,-1,1,0.15,low,#e5f5e0,14.16699743,0,15.56798855,1.6,0,0,0
+1606,133122,12,Perennial Ice/Snow,,133,Developed park,Resort/ski area,-1,-1,-1,-1,-1,-1,-1,-1,2,0.4,medium,#a1d99b,37.7786598,0,41.51463613,4.266666667,0,0,0
+1607,133123,12,Perennial Ice/Snow,,133,Developed park,Resort/ski area,-1,-1,-1,-1,-1,-1,-1,-1,3,0.66,high,#31a354,62.33478868,0,68.49914961,7.04,0,0,0
+1608,133210,21,"Developed, Open Space","20% trees, 60% grass, and 10% buildings and 10% bare soil",133,Developed park,Resort/ski area,-1,-1,-1,-1,-1,-1,1,-1,0,0,none,#ffffff,25.49986095,4.08,79.01411479,1.76,51.81402439,212.31,37.03522039
+1609,133211,21,"Developed, Open Space","20% trees, 60% grass, and 10% buildings and 10% bare soil",133,Developed park,Resort/ski area,-1,-1,-1,-1,-1,-1,1,-1,1,0.15,low,#e5f5e0,35.84187923,3.468,82.72998612,3.096,51.81402439,212.31,37.03522039
+1610,133212,21,"Developed, Open Space","20% trees, 60% grass, and 10% buildings and 10% bare soil",133,Developed park,Resort/ski area,-1,-1,-1,-1,-1,-1,1,-1,2,0.4,medium,#a1d99b,53.07857637,2.448,88.923105,5.322666667,51.81402439,212.31,37.03522039
+1611,133213,21,"Developed, Open Space","20% trees, 60% grass, and 10% buildings and 10% bare soil",133,Developed park,Resort/ski area,-1,-1,-1,-1,-1,-1,1,-1,3,0.66,high,#31a354,71.0047414,1.3872,95.36394864,7.6384,51.81402439,212.31,37.03522039
+1612,133220,22,"Developed, Low Intensity","20% trees, 40% grass, and 40% buildings",133,Developed park,Resort/ski area,-1,-1,-1,-1,-1,-1,1,-1,0,0,none,#ffffff,20.90844667,3.52,72.06732319,0.61,207.2560976,849.24,147.1338816
+1613,133221,22,"Developed, Low Intensity","20% trees, 40% grass, and 40% buildings",133,Developed park,Resort/ski area,-1,-1,-1,-1,-1,-1,1,-1,1,0.15,low,#e5f5e0,31.9391771,2.992,76.82521326,2.1185,207.2560976,849.24,147.1338816
+1614,133222,22,"Developed, Low Intensity","20% trees, 40% grass, and 40% buildings",133,Developed park,Resort/ski area,-1,-1,-1,-1,-1,-1,1,-1,2,0.4,medium,#a1d99b,50.32372781,2.112,84.75503004,4.632666667,207.2560976,849.24,147.1338816
+1615,133223,22,"Developed, Low Intensity","20% trees, 40% grass, and 40% buildings",133,Developed park,Resort/ski area,-1,-1,-1,-1,-1,-1,1,-1,3,0.66,high,#31a354,69.44366054,1.1968,93.0020395,7.2474,207.2560976,849.24,147.1338816
+1616,133230,23,"Developed, Medium Intensity","15% trees, 35% grass, and 50% buildings",133,Developed park,Resort/ski area,-1,-1,-1,-1,-1,-1,1,-1,0,0,none,#ffffff,17.69813636,3.08,61.93838294,0.36,234.070122,954.85,720.4716833
+1617,133231,23,"Developed, Medium Intensity","15% trees, 35% grass, and 50% buildings",133,Developed park,Resort/ski area,-1,-1,-1,-1,-1,-1,1,-1,1,0.15,low,#e5f5e0,29.21041333,2.618,68.21561405,1.906,234.070122,954.85,720.4716833
+1618,133232,23,"Developed, Medium Intensity","15% trees, 35% grass, and 50% buildings",133,Developed park,Resort/ski area,-1,-1,-1,-1,-1,-1,1,-1,2,0.4,medium,#a1d99b,48.39754162,1.848,78.67766589,4.482666667,234.070122,954.85,720.4716833
+1619,133233,23,"Developed, Medium Intensity","15% trees, 35% grass, and 50% buildings",133,Developed park,Resort/ski area,-1,-1,-1,-1,-1,-1,1,-1,3,0.66,high,#31a354,68.35215504,1.0472,89.55819981,7.1624,234.070122,954.85,720.4716833
+1620,133240,24,"Developed, High Intensity","10% trees, 20% grass, and 70% buildings",133,Developed park,Resort/ski area,-1,-1,-1,-1,-1,-1,1,-1,0,0,none,#ffffff,10.98142029,1.76,44.78642515,0.245,267.9065041,3418.485,1805.616283
+1621,133241,24,"Developed, High Intensity","10% trees, 20% grass, and 70% buildings",133,Developed park,Resort/ski area,-1,-1,-1,-1,-1,-1,1,-1,1,0.15,low,#e5f5e0,23.50120467,1.496,53.63644993,1.80825,267.9065041,3418.485,1805.616283
+1622,133242,24,"Developed, High Intensity","10% trees, 20% grass, and 70% buildings",133,Developed park,Resort/ski area,-1,-1,-1,-1,-1,-1,1,-1,2,0.4,medium,#a1d99b,44.36751198,1.056,68.38649122,4.413666667,267.9065041,3418.485,1805.616283
+1623,133243,24,"Developed, High Intensity","10% trees, 20% grass, and 70% buildings",133,Developed park,Resort/ski area,-1,-1,-1,-1,-1,-1,1,-1,3,0.66,high,#31a354,66.06847158,0.5984,83.72653416,7.1233,267.9065041,3418.485,1805.616283
+1624,133310,31,Barren Land,,133,Developed park,Resort/ski area,-1,-1,-1,-1,-1,-1,1,-1,0,0,none,#ffffff,6.8,0,25.5,0,0,0,0
+1625,133311,31,Barren Land,,133,Developed park,Resort/ski area,-1,-1,-1,-1,-1,-1,1,-1,1,0.15,low,#e5f5e0,19.94699743,0,37.24298855,1.6,0,0,0
+1626,133312,31,Barren Land,,133,Developed park,Resort/ski area,-1,-1,-1,-1,-1,-1,1,-1,2,0.4,medium,#a1d99b,41.8586598,0,56.81463613,4.266666667,0,0,0
+1627,133313,31,Barren Land,,133,Developed park,Resort/ski area,-1,-1,-1,-1,-1,-1,1,-1,3,0.66,high,#31a354,64.64678868,0,77.16914961,7.04,0,0,0
+1628,133410,41,Deciduous Forest,,133,Developed park,Resort/ski area,-1,-1,-1,-1,-1,-1,1,-1,0,0,none,#ffffff,85.88498714,0,96.08994273,8.8,0,0,0
+1629,133411,41,Deciduous Forest,,133,Developed park,Resort/ski area,-1,-1,-1,-1,-1,-1,1,-1,1,0.15,low,#e5f5e0,85.88498714,0,96.08994273,8.8,0,0,0
+1630,133412,41,Deciduous Forest,,133,Developed park,Resort/ski area,-1,-1,-1,-1,-1,-1,1,-1,2,0.4,medium,#a1d99b,85.88498714,0,96.08994273,8.8,0,0,0
+1631,133413,41,Deciduous Forest,,133,Developed park,Resort/ski area,-1,-1,-1,-1,-1,-1,1,-1,3,0.66,high,#31a354,85.88498714,0,96.08994273,8.8,0,0,0
+1632,133420,42,Evergreen Forest,,133,Developed park,Resort/ski area,-1,-1,-1,-1,-1,-1,1,-1,0,0,none,#ffffff,105.6849871,0,96.08994273,14.4,0,0,0
+1633,133421,42,Evergreen Forest,,133,Developed park,Resort/ski area,-1,-1,-1,-1,-1,-1,1,-1,1,0.15,low,#e5f5e0,105.6849871,0,96.08994273,14.4,0,0,0
+1634,133422,42,Evergreen Forest,,133,Developed park,Resort/ski area,-1,-1,-1,-1,-1,-1,1,-1,2,0.4,medium,#a1d99b,105.6849871,0,96.08994273,14.4,0,0,0
+1635,133423,42,Evergreen Forest,,133,Developed park,Resort/ski area,-1,-1,-1,-1,-1,-1,1,-1,3,0.66,high,#31a354,105.6849871,0,96.08994273,14.4,0,0,0
+1636,133430,43,Mixed Forest,,133,Developed park,Resort/ski area,-1,-1,-1,-1,-1,-1,1,-1,0,0,none,#ffffff,91.76997429,0,119.1798855,8.8,0,0,0
+1637,133431,43,Mixed Forest,,133,Developed park,Resort/ski area,-1,-1,-1,-1,-1,-1,1,-1,1,0.15,low,#e5f5e0,91.76997429,0,119.1798855,8.8,0,0,0
+1638,133432,43,Mixed Forest,,133,Developed park,Resort/ski area,-1,-1,-1,-1,-1,-1,1,-1,2,0.4,medium,#a1d99b,91.76997429,0,119.1798855,8.8,0,0,0
+1639,133433,43,Mixed Forest,,133,Developed park,Resort/ski area,-1,-1,-1,-1,-1,-1,1,-1,3,0.66,high,#31a354,91.76997429,0,119.1798855,8.8,0,0,0
+1640,133520,52,Shrub/Scrub,,133,Developed park,Resort/ski area,-1,-1,-1,-1,-1,-1,1,-1,0,0,none,#ffffff,47.875,0,68.15477645,0,0,0,0
+1641,133521,52,Shrub/Scrub,,133,Developed park,Resort/ski area,-1,-1,-1,-1,-1,-1,1,-1,1,0.15,low,#e5f5e0,54.86074743,0,73.49954853,1.6,0,0,0
+1642,133522,52,Shrub/Scrub,,133,Developed park,Resort/ski area,-1,-1,-1,-1,-1,-1,1,-1,2,0.4,medium,#a1d99b,66.5036598,0,82.407502,4.266666667,0,0,0
+1643,133523,52,Shrub/Scrub,,133,Developed park,Resort/ski area,-1,-1,-1,-1,-1,-1,1,-1,3,0.66,high,#31a354,78.61228868,0,91.6717736,7.04,0,0,0
+1644,133710,71,Herbaceuous,,133,Developed park,Resort/ski area,-1,-1,-1,-1,-1,-1,1,-1,0,0,none,#ffffff,10.10660117,8,98.79264417,0,0,0,0
+1645,133711,71,Herbaceuous,,133,Developed park,Resort/ski area,-1,-1,-1,-1,-1,-1,1,-1,1,0.15,low,#e5f5e0,22.75760842,6.8,99.54173609,1.6,0,0,0
+1646,133712,71,Herbaceuous,,133,Developed park,Resort/ski area,-1,-1,-1,-1,-1,-1,1,-1,2,0.4,medium,#a1d99b,43.84262051,4.8,100.7902226,4.266666667,0,0,0
+1647,133713,71,Herbaceuous,,133,Developed park,Resort/ski area,-1,-1,-1,-1,-1,-1,1,-1,3,0.66,high,#31a354,65.77103307,2.72,102.0886486,7.04,0,0,0
+1648,133810,81,Hay/Pasture,,133,Developed park,Resort/ski area,-1,-1,-1,-1,-1,-1,1,-1,0,0,none,#ffffff,10.10660117,8,98.79264417,0,0,0,0
+1649,133811,81,Hay/Pasture,,133,Developed park,Resort/ski area,-1,-1,-1,-1,-1,-1,1,-1,1,0.15,low,#e5f5e0,22.75760842,6.8,99.54173609,1.6,0,0,0
+1650,133812,81,Hay/Pasture,,133,Developed park,Resort/ski area,-1,-1,-1,-1,-1,-1,1,-1,2,0.4,medium,#a1d99b,43.84262051,4.8,100.7902226,4.266666667,0,0,0
+1651,133813,81,Hay/Pasture,,133,Developed park,Resort/ski area,-1,-1,-1,-1,-1,-1,1,-1,3,0.66,high,#31a354,65.77103307,2.72,102.0886486,7.04,0,0,0
+1652,133820,82,Cultivated Crops,,133,Developed park,Resort/ski area,-1,-1,-1,-1,-1,-1,1,-1,0,0,none,#ffffff,4.793840162,0,65.75263422,0,0,0,0
+1653,133821,82,Cultivated Crops,,133,Developed park,Resort/ski area,-1,-1,-1,-1,-1,-1,1,-1,1,0.15,low,#e5f5e0,18.24176156,0,71.45772764,1.6,0,0,0
+1654,133822,82,Cultivated Crops,,133,Developed park,Resort/ski area,-1,-1,-1,-1,-1,-1,1,-1,2,0.4,medium,#a1d99b,40.6549639,0,80.96621666,4.266666667,0,0,0
+1655,133823,82,Cultivated Crops,,133,Developed park,Resort/ski area,-1,-1,-1,-1,-1,-1,1,-1,3,0.66,high,#31a354,63.96469433,0,90.85504525,7.04,0,0,0
+1656,133900,90,Woody Wetlands,,133,Developed park,Resort/ski area,-1,-1,-1,-1,-1,-1,1,-1,0,0,none,#ffffff,33.5,0,259,0,0,0,0
+1657,133901,90,Woody Wetlands,,133,Developed park,Resort/ski area,-1,-1,-1,-1,-1,-1,1,-1,1,0.15,low,#e5f5e0,42.64199743,0,235.7179885,1.6,0,0,0
+1658,133902,90,Woody Wetlands,,133,Developed park,Resort/ski area,-1,-1,-1,-1,-1,-1,1,-1,2,0.4,medium,#a1d99b,57.8786598,0,196.9146361,4.266666667,0,0,0
+1659,133903,90,Woody Wetlands,,133,Developed park,Resort/ski area,-1,-1,-1,-1,-1,-1,1,-1,3,0.66,high,#31a354,73.72478868,0,156.5591496,7.04,0,0,0
+1660,133950,95,Emergent Herbaceuous Wetlands,,133,Developed park,Resort/ski area,-1,-1,-1,-1,-1,-1,1,-1,0,0,none,#ffffff,33.5,0,259,0,0,0,0
+1661,133951,95,Emergent Herbaceuous Wetlands,,133,Developed park,Resort/ski area,-1,-1,-1,-1,-1,-1,1,-1,1,0.15,low,#e5f5e0,42.64199743,0,235.7179885,1.6,0,0,0
+1662,133952,95,Emergent Herbaceuous Wetlands,,133,Developed park,Resort/ski area,-1,-1,-1,-1,-1,-1,1,-1,2,0.4,medium,#a1d99b,57.8786598,0,196.9146361,4.266666667,0,0,0
+1663,133953,95,Emergent Herbaceuous Wetlands,,133,Developed park,Resort/ski area,-1,-1,-1,-1,-1,-1,1,-1,3,0.66,high,#31a354,73.72478868,0,156.5591496,7.04,0,0,0
+1664,134110,11,Open Water,,134,Developed park,Other,-1,-1,-1,-1,-1,-1,1,-1,0,0,none,#ffffff,0,0,0,0,0,0,0
+1665,134111,11,Open Water,,134,Developed park,Other,-1,-1,-1,-1,-1,-1,1,-1,1,0.15,low,#e5f5e0,14.16699743,0,15.56798855,1.6,0,0,0
+1666,134112,11,Open Water,,134,Developed park,Other,-1,-1,-1,-1,-1,-1,1,-1,2,0.4,medium,#a1d99b,37.7786598,0,41.51463613,4.266666667,0,0,0
+1667,134113,11,Open Water,,134,Developed park,Other,-1,-1,-1,-1,-1,-1,1,-1,3,0.66,high,#31a354,62.33478868,0,68.49914961,7.04,0,0,0
+1668,134120,12,Perennial Ice/Snow,,134,Developed park,Other,-1,-1,-1,-1,-1,-1,-1,-1,0,0,none,#ffffff,0,0,0,0,0,0,0
+1669,134121,12,Perennial Ice/Snow,,134,Developed park,Other,-1,-1,-1,-1,-1,-1,-1,-1,1,0.15,low,#e5f5e0,14.16699743,0,15.56798855,1.6,0,0,0
+1670,134122,12,Perennial Ice/Snow,,134,Developed park,Other,-1,-1,-1,-1,-1,-1,-1,-1,2,0.4,medium,#a1d99b,37.7786598,0,41.51463613,4.266666667,0,0,0
+1671,134123,12,Perennial Ice/Snow,,134,Developed park,Other,-1,-1,-1,-1,-1,-1,-1,-1,3,0.66,high,#31a354,62.33478868,0,68.49914961,7.04,0,0,0
+1672,134210,21,"Developed, Open Space","20% trees, 60% grass, and 10% buildings and 10% bare soil",134,Developed park,Other,-1,-1,-1,-1,-1,-1,1,-1,0,0,none,#ffffff,25.49986095,4.08,79.01411479,1.76,51.81402439,212.31,37.03522039
+1673,134211,21,"Developed, Open Space","20% trees, 60% grass, and 10% buildings and 10% bare soil",134,Developed park,Other,-1,-1,-1,-1,-1,-1,1,-1,1,0.15,low,#e5f5e0,35.84187923,3.468,82.72998612,3.096,51.81402439,212.31,37.03522039
+1674,134212,21,"Developed, Open Space","20% trees, 60% grass, and 10% buildings and 10% bare soil",134,Developed park,Other,-1,-1,-1,-1,-1,-1,1,-1,2,0.4,medium,#a1d99b,53.07857637,2.448,88.923105,5.322666667,51.81402439,212.31,37.03522039
+1675,134213,21,"Developed, Open Space","20% trees, 60% grass, and 10% buildings and 10% bare soil",134,Developed park,Other,-1,-1,-1,-1,-1,-1,1,-1,3,0.66,high,#31a354,71.0047414,1.3872,95.36394864,7.6384,51.81402439,212.31,37.03522039
+1676,134220,22,"Developed, Low Intensity","20% trees, 40% grass, and 40% buildings",134,Developed park,Other,-1,-1,-1,-1,-1,-1,1,-1,0,0,none,#ffffff,20.90844667,3.52,72.06732319,0.61,207.2560976,849.24,147.1338816
+1677,134221,22,"Developed, Low Intensity","20% trees, 40% grass, and 40% buildings",134,Developed park,Other,-1,-1,-1,-1,-1,-1,1,-1,1,0.15,low,#e5f5e0,31.9391771,2.992,76.82521326,2.1185,207.2560976,849.24,147.1338816
+1678,134222,22,"Developed, Low Intensity","20% trees, 40% grass, and 40% buildings",134,Developed park,Other,-1,-1,-1,-1,-1,-1,1,-1,2,0.4,medium,#a1d99b,50.32372781,2.112,84.75503004,4.632666667,207.2560976,849.24,147.1338816
+1679,134223,22,"Developed, Low Intensity","20% trees, 40% grass, and 40% buildings",134,Developed park,Other,-1,-1,-1,-1,-1,-1,1,-1,3,0.66,high,#31a354,69.44366054,1.1968,93.0020395,7.2474,207.2560976,849.24,147.1338816
+1680,134230,23,"Developed, Medium Intensity","15% trees, 35% grass, and 50% buildings",134,Developed park,Other,-1,-1,-1,-1,-1,-1,1,-1,0,0,none,#ffffff,17.69813636,3.08,61.93838294,0.36,234.070122,954.85,720.4716833
+1681,134231,23,"Developed, Medium Intensity","15% trees, 35% grass, and 50% buildings",134,Developed park,Other,-1,-1,-1,-1,-1,-1,1,-1,1,0.15,low,#e5f5e0,29.21041333,2.618,68.21561405,1.906,234.070122,954.85,720.4716833
+1682,134232,23,"Developed, Medium Intensity","15% trees, 35% grass, and 50% buildings",134,Developed park,Other,-1,-1,-1,-1,-1,-1,1,-1,2,0.4,medium,#a1d99b,48.39754162,1.848,78.67766589,4.482666667,234.070122,954.85,720.4716833
+1683,134233,23,"Developed, Medium Intensity","15% trees, 35% grass, and 50% buildings",134,Developed park,Other,-1,-1,-1,-1,-1,-1,1,-1,3,0.66,high,#31a354,68.35215504,1.0472,89.55819981,7.1624,234.070122,954.85,720.4716833
+1684,134240,24,"Developed, High Intensity","10% trees, 20% grass, and 70% buildings",134,Developed park,Other,-1,-1,-1,-1,-1,-1,1,-1,0,0,none,#ffffff,10.98142029,1.76,44.78642515,0.245,267.9065041,3418.485,1805.616283
+1685,134241,24,"Developed, High Intensity","10% trees, 20% grass, and 70% buildings",134,Developed park,Other,-1,-1,-1,-1,-1,-1,1,-1,1,0.15,low,#e5f5e0,23.50120467,1.496,53.63644993,1.80825,267.9065041,3418.485,1805.616283
+1686,134242,24,"Developed, High Intensity","10% trees, 20% grass, and 70% buildings",134,Developed park,Other,-1,-1,-1,-1,-1,-1,1,-1,2,0.4,medium,#a1d99b,44.36751198,1.056,68.38649122,4.413666667,267.9065041,3418.485,1805.616283
+1687,134243,24,"Developed, High Intensity","10% trees, 20% grass, and 70% buildings",134,Developed park,Other,-1,-1,-1,-1,-1,-1,1,-1,3,0.66,high,#31a354,66.06847158,0.5984,83.72653416,7.1233,267.9065041,3418.485,1805.616283
+1688,134310,31,Barren Land,,134,Developed park,Other,-1,-1,-1,-1,-1,-1,1,-1,0,0,none,#ffffff,6.8,0,25.5,0,0,0,0
+1689,134311,31,Barren Land,,134,Developed park,Other,-1,-1,-1,-1,-1,-1,1,-1,1,0.15,low,#e5f5e0,19.94699743,0,37.24298855,1.6,0,0,0
+1690,134312,31,Barren Land,,134,Developed park,Other,-1,-1,-1,-1,-1,-1,1,-1,2,0.4,medium,#a1d99b,41.8586598,0,56.81463613,4.266666667,0,0,0
+1691,134313,31,Barren Land,,134,Developed park,Other,-1,-1,-1,-1,-1,-1,1,-1,3,0.66,high,#31a354,64.64678868,0,77.16914961,7.04,0,0,0
+1692,134410,41,Deciduous Forest,,134,Developed park,Other,-1,-1,-1,-1,-1,-1,1,-1,0,0,none,#ffffff,85.88498714,0,96.08994273,8.8,0,0,0
+1693,134411,41,Deciduous Forest,,134,Developed park,Other,-1,-1,-1,-1,-1,-1,1,-1,1,0.15,low,#e5f5e0,85.88498714,0,96.08994273,8.8,0,0,0
+1694,134412,41,Deciduous Forest,,134,Developed park,Other,-1,-1,-1,-1,-1,-1,1,-1,2,0.4,medium,#a1d99b,85.88498714,0,96.08994273,8.8,0,0,0
+1695,134413,41,Deciduous Forest,,134,Developed park,Other,-1,-1,-1,-1,-1,-1,1,-1,3,0.66,high,#31a354,85.88498714,0,96.08994273,8.8,0,0,0
+1696,134420,42,Evergreen Forest,,134,Developed park,Other,-1,-1,-1,-1,-1,-1,1,-1,0,0,none,#ffffff,105.6849871,0,96.08994273,14.4,0,0,0
+1697,134421,42,Evergreen Forest,,134,Developed park,Other,-1,-1,-1,-1,-1,-1,1,-1,1,0.15,low,#e5f5e0,105.6849871,0,96.08994273,14.4,0,0,0
+1698,134422,42,Evergreen Forest,,134,Developed park,Other,-1,-1,-1,-1,-1,-1,1,-1,2,0.4,medium,#a1d99b,105.6849871,0,96.08994273,14.4,0,0,0
+1699,134423,42,Evergreen Forest,,134,Developed park,Other,-1,-1,-1,-1,-1,-1,1,-1,3,0.66,high,#31a354,105.6849871,0,96.08994273,14.4,0,0,0
+1700,134430,43,Mixed Forest,,134,Developed park,Other,-1,-1,-1,-1,-1,-1,1,-1,0,0,none,#ffffff,91.76997429,0,119.1798855,8.8,0,0,0
+1701,134431,43,Mixed Forest,,134,Developed park,Other,-1,-1,-1,-1,-1,-1,1,-1,1,0.15,low,#e5f5e0,91.76997429,0,119.1798855,8.8,0,0,0
+1702,134432,43,Mixed Forest,,134,Developed park,Other,-1,-1,-1,-1,-1,-1,1,-1,2,0.4,medium,#a1d99b,91.76997429,0,119.1798855,8.8,0,0,0
+1703,134433,43,Mixed Forest,,134,Developed park,Other,-1,-1,-1,-1,-1,-1,1,-1,3,0.66,high,#31a354,91.76997429,0,119.1798855,8.8,0,0,0
+1704,134520,52,Shrub/Scrub,,134,Developed park,Other,-1,-1,-1,-1,-1,-1,1,-1,0,0,none,#ffffff,47.875,0,68.15477645,0,0,0,0
+1705,134521,52,Shrub/Scrub,,134,Developed park,Other,-1,-1,-1,-1,-1,-1,1,-1,1,0.15,low,#e5f5e0,54.86074743,0,73.49954853,1.6,0,0,0
+1706,134522,52,Shrub/Scrub,,134,Developed park,Other,-1,-1,-1,-1,-1,-1,1,-1,2,0.4,medium,#a1d99b,66.5036598,0,82.407502,4.266666667,0,0,0
+1707,134523,52,Shrub/Scrub,,134,Developed park,Other,-1,-1,-1,-1,-1,-1,1,-1,3,0.66,high,#31a354,78.61228868,0,91.6717736,7.04,0,0,0
+1708,134710,71,Herbaceuous,,134,Developed park,Other,-1,-1,-1,-1,-1,-1,1,-1,0,0,none,#ffffff,10.10660117,8,98.79264417,0,0,0,0
+1709,134711,71,Herbaceuous,,134,Developed park,Other,-1,-1,-1,-1,-1,-1,1,-1,1,0.15,low,#e5f5e0,22.75760842,6.8,99.54173609,1.6,0,0,0
+1710,134712,71,Herbaceuous,,134,Developed park,Other,-1,-1,-1,-1,-1,-1,1,-1,2,0.4,medium,#a1d99b,43.84262051,4.8,100.7902226,4.266666667,0,0,0
+1711,134713,71,Herbaceuous,,134,Developed park,Other,-1,-1,-1,-1,-1,-1,1,-1,3,0.66,high,#31a354,65.77103307,2.72,102.0886486,7.04,0,0,0
+1712,134810,81,Hay/Pasture,,134,Developed park,Other,-1,-1,-1,-1,-1,-1,1,-1,0,0,none,#ffffff,10.10660117,8,98.79264417,0,0,0,0
+1713,134811,81,Hay/Pasture,,134,Developed park,Other,-1,-1,-1,-1,-1,-1,1,-1,1,0.15,low,#e5f5e0,22.75760842,6.8,99.54173609,1.6,0,0,0
+1714,134812,81,Hay/Pasture,,134,Developed park,Other,-1,-1,-1,-1,-1,-1,1,-1,2,0.4,medium,#a1d99b,43.84262051,4.8,100.7902226,4.266666667,0,0,0
+1715,134813,81,Hay/Pasture,,134,Developed park,Other,-1,-1,-1,-1,-1,-1,1,-1,3,0.66,high,#31a354,65.77103307,2.72,102.0886486,7.04,0,0,0
+1716,134820,82,Cultivated Crops,,134,Developed park,Other,-1,-1,-1,-1,-1,-1,1,-1,0,0,none,#ffffff,4.793840162,0,65.75263422,0,0,0,0
+1717,134821,82,Cultivated Crops,,134,Developed park,Other,-1,-1,-1,-1,-1,-1,1,-1,1,0.15,low,#e5f5e0,18.24176156,0,71.45772764,1.6,0,0,0
+1718,134822,82,Cultivated Crops,,134,Developed park,Other,-1,-1,-1,-1,-1,-1,1,-1,2,0.4,medium,#a1d99b,40.6549639,0,80.96621666,4.266666667,0,0,0
+1719,134823,82,Cultivated Crops,,134,Developed park,Other,-1,-1,-1,-1,-1,-1,1,-1,3,0.66,high,#31a354,63.96469433,0,90.85504525,7.04,0,0,0
+1720,134900,90,Woody Wetlands,,134,Developed park,Other,-1,-1,-1,-1,-1,-1,1,-1,0,0,none,#ffffff,33.5,0,259,0,0,0,0
+1721,134901,90,Woody Wetlands,,134,Developed park,Other,-1,-1,-1,-1,-1,-1,1,-1,1,0.15,low,#e5f5e0,42.64199743,0,235.7179885,1.6,0,0,0
+1722,134902,90,Woody Wetlands,,134,Developed park,Other,-1,-1,-1,-1,-1,-1,1,-1,2,0.4,medium,#a1d99b,57.8786598,0,196.9146361,4.266666667,0,0,0
+1723,134903,90,Woody Wetlands,,134,Developed park,Other,-1,-1,-1,-1,-1,-1,1,-1,3,0.66,high,#31a354,73.72478868,0,156.5591496,7.04,0,0,0
+1724,134950,95,Emergent Herbaceuous Wetlands,,134,Developed park,Other,-1,-1,-1,-1,-1,-1,1,-1,0,0,none,#ffffff,33.5,0,259,0,0,0,0
+1725,134951,95,Emergent Herbaceuous Wetlands,,134,Developed park,Other,-1,-1,-1,-1,-1,-1,1,-1,1,0.15,low,#e5f5e0,42.64199743,0,235.7179885,1.6,0,0,0
+1726,134952,95,Emergent Herbaceuous Wetlands,,134,Developed park,Other,-1,-1,-1,-1,-1,-1,1,-1,2,0.4,medium,#a1d99b,57.8786598,0,196.9146361,4.266666667,0,0,0
+1727,134953,95,Emergent Herbaceuous Wetlands,,134,Developed park,Other,-1,-1,-1,-1,-1,-1,1,-1,3,0.66,high,#31a354,73.72478868,0,156.5591496,7.04,0,0,0
+1728,140110,11,Open Water,,140,Natural park,,-1,-1,-1,-1,-1,-1,1,-1,0,0,none,#ffffff,0,0,0,0,0,0,0
+1729,140111,11,Open Water,,140,Natural park,,-1,-1,-1,-1,-1,-1,1,-1,1,0.15,low,#e5f5e0,14.16699743,0,15.56798855,1.6,0,0,0
+1730,140112,11,Open Water,,140,Natural park,,-1,-1,-1,-1,-1,-1,1,-1,2,0.4,medium,#a1d99b,37.7786598,0,41.51463613,4.266666667,0,0,0
+1731,140113,11,Open Water,,140,Natural park,,-1,-1,-1,-1,-1,-1,1,-1,3,0.66,high,#31a354,62.33478868,0,68.49914961,7.04,0,0,0
+1732,140120,12,Perennial Ice/Snow,,140,Natural park,,-1,-1,-1,-1,-1,-1,-1,-1,0,0,none,#ffffff,0,0,0,0,0,0,0
+1733,140121,12,Perennial Ice/Snow,,140,Natural park,,-1,-1,-1,-1,-1,-1,-1,-1,1,0.15,low,#e5f5e0,14.16699743,0,15.56798855,1.6,0,0,0
+1734,140122,12,Perennial Ice/Snow,,140,Natural park,,-1,-1,-1,-1,-1,-1,-1,-1,2,0.4,medium,#a1d99b,37.7786598,0,41.51463613,4.266666667,0,0,0
+1735,140123,12,Perennial Ice/Snow,,140,Natural park,,-1,-1,-1,-1,-1,-1,-1,-1,3,0.66,high,#31a354,62.33478868,0,68.49914961,7.04,0,0,0
+1736,140210,21,"Developed, Open Space","20% trees, 60% grass, and 10% buildings and 10% bare soil",140,Natural park,,-1,-1,-1,1,-1,-1,1,-1,0,0,none,#ffffff,25.49986095,4.08,79.01411479,1.76,51.81402439,212.31,37.03522039
+1737,140211,21,"Developed, Open Space","20% trees, 60% grass, and 10% buildings and 10% bare soil",140,Natural park,,-1,-1,-1,1,-1,-1,1,-1,1,0.15,low,#e5f5e0,35.84187923,3.468,82.72998612,3.096,51.81402439,212.31,37.03522039
+1738,140212,21,"Developed, Open Space","20% trees, 60% grass, and 10% buildings and 10% bare soil",140,Natural park,,-1,-1,-1,1,-1,-1,1,-1,2,0.4,medium,#a1d99b,53.07857637,2.448,88.923105,5.322666667,51.81402439,212.31,37.03522039
+1739,140213,21,"Developed, Open Space","20% trees, 60% grass, and 10% buildings and 10% bare soil",140,Natural park,,-1,-1,-1,1,-1,-1,1,-1,3,0.66,high,#31a354,71.0047414,1.3872,95.36394864,7.6384,51.81402439,212.31,37.03522039
+1740,140220,22,"Developed, Low Intensity","20% trees, 40% grass, and 40% buildings",140,Natural park,,-1,-1,-1,1,-1,-1,1,-1,0,0,none,#ffffff,20.90844667,3.52,72.06732319,0.61,207.2560976,849.24,147.1338816
+1741,140221,22,"Developed, Low Intensity","20% trees, 40% grass, and 40% buildings",140,Natural park,,-1,-1,-1,1,-1,-1,1,-1,1,0.15,low,#e5f5e0,31.9391771,2.992,76.82521326,2.1185,207.2560976,849.24,147.1338816
+1742,140222,22,"Developed, Low Intensity","20% trees, 40% grass, and 40% buildings",140,Natural park,,-1,-1,-1,1,-1,-1,1,-1,2,0.4,medium,#a1d99b,50.32372781,2.112,84.75503004,4.632666667,207.2560976,849.24,147.1338816
+1743,140223,22,"Developed, Low Intensity","20% trees, 40% grass, and 40% buildings",140,Natural park,,-1,-1,-1,1,-1,-1,1,-1,3,0.66,high,#31a354,69.44366054,1.1968,93.0020395,7.2474,207.2560976,849.24,147.1338816
+1744,140230,23,"Developed, Medium Intensity","15% trees, 35% grass, and 50% buildings",140,Natural park,,-1,-1,-1,1,-1,-1,1,-1,0,0,none,#ffffff,17.69813636,3.08,61.93838294,0.36,234.070122,954.85,720.4716833
+1745,140231,23,"Developed, Medium Intensity","15% trees, 35% grass, and 50% buildings",140,Natural park,,-1,-1,-1,1,-1,-1,1,-1,1,0.15,low,#e5f5e0,29.21041333,2.618,68.21561405,1.906,234.070122,954.85,720.4716833
+1746,140232,23,"Developed, Medium Intensity","15% trees, 35% grass, and 50% buildings",140,Natural park,,-1,-1,-1,1,-1,-1,1,-1,2,0.4,medium,#a1d99b,48.39754162,1.848,78.67766589,4.482666667,234.070122,954.85,720.4716833
+1747,140233,23,"Developed, Medium Intensity","15% trees, 35% grass, and 50% buildings",140,Natural park,,-1,-1,-1,1,-1,-1,1,-1,3,0.66,high,#31a354,68.35215504,1.0472,89.55819981,7.1624,234.070122,954.85,720.4716833
+1748,140240,24,"Developed, High Intensity","10% trees, 20% grass, and 70% buildings",140,Natural park,,-1,-1,-1,1,-1,-1,1,-1,0,0,none,#ffffff,10.98142029,1.76,44.78642515,0.245,267.9065041,3418.485,1805.616283
+1749,140241,24,"Developed, High Intensity","10% trees, 20% grass, and 70% buildings",140,Natural park,,-1,-1,-1,1,-1,-1,1,-1,1,0.15,low,#e5f5e0,23.50120467,1.496,53.63644993,1.80825,267.9065041,3418.485,1805.616283
+1750,140242,24,"Developed, High Intensity","10% trees, 20% grass, and 70% buildings",140,Natural park,,-1,-1,-1,1,-1,-1,1,-1,2,0.4,medium,#a1d99b,44.36751198,1.056,68.38649122,4.413666667,267.9065041,3418.485,1805.616283
+1751,140243,24,"Developed, High Intensity","10% trees, 20% grass, and 70% buildings",140,Natural park,,-1,-1,-1,1,-1,-1,1,-1,3,0.66,high,#31a354,66.06847158,0.5984,83.72653416,7.1233,267.9065041,3418.485,1805.616283
+1752,140310,31,Barren Land,,140,Natural park,,-1,-1,-1,1,-1,-1,1,-1,0,0,none,#ffffff,6.8,0,25.5,0,0,0,0
+1753,140311,31,Barren Land,,140,Natural park,,-1,-1,-1,1,-1,-1,1,-1,1,0.15,low,#e5f5e0,19.94699743,0,37.24298855,1.6,0,0,0
+1754,140312,31,Barren Land,,140,Natural park,,-1,-1,-1,1,-1,-1,1,-1,2,0.4,medium,#a1d99b,41.8586598,0,56.81463613,4.266666667,0,0,0
+1755,140313,31,Barren Land,,140,Natural park,,-1,-1,-1,1,-1,-1,1,-1,3,0.66,high,#31a354,64.64678868,0,77.16914961,7.04,0,0,0
+1756,140410,41,Deciduous Forest,,140,Natural park,,-1,-1,-1,-1,-1,-1,1,-1,0,0,none,#ffffff,85.88498714,0,96.08994273,8.8,0,0,0
+1757,140411,41,Deciduous Forest,,140,Natural park,,-1,-1,-1,-1,-1,-1,1,-1,1,0.15,low,#e5f5e0,85.88498714,0,96.08994273,8.8,0,0,0
+1758,140412,41,Deciduous Forest,,140,Natural park,,-1,-1,-1,-1,-1,-1,1,-1,2,0.4,medium,#a1d99b,85.88498714,0,96.08994273,8.8,0,0,0
+1759,140413,41,Deciduous Forest,,140,Natural park,,-1,-1,-1,-1,-1,-1,1,-1,3,0.66,high,#31a354,85.88498714,0,96.08994273,8.8,0,0,0
+1760,140420,42,Evergreen Forest,,140,Natural park,,-1,-1,-1,-1,-1,-1,1,-1,0,0,none,#ffffff,105.6849871,0,96.08994273,14.4,0,0,0
+1761,140421,42,Evergreen Forest,,140,Natural park,,-1,-1,-1,-1,-1,-1,1,-1,1,0.15,low,#e5f5e0,105.6849871,0,96.08994273,14.4,0,0,0
+1762,140422,42,Evergreen Forest,,140,Natural park,,-1,-1,-1,-1,-1,-1,1,-1,2,0.4,medium,#a1d99b,105.6849871,0,96.08994273,14.4,0,0,0
+1763,140423,42,Evergreen Forest,,140,Natural park,,-1,-1,-1,-1,-1,-1,1,-1,3,0.66,high,#31a354,105.6849871,0,96.08994273,14.4,0,0,0
+1764,140430,43,Mixed Forest,,140,Natural park,,-1,-1,-1,-1,-1,-1,1,-1,0,0,none,#ffffff,91.76997429,0,119.1798855,8.8,0,0,0
+1765,140431,43,Mixed Forest,,140,Natural park,,-1,-1,-1,-1,-1,-1,1,-1,1,0.15,low,#e5f5e0,91.76997429,0,119.1798855,8.8,0,0,0
+1766,140432,43,Mixed Forest,,140,Natural park,,-1,-1,-1,-1,-1,-1,1,-1,2,0.4,medium,#a1d99b,91.76997429,0,119.1798855,8.8,0,0,0
+1767,140433,43,Mixed Forest,,140,Natural park,,-1,-1,-1,-1,-1,-1,1,-1,3,0.66,high,#31a354,91.76997429,0,119.1798855,8.8,0,0,0
+1768,140520,52,Shrub/Scrub,,140,Natural park,,-1,-1,-1,1,-1,-1,1,-1,0,0,none,#ffffff,47.875,0,68.15477645,0,0,0,0
+1769,140521,52,Shrub/Scrub,,140,Natural park,,-1,-1,-1,1,-1,-1,1,-1,1,0.15,low,#e5f5e0,54.86074743,0,73.49954853,1.6,0,0,0
+1770,140522,52,Shrub/Scrub,,140,Natural park,,-1,-1,-1,1,-1,-1,1,-1,2,0.4,medium,#a1d99b,66.5036598,0,82.407502,4.266666667,0,0,0
+1771,140523,52,Shrub/Scrub,,140,Natural park,,-1,-1,-1,1,-1,-1,1,-1,3,0.66,high,#31a354,78.61228868,0,91.6717736,7.04,0,0,0
+1772,140710,71,Herbaceuous,,140,Natural park,,-1,-1,-1,1,-1,-1,1,-1,0,0,none,#ffffff,10.10660117,8,98.79264417,0,0,0,0
+1773,140711,71,Herbaceuous,,140,Natural park,,-1,-1,-1,1,-1,-1,1,-1,1,0.15,low,#e5f5e0,22.75760842,6.8,99.54173609,1.6,0,0,0
+1774,140712,71,Herbaceuous,,140,Natural park,,-1,-1,-1,1,-1,-1,1,-1,2,0.4,medium,#a1d99b,43.84262051,4.8,100.7902226,4.266666667,0,0,0
+1775,140713,71,Herbaceuous,,140,Natural park,,-1,-1,-1,1,-1,-1,1,-1,3,0.66,high,#31a354,65.77103307,2.72,102.0886486,7.04,0,0,0
+1776,140810,81,Hay/Pasture,,140,Natural park,,-1,-1,-1,1,-1,-1,1,-1,0,0,none,#ffffff,10.10660117,8,98.79264417,0,0,0,0
+1777,140811,81,Hay/Pasture,,140,Natural park,,-1,-1,-1,1,-1,-1,1,-1,1,0.15,low,#e5f5e0,22.75760842,6.8,99.54173609,1.6,0,0,0
+1778,140812,81,Hay/Pasture,,140,Natural park,,-1,-1,-1,1,-1,-1,1,-1,2,0.4,medium,#a1d99b,43.84262051,4.8,100.7902226,4.266666667,0,0,0
+1779,140813,81,Hay/Pasture,,140,Natural park,,-1,-1,-1,1,-1,-1,1,-1,3,0.66,high,#31a354,65.77103307,2.72,102.0886486,7.04,0,0,0
+1780,140820,82,Cultivated Crops,,140,Natural park,,-1,-1,-1,-1,-1,-1,1,-1,0,0,none,#ffffff,4.793840162,0,65.75263422,0,0,0,0
+1781,140821,82,Cultivated Crops,,140,Natural park,,-1,-1,-1,-1,-1,-1,1,-1,1,0.15,low,#e5f5e0,18.24176156,0,71.45772764,1.6,0,0,0
+1782,140822,82,Cultivated Crops,,140,Natural park,,-1,-1,-1,-1,-1,-1,1,-1,2,0.4,medium,#a1d99b,40.6549639,0,80.96621666,4.266666667,0,0,0
+1783,140823,82,Cultivated Crops,,140,Natural park,,-1,-1,-1,-1,-1,-1,1,-1,3,0.66,high,#31a354,63.96469433,0,90.85504525,7.04,0,0,0
+1784,140900,90,Woody Wetlands,,140,Natural park,,-1,-1,-1,-1,-1,-1,1,-1,0,0,none,#ffffff,33.5,0,259,0,0,0,0
+1785,140901,90,Woody Wetlands,,140,Natural park,,-1,-1,-1,-1,-1,-1,1,-1,1,0.15,low,#e5f5e0,42.64199743,0,235.7179885,1.6,0,0,0
+1786,140902,90,Woody Wetlands,,140,Natural park,,-1,-1,-1,-1,-1,-1,1,-1,2,0.4,medium,#a1d99b,57.8786598,0,196.9146361,4.266666667,0,0,0
+1787,140903,90,Woody Wetlands,,140,Natural park,,-1,-1,-1,-1,-1,-1,1,-1,3,0.66,high,#31a354,73.72478868,0,156.5591496,7.04,0,0,0
+1788,140950,95,Emergent Herbaceuous Wetlands,,140,Natural park,,-1,-1,-1,-1,-1,-1,1,-1,0,0,none,#ffffff,33.5,0,259,0,0,0,0
+1789,140951,95,Emergent Herbaceuous Wetlands,,140,Natural park,,-1,-1,-1,-1,-1,-1,1,-1,1,0.15,low,#e5f5e0,42.64199743,0,235.7179885,1.6,0,0,0
+1790,140952,95,Emergent Herbaceuous Wetlands,,140,Natural park,,-1,-1,-1,-1,-1,-1,1,-1,2,0.4,medium,#a1d99b,57.8786598,0,196.9146361,4.266666667,0,0,0
+1791,140953,95,Emergent Herbaceuous Wetlands,,140,Natural park,,-1,-1,-1,-1,-1,-1,1,-1,3,0.66,high,#31a354,73.72478868,0,156.5591496,7.04,0,0,0
+1792,151110,11,Open Water,,151,Conservation,Public,-1,-1,-1,-1,-1,-1,1,-1,0,0,none,#ffffff,0,0,0,0,0,0,0
+1793,151111,11,Open Water,,151,Conservation,Public,-1,-1,-1,-1,-1,-1,1,-1,1,0.15,low,#e5f5e0,14.16699743,0,15.56798855,1.6,0,0,0
+1794,151112,11,Open Water,,151,Conservation,Public,-1,-1,-1,-1,-1,-1,1,-1,2,0.4,medium,#a1d99b,37.7786598,0,41.51463613,4.266666667,0,0,0
+1795,151113,11,Open Water,,151,Conservation,Public,-1,-1,-1,-1,-1,-1,1,-1,3,0.66,high,#31a354,62.33478868,0,68.49914961,7.04,0,0,0
+1796,151120,12,Perennial Ice/Snow,,151,Conservation,Public,-1,-1,-1,-1,-1,-1,-1,-1,0,0,none,#ffffff,0,0,0,0,0,0,0
+1797,151121,12,Perennial Ice/Snow,,151,Conservation,Public,-1,-1,-1,-1,-1,-1,-1,-1,1,0.15,low,#e5f5e0,14.16699743,0,15.56798855,1.6,0,0,0
+1798,151122,12,Perennial Ice/Snow,,151,Conservation,Public,-1,-1,-1,-1,-1,-1,-1,-1,2,0.4,medium,#a1d99b,37.7786598,0,41.51463613,4.266666667,0,0,0
+1799,151123,12,Perennial Ice/Snow,,151,Conservation,Public,-1,-1,-1,-1,-1,-1,-1,-1,3,0.66,high,#31a354,62.33478868,0,68.49914961,7.04,0,0,0
+1800,151210,21,"Developed, Open Space","20% trees, 60% grass, and 10% buildings and 10% bare soil",151,Conservation,Public,-1,-1,-1,1,-1,-1,1,-1,0,0,none,#ffffff,25.49986095,4.08,79.01411479,1.76,51.81402439,212.31,37.03522039
+1801,151211,21,"Developed, Open Space","20% trees, 60% grass, and 10% buildings and 10% bare soil",151,Conservation,Public,-1,-1,-1,1,-1,-1,1,-1,1,0.15,low,#e5f5e0,35.84187923,3.468,82.72998612,3.096,51.81402439,212.31,37.03522039
+1802,151212,21,"Developed, Open Space","20% trees, 60% grass, and 10% buildings and 10% bare soil",151,Conservation,Public,-1,-1,-1,1,-1,-1,1,-1,2,0.4,medium,#a1d99b,53.07857637,2.448,88.923105,5.322666667,51.81402439,212.31,37.03522039
+1803,151213,21,"Developed, Open Space","20% trees, 60% grass, and 10% buildings and 10% bare soil",151,Conservation,Public,-1,-1,-1,1,-1,-1,1,-1,3,0.66,high,#31a354,71.0047414,1.3872,95.36394864,7.6384,51.81402439,212.31,37.03522039
+1804,151220,22,"Developed, Low Intensity","20% trees, 40% grass, and 40% buildings",151,Conservation,Public,-1,-1,-1,1,-1,-1,1,-1,0,0,none,#ffffff,20.90844667,3.52,72.06732319,0.61,207.2560976,849.24,147.1338816
+1805,151221,22,"Developed, Low Intensity","20% trees, 40% grass, and 40% buildings",151,Conservation,Public,-1,-1,-1,1,-1,-1,1,-1,1,0.15,low,#e5f5e0,31.9391771,2.992,76.82521326,2.1185,207.2560976,849.24,147.1338816
+1806,151222,22,"Developed, Low Intensity","20% trees, 40% grass, and 40% buildings",151,Conservation,Public,-1,-1,-1,1,-1,-1,1,-1,2,0.4,medium,#a1d99b,50.32372781,2.112,84.75503004,4.632666667,207.2560976,849.24,147.1338816
+1807,151223,22,"Developed, Low Intensity","20% trees, 40% grass, and 40% buildings",151,Conservation,Public,-1,-1,-1,1,-1,-1,1,-1,3,0.66,high,#31a354,69.44366054,1.1968,93.0020395,7.2474,207.2560976,849.24,147.1338816
+1808,151230,23,"Developed, Medium Intensity","15% trees, 35% grass, and 50% buildings",151,Conservation,Public,-1,-1,-1,1,-1,-1,1,-1,0,0,none,#ffffff,17.69813636,3.08,61.93838294,0.36,234.070122,954.85,720.4716833
+1809,151231,23,"Developed, Medium Intensity","15% trees, 35% grass, and 50% buildings",151,Conservation,Public,-1,-1,-1,1,-1,-1,1,-1,1,0.15,low,#e5f5e0,29.21041333,2.618,68.21561405,1.906,234.070122,954.85,720.4716833
+1810,151232,23,"Developed, Medium Intensity","15% trees, 35% grass, and 50% buildings",151,Conservation,Public,-1,-1,-1,1,-1,-1,1,-1,2,0.4,medium,#a1d99b,48.39754162,1.848,78.67766589,4.482666667,234.070122,954.85,720.4716833
+1811,151233,23,"Developed, Medium Intensity","15% trees, 35% grass, and 50% buildings",151,Conservation,Public,-1,-1,-1,1,-1,-1,1,-1,3,0.66,high,#31a354,68.35215504,1.0472,89.55819981,7.1624,234.070122,954.85,720.4716833
+1812,151240,24,"Developed, High Intensity","10% trees, 20% grass, and 70% buildings",151,Conservation,Public,-1,-1,-1,1,-1,-1,1,-1,0,0,none,#ffffff,10.98142029,1.76,44.78642515,0.245,267.9065041,3418.485,1805.616283
+1813,151241,24,"Developed, High Intensity","10% trees, 20% grass, and 70% buildings",151,Conservation,Public,-1,-1,-1,1,-1,-1,1,-1,1,0.15,low,#e5f5e0,23.50120467,1.496,53.63644993,1.80825,267.9065041,3418.485,1805.616283
+1814,151242,24,"Developed, High Intensity","10% trees, 20% grass, and 70% buildings",151,Conservation,Public,-1,-1,-1,1,-1,-1,1,-1,2,0.4,medium,#a1d99b,44.36751198,1.056,68.38649122,4.413666667,267.9065041,3418.485,1805.616283
+1815,151243,24,"Developed, High Intensity","10% trees, 20% grass, and 70% buildings",151,Conservation,Public,-1,-1,-1,1,-1,-1,1,-1,3,0.66,high,#31a354,66.06847158,0.5984,83.72653416,7.1233,267.9065041,3418.485,1805.616283
+1816,151310,31,Barren Land,,151,Conservation,Public,-1,-1,-1,1,-1,-1,1,-1,0,0,none,#ffffff,6.8,0,25.5,0,0,0,0
+1817,151311,31,Barren Land,,151,Conservation,Public,-1,-1,-1,1,-1,-1,1,-1,1,0.15,low,#e5f5e0,19.94699743,0,37.24298855,1.6,0,0,0
+1818,151312,31,Barren Land,,151,Conservation,Public,-1,-1,-1,1,-1,-1,1,-1,2,0.4,medium,#a1d99b,41.8586598,0,56.81463613,4.266666667,0,0,0
+1819,151313,31,Barren Land,,151,Conservation,Public,-1,-1,-1,1,-1,-1,1,-1,3,0.66,high,#31a354,64.64678868,0,77.16914961,7.04,0,0,0
+1820,151410,41,Deciduous Forest,,151,Conservation,Public,-1,-1,-1,-1,-1,-1,1,-1,0,0,none,#ffffff,85.88498714,0,96.08994273,8.8,0,0,0
+1821,151411,41,Deciduous Forest,,151,Conservation,Public,-1,-1,-1,-1,-1,-1,1,-1,1,0.15,low,#e5f5e0,85.88498714,0,96.08994273,8.8,0,0,0
+1822,151412,41,Deciduous Forest,,151,Conservation,Public,-1,-1,-1,-1,-1,-1,1,-1,2,0.4,medium,#a1d99b,85.88498714,0,96.08994273,8.8,0,0,0
+1823,151413,41,Deciduous Forest,,151,Conservation,Public,-1,-1,-1,-1,-1,-1,1,-1,3,0.66,high,#31a354,85.88498714,0,96.08994273,8.8,0,0,0
+1824,151420,42,Evergreen Forest,,151,Conservation,Public,-1,-1,-1,-1,-1,-1,1,-1,0,0,none,#ffffff,105.6849871,0,96.08994273,14.4,0,0,0
+1825,151421,42,Evergreen Forest,,151,Conservation,Public,-1,-1,-1,-1,-1,-1,1,-1,1,0.15,low,#e5f5e0,105.6849871,0,96.08994273,14.4,0,0,0
+1826,151422,42,Evergreen Forest,,151,Conservation,Public,-1,-1,-1,-1,-1,-1,1,-1,2,0.4,medium,#a1d99b,105.6849871,0,96.08994273,14.4,0,0,0
+1827,151423,42,Evergreen Forest,,151,Conservation,Public,-1,-1,-1,-1,-1,-1,1,-1,3,0.66,high,#31a354,105.6849871,0,96.08994273,14.4,0,0,0
+1828,151430,43,Mixed Forest,,151,Conservation,Public,-1,-1,-1,-1,-1,-1,1,-1,0,0,none,#ffffff,91.76997429,0,119.1798855,8.8,0,0,0
+1829,151431,43,Mixed Forest,,151,Conservation,Public,-1,-1,-1,-1,-1,-1,1,-1,1,0.15,low,#e5f5e0,91.76997429,0,119.1798855,8.8,0,0,0
+1830,151432,43,Mixed Forest,,151,Conservation,Public,-1,-1,-1,-1,-1,-1,1,-1,2,0.4,medium,#a1d99b,91.76997429,0,119.1798855,8.8,0,0,0
+1831,151433,43,Mixed Forest,,151,Conservation,Public,-1,-1,-1,-1,-1,-1,1,-1,3,0.66,high,#31a354,91.76997429,0,119.1798855,8.8,0,0,0
+1832,151520,52,Shrub/Scrub,,151,Conservation,Public,-1,-1,-1,1,-1,-1,1,-1,0,0,none,#ffffff,47.875,0,68.15477645,0,0,0,0
+1833,151521,52,Shrub/Scrub,,151,Conservation,Public,-1,-1,-1,1,-1,-1,1,-1,1,0.15,low,#e5f5e0,54.86074743,0,73.49954853,1.6,0,0,0
+1834,151522,52,Shrub/Scrub,,151,Conservation,Public,-1,-1,-1,1,-1,-1,1,-1,2,0.4,medium,#a1d99b,66.5036598,0,82.407502,4.266666667,0,0,0
+1835,151523,52,Shrub/Scrub,,151,Conservation,Public,-1,-1,-1,1,-1,-1,1,-1,3,0.66,high,#31a354,78.61228868,0,91.6717736,7.04,0,0,0
+1836,151710,71,Herbaceuous,,151,Conservation,Public,-1,-1,-1,1,-1,-1,1,-1,0,0,none,#ffffff,10.10660117,8,98.79264417,0,0,0,0
+1837,151711,71,Herbaceuous,,151,Conservation,Public,-1,-1,-1,1,-1,-1,1,-1,1,0.15,low,#e5f5e0,22.75760842,6.8,99.54173609,1.6,0,0,0
+1838,151712,71,Herbaceuous,,151,Conservation,Public,-1,-1,-1,1,-1,-1,1,-1,2,0.4,medium,#a1d99b,43.84262051,4.8,100.7902226,4.266666667,0,0,0
+1839,151713,71,Herbaceuous,,151,Conservation,Public,-1,-1,-1,1,-1,-1,1,-1,3,0.66,high,#31a354,65.77103307,2.72,102.0886486,7.04,0,0,0
+1840,151810,81,Hay/Pasture,,151,Conservation,Public,-1,-1,-1,1,-1,-1,1,-1,0,0,none,#ffffff,10.10660117,8,98.79264417,0,0,0,0
+1841,151811,81,Hay/Pasture,,151,Conservation,Public,-1,-1,-1,1,-1,-1,1,-1,1,0.15,low,#e5f5e0,22.75760842,6.8,99.54173609,1.6,0,0,0
+1842,151812,81,Hay/Pasture,,151,Conservation,Public,-1,-1,-1,1,-1,-1,1,-1,2,0.4,medium,#a1d99b,43.84262051,4.8,100.7902226,4.266666667,0,0,0
+1843,151813,81,Hay/Pasture,,151,Conservation,Public,-1,-1,-1,1,-1,-1,1,-1,3,0.66,high,#31a354,65.77103307,2.72,102.0886486,7.04,0,0,0
+1844,151820,82,Cultivated Crops,,151,Conservation,Public,-1,-1,-1,-1,-1,-1,1,-1,0,0,none,#ffffff,4.793840162,0,65.75263422,0,0,0,0
+1845,151821,82,Cultivated Crops,,151,Conservation,Public,-1,-1,-1,-1,-1,-1,1,-1,1,0.15,low,#e5f5e0,18.24176156,0,71.45772764,1.6,0,0,0
+1846,151822,82,Cultivated Crops,,151,Conservation,Public,-1,-1,-1,-1,-1,-1,1,-1,2,0.4,medium,#a1d99b,40.6549639,0,80.96621666,4.266666667,0,0,0
+1847,151823,82,Cultivated Crops,,151,Conservation,Public,-1,-1,-1,-1,-1,-1,1,-1,3,0.66,high,#31a354,63.96469433,0,90.85504525,7.04,0,0,0
+1848,151900,90,Woody Wetlands,,151,Conservation,Public,-1,-1,-1,-1,-1,-1,1,-1,0,0,none,#ffffff,33.5,0,259,0,0,0,0
+1849,151901,90,Woody Wetlands,,151,Conservation,Public,-1,-1,-1,-1,-1,-1,1,-1,1,0.15,low,#e5f5e0,42.64199743,0,235.7179885,1.6,0,0,0
+1850,151902,90,Woody Wetlands,,151,Conservation,Public,-1,-1,-1,-1,-1,-1,1,-1,2,0.4,medium,#a1d99b,57.8786598,0,196.9146361,4.266666667,0,0,0
+1851,151903,90,Woody Wetlands,,151,Conservation,Public,-1,-1,-1,-1,-1,-1,1,-1,3,0.66,high,#31a354,73.72478868,0,156.5591496,7.04,0,0,0
+1852,151950,95,Emergent Herbaceuous Wetlands,,151,Conservation,Public,-1,-1,-1,-1,-1,-1,1,-1,0,0,none,#ffffff,33.5,0,259,0,0,0,0
+1853,151951,95,Emergent Herbaceuous Wetlands,,151,Conservation,Public,-1,-1,-1,-1,-1,-1,1,-1,1,0.15,low,#e5f5e0,42.64199743,0,235.7179885,1.6,0,0,0
+1854,151952,95,Emergent Herbaceuous Wetlands,,151,Conservation,Public,-1,-1,-1,-1,-1,-1,1,-1,2,0.4,medium,#a1d99b,57.8786598,0,196.9146361,4.266666667,0,0,0
+1855,151953,95,Emergent Herbaceuous Wetlands,,151,Conservation,Public,-1,-1,-1,-1,-1,-1,1,-1,3,0.66,high,#31a354,73.72478868,0,156.5591496,7.04,0,0,0
+1856,152110,11,Open Water,,152,Conservation,Public-limited access,-1,-1,-1,-1,-1,0.5,1,-1,0,0,none,#ffffff,0,0,0,0,0,0,0
+1857,152111,11,Open Water,,152,Conservation,Public-limited access,-1,-1,-1,-1,-1,0.5,1,-1,1,0.15,low,#e5f5e0,14.16699743,0,15.56798855,1.6,0,0,0
+1858,152112,11,Open Water,,152,Conservation,Public-limited access,-1,-1,-1,-1,-1,0.5,1,-1,2,0.4,medium,#a1d99b,37.7786598,0,41.51463613,4.266666667,0,0,0
+1859,152113,11,Open Water,,152,Conservation,Public-limited access,-1,-1,-1,-1,-1,0.5,1,-1,3,0.66,high,#31a354,62.33478868,0,68.49914961,7.04,0,0,0
+1860,152120,12,Perennial Ice/Snow,,152,Conservation,Public-limited access,-1,-1,-1,-1,-1,-1,-1,-1,0,0,none,#ffffff,0,0,0,0,0,0,0
+1861,152121,12,Perennial Ice/Snow,,152,Conservation,Public-limited access,-1,-1,-1,-1,-1,-1,-1,-1,1,0.15,low,#e5f5e0,14.16699743,0,15.56798855,1.6,0,0,0
+1862,152122,12,Perennial Ice/Snow,,152,Conservation,Public-limited access,-1,-1,-1,-1,-1,-1,-1,-1,2,0.4,medium,#a1d99b,37.7786598,0,41.51463613,4.266666667,0,0,0
+1863,152123,12,Perennial Ice/Snow,,152,Conservation,Public-limited access,-1,-1,-1,-1,-1,-1,-1,-1,3,0.66,high,#31a354,62.33478868,0,68.49914961,7.04,0,0,0
+1864,152210,21,"Developed, Open Space","20% trees, 60% grass, and 10% buildings and 10% bare soil",152,Conservation,Public-limited access,-1,-1,-1,1,-1,0.5,1,-1,0,0,none,#ffffff,25.49986095,4.08,79.01411479,1.76,51.81402439,212.31,37.03522039
+1865,152211,21,"Developed, Open Space","20% trees, 60% grass, and 10% buildings and 10% bare soil",152,Conservation,Public-limited access,-1,-1,-1,1,-1,0.5,1,-1,1,0.15,low,#e5f5e0,35.84187923,3.468,82.72998612,3.096,51.81402439,212.31,37.03522039
+1866,152212,21,"Developed, Open Space","20% trees, 60% grass, and 10% buildings and 10% bare soil",152,Conservation,Public-limited access,-1,-1,-1,1,-1,0.5,1,-1,2,0.4,medium,#a1d99b,53.07857637,2.448,88.923105,5.322666667,51.81402439,212.31,37.03522039
+1867,152213,21,"Developed, Open Space","20% trees, 60% grass, and 10% buildings and 10% bare soil",152,Conservation,Public-limited access,-1,-1,-1,1,-1,0.5,1,-1,3,0.66,high,#31a354,71.0047414,1.3872,95.36394864,7.6384,51.81402439,212.31,37.03522039
+1868,152220,22,"Developed, Low Intensity","20% trees, 40% grass, and 40% buildings",152,Conservation,Public-limited access,-1,-1,-1,1,-1,-1,1,-1,0,0,none,#ffffff,20.90844667,3.52,72.06732319,0.61,207.2560976,849.24,147.1338816
+1869,152221,22,"Developed, Low Intensity","20% trees, 40% grass, and 40% buildings",152,Conservation,Public-limited access,-1,-1,-1,1,-1,-1,1,-1,1,0.15,low,#e5f5e0,31.9391771,2.992,76.82521326,2.1185,207.2560976,849.24,147.1338816
+1870,152222,22,"Developed, Low Intensity","20% trees, 40% grass, and 40% buildings",152,Conservation,Public-limited access,-1,-1,-1,1,-1,-1,1,-1,2,0.4,medium,#a1d99b,50.32372781,2.112,84.75503004,4.632666667,207.2560976,849.24,147.1338816
+1871,152223,22,"Developed, Low Intensity","20% trees, 40% grass, and 40% buildings",152,Conservation,Public-limited access,-1,-1,-1,1,-1,-1,1,-1,3,0.66,high,#31a354,69.44366054,1.1968,93.0020395,7.2474,207.2560976,849.24,147.1338816
+1872,152230,23,"Developed, Medium Intensity","15% trees, 35% grass, and 50% buildings",152,Conservation,Public-limited access,-1,-1,-1,1,-1,-1,1,-1,0,0,none,#ffffff,17.69813636,3.08,61.93838294,0.36,234.070122,954.85,720.4716833
+1873,152231,23,"Developed, Medium Intensity","15% trees, 35% grass, and 50% buildings",152,Conservation,Public-limited access,-1,-1,-1,1,-1,-1,1,-1,1,0.15,low,#e5f5e0,29.21041333,2.618,68.21561405,1.906,234.070122,954.85,720.4716833
+1874,152232,23,"Developed, Medium Intensity","15% trees, 35% grass, and 50% buildings",152,Conservation,Public-limited access,-1,-1,-1,1,-1,-1,1,-1,2,0.4,medium,#a1d99b,48.39754162,1.848,78.67766589,4.482666667,234.070122,954.85,720.4716833
+1875,152233,23,"Developed, Medium Intensity","15% trees, 35% grass, and 50% buildings",152,Conservation,Public-limited access,-1,-1,-1,1,-1,-1,1,-1,3,0.66,high,#31a354,68.35215504,1.0472,89.55819981,7.1624,234.070122,954.85,720.4716833
+1876,152240,24,"Developed, High Intensity","10% trees, 20% grass, and 70% buildings",152,Conservation,Public-limited access,-1,-1,-1,1,-1,-1,1,-1,0,0,none,#ffffff,10.98142029,1.76,44.78642515,0.245,267.9065041,3418.485,1805.616283
+1877,152241,24,"Developed, High Intensity","10% trees, 20% grass, and 70% buildings",152,Conservation,Public-limited access,-1,-1,-1,1,-1,-1,1,-1,1,0.15,low,#e5f5e0,23.50120467,1.496,53.63644993,1.80825,267.9065041,3418.485,1805.616283
+1878,152242,24,"Developed, High Intensity","10% trees, 20% grass, and 70% buildings",152,Conservation,Public-limited access,-1,-1,-1,1,-1,-1,1,-1,2,0.4,medium,#a1d99b,44.36751198,1.056,68.38649122,4.413666667,267.9065041,3418.485,1805.616283
+1879,152243,24,"Developed, High Intensity","10% trees, 20% grass, and 70% buildings",152,Conservation,Public-limited access,-1,-1,-1,1,-1,-1,1,-1,3,0.66,high,#31a354,66.06847158,0.5984,83.72653416,7.1233,267.9065041,3418.485,1805.616283
+1880,152310,31,Barren Land,,152,Conservation,Public-limited access,-1,-1,-1,1,-1,0.5,1,-1,0,0,none,#ffffff,6.8,0,25.5,0,0,0,0
+1881,152311,31,Barren Land,,152,Conservation,Public-limited access,-1,-1,-1,1,-1,0.5,1,-1,1,0.15,low,#e5f5e0,19.94699743,0,37.24298855,1.6,0,0,0
+1882,152312,31,Barren Land,,152,Conservation,Public-limited access,-1,-1,-1,1,-1,0.5,1,-1,2,0.4,medium,#a1d99b,41.8586598,0,56.81463613,4.266666667,0,0,0
+1883,152313,31,Barren Land,,152,Conservation,Public-limited access,-1,-1,-1,1,-1,0.5,1,-1,3,0.66,high,#31a354,64.64678868,0,77.16914961,7.04,0,0,0
+1884,152410,41,Deciduous Forest,,152,Conservation,Public-limited access,-1,-1,-1,-1,-1,0.5,1,-1,0,0,none,#ffffff,85.88498714,0,96.08994273,8.8,0,0,0
+1885,152411,41,Deciduous Forest,,152,Conservation,Public-limited access,-1,-1,-1,-1,-1,0.5,1,-1,1,0.15,low,#e5f5e0,85.88498714,0,96.08994273,8.8,0,0,0
+1886,152412,41,Deciduous Forest,,152,Conservation,Public-limited access,-1,-1,-1,-1,-1,0.5,1,-1,2,0.4,medium,#a1d99b,85.88498714,0,96.08994273,8.8,0,0,0
+1887,152413,41,Deciduous Forest,,152,Conservation,Public-limited access,-1,-1,-1,-1,-1,0.5,1,-1,3,0.66,high,#31a354,85.88498714,0,96.08994273,8.8,0,0,0
+1888,152420,42,Evergreen Forest,,152,Conservation,Public-limited access,-1,-1,-1,-1,-1,0.5,1,-1,0,0,none,#ffffff,105.6849871,0,96.08994273,14.4,0,0,0
+1889,152421,42,Evergreen Forest,,152,Conservation,Public-limited access,-1,-1,-1,-1,-1,0.5,1,-1,1,0.15,low,#e5f5e0,105.6849871,0,96.08994273,14.4,0,0,0
+1890,152422,42,Evergreen Forest,,152,Conservation,Public-limited access,-1,-1,-1,-1,-1,0.5,1,-1,2,0.4,medium,#a1d99b,105.6849871,0,96.08994273,14.4,0,0,0
+1891,152423,42,Evergreen Forest,,152,Conservation,Public-limited access,-1,-1,-1,-1,-1,0.5,1,-1,3,0.66,high,#31a354,105.6849871,0,96.08994273,14.4,0,0,0
+1892,152430,43,Mixed Forest,,152,Conservation,Public-limited access,-1,-1,-1,-1,-1,0.5,1,-1,0,0,none,#ffffff,91.76997429,0,119.1798855,8.8,0,0,0
+1893,152431,43,Mixed Forest,,152,Conservation,Public-limited access,-1,-1,-1,-1,-1,0.5,1,-1,1,0.15,low,#e5f5e0,91.76997429,0,119.1798855,8.8,0,0,0
+1894,152432,43,Mixed Forest,,152,Conservation,Public-limited access,-1,-1,-1,-1,-1,0.5,1,-1,2,0.4,medium,#a1d99b,91.76997429,0,119.1798855,8.8,0,0,0
+1895,152433,43,Mixed Forest,,152,Conservation,Public-limited access,-1,-1,-1,-1,-1,0.5,1,-1,3,0.66,high,#31a354,91.76997429,0,119.1798855,8.8,0,0,0
+1896,152520,52,Shrub/Scrub,,152,Conservation,Public-limited access,-1,-1,-1,1,-1,0.5,1,-1,0,0,none,#ffffff,47.875,0,68.15477645,0,0,0,0
+1897,152521,52,Shrub/Scrub,,152,Conservation,Public-limited access,-1,-1,-1,1,-1,0.5,1,-1,1,0.15,low,#e5f5e0,54.86074743,0,73.49954853,1.6,0,0,0
+1898,152522,52,Shrub/Scrub,,152,Conservation,Public-limited access,-1,-1,-1,1,-1,0.5,1,-1,2,0.4,medium,#a1d99b,66.5036598,0,82.407502,4.266666667,0,0,0
+1899,152523,52,Shrub/Scrub,,152,Conservation,Public-limited access,-1,-1,-1,1,-1,0.5,1,-1,3,0.66,high,#31a354,78.61228868,0,91.6717736,7.04,0,0,0
+1900,152710,71,Herbaceuous,,152,Conservation,Public-limited access,-1,-1,-1,1,-1,0.5,1,-1,0,0,none,#ffffff,10.10660117,8,98.79264417,0,0,0,0
+1901,152711,71,Herbaceuous,,152,Conservation,Public-limited access,-1,-1,-1,1,-1,0.5,1,-1,1,0.15,low,#e5f5e0,22.75760842,6.8,99.54173609,1.6,0,0,0
+1902,152712,71,Herbaceuous,,152,Conservation,Public-limited access,-1,-1,-1,1,-1,0.5,1,-1,2,0.4,medium,#a1d99b,43.84262051,4.8,100.7902226,4.266666667,0,0,0
+1903,152713,71,Herbaceuous,,152,Conservation,Public-limited access,-1,-1,-1,1,-1,0.5,1,-1,3,0.66,high,#31a354,65.77103307,2.72,102.0886486,7.04,0,0,0
+1904,152810,81,Hay/Pasture,,152,Conservation,Public-limited access,-1,-1,-1,1,-1,0.5,1,-1,0,0,none,#ffffff,10.10660117,8,98.79264417,0,0,0,0
+1905,152811,81,Hay/Pasture,,152,Conservation,Public-limited access,-1,-1,-1,1,-1,0.5,1,-1,1,0.15,low,#e5f5e0,22.75760842,6.8,99.54173609,1.6,0,0,0
+1906,152812,81,Hay/Pasture,,152,Conservation,Public-limited access,-1,-1,-1,1,-1,0.5,1,-1,2,0.4,medium,#a1d99b,43.84262051,4.8,100.7902226,4.266666667,0,0,0
+1907,152813,81,Hay/Pasture,,152,Conservation,Public-limited access,-1,-1,-1,1,-1,0.5,1,-1,3,0.66,high,#31a354,65.77103307,2.72,102.0886486,7.04,0,0,0
+1908,152820,82,Cultivated Crops,,152,Conservation,Public-limited access,-1,-1,-1,-1,-1,0.5,1,-1,0,0,none,#ffffff,4.793840162,0,65.75263422,0,0,0,0
+1909,152821,82,Cultivated Crops,,152,Conservation,Public-limited access,-1,-1,-1,-1,-1,0.5,1,-1,1,0.15,low,#e5f5e0,18.24176156,0,71.45772764,1.6,0,0,0
+1910,152822,82,Cultivated Crops,,152,Conservation,Public-limited access,-1,-1,-1,-1,-1,0.5,1,-1,2,0.4,medium,#a1d99b,40.6549639,0,80.96621666,4.266666667,0,0,0
+1911,152823,82,Cultivated Crops,,152,Conservation,Public-limited access,-1,-1,-1,-1,-1,0.5,1,-1,3,0.66,high,#31a354,63.96469433,0,90.85504525,7.04,0,0,0
+1912,152900,90,Woody Wetlands,,152,Conservation,Public-limited access,-1,-1,-1,-1,-1,0.5,1,-1,0,0,none,#ffffff,33.5,0,259,0,0,0,0
+1913,152901,90,Woody Wetlands,,152,Conservation,Public-limited access,-1,-1,-1,-1,-1,0.5,1,-1,1,0.15,low,#e5f5e0,42.64199743,0,235.7179885,1.6,0,0,0
+1914,152902,90,Woody Wetlands,,152,Conservation,Public-limited access,-1,-1,-1,-1,-1,0.5,1,-1,2,0.4,medium,#a1d99b,57.8786598,0,196.9146361,4.266666667,0,0,0
+1915,152903,90,Woody Wetlands,,152,Conservation,Public-limited access,-1,-1,-1,-1,-1,0.5,1,-1,3,0.66,high,#31a354,73.72478868,0,156.5591496,7.04,0,0,0
+1916,152950,95,Emergent Herbaceuous Wetlands,,152,Conservation,Public-limited access,-1,-1,-1,-1,-1,0.5,1,-1,0,0,none,#ffffff,33.5,0,259,0,0,0,0
+1917,152951,95,Emergent Herbaceuous Wetlands,,152,Conservation,Public-limited access,-1,-1,-1,-1,-1,0.5,1,-1,1,0.15,low,#e5f5e0,42.64199743,0,235.7179885,1.6,0,0,0
+1918,152952,95,Emergent Herbaceuous Wetlands,,152,Conservation,Public-limited access,-1,-1,-1,-1,-1,0.5,1,-1,2,0.4,medium,#a1d99b,57.8786598,0,196.9146361,4.266666667,0,0,0
+1919,152953,95,Emergent Herbaceuous Wetlands,,152,Conservation,Public-limited access,-1,-1,-1,-1,-1,0.5,1,-1,3,0.66,high,#31a354,73.72478868,0,156.5591496,7.04,0,0,0
+1920,153110,11,Open Water,,153,Conservation,Private easement,-1,-1,-1,-1,-1,0,1,-1,0,0,none,#ffffff,0,0,0,0,0,0,0
+1921,153111,11,Open Water,,153,Conservation,Private easement,-1,-1,-1,-1,-1,0,1,-1,1,0.15,low,#e5f5e0,14.16699743,0,15.56798855,1.6,0,0,0
+1922,153112,11,Open Water,,153,Conservation,Private easement,-1,-1,-1,-1,-1,0,1,-1,2,0.4,medium,#a1d99b,37.7786598,0,41.51463613,4.266666667,0,0,0
+1923,153113,11,Open Water,,153,Conservation,Private easement,-1,-1,-1,-1,-1,0,1,-1,3,0.66,high,#31a354,62.33478868,0,68.49914961,7.04,0,0,0
+1924,153120,12,Perennial Ice/Snow,,153,Conservation,Private easement,-1,-1,-1,-1,-1,-1,-1,-1,0,0,none,#ffffff,0,0,0,0,0,0,0
+1925,153121,12,Perennial Ice/Snow,,153,Conservation,Private easement,-1,-1,-1,-1,-1,-1,-1,-1,1,0.15,low,#e5f5e0,14.16699743,0,15.56798855,1.6,0,0,0
+1926,153122,12,Perennial Ice/Snow,,153,Conservation,Private easement,-1,-1,-1,-1,-1,-1,-1,-1,2,0.4,medium,#a1d99b,37.7786598,0,41.51463613,4.266666667,0,0,0
+1927,153123,12,Perennial Ice/Snow,,153,Conservation,Private easement,-1,-1,-1,-1,-1,-1,-1,-1,3,0.66,high,#31a354,62.33478868,0,68.49914961,7.04,0,0,0
+1928,153210,21,"Developed, Open Space","20% trees, 60% grass, and 10% buildings and 10% bare soil",153,Conservation,Private easement,-1,-1,-1,1,-1,0,1,-1,0,0,none,#ffffff,25.49986095,4.08,79.01411479,1.76,51.81402439,212.31,37.03522039
+1929,153211,21,"Developed, Open Space","20% trees, 60% grass, and 10% buildings and 10% bare soil",153,Conservation,Private easement,-1,-1,-1,1,-1,0,1,-1,1,0.15,low,#e5f5e0,35.84187923,3.468,82.72998612,3.096,51.81402439,212.31,37.03522039
+1930,153212,21,"Developed, Open Space","20% trees, 60% grass, and 10% buildings and 10% bare soil",153,Conservation,Private easement,-1,-1,-1,1,-1,0,1,-1,2,0.4,medium,#a1d99b,53.07857637,2.448,88.923105,5.322666667,51.81402439,212.31,37.03522039
+1931,153213,21,"Developed, Open Space","20% trees, 60% grass, and 10% buildings and 10% bare soil",153,Conservation,Private easement,-1,-1,-1,1,-1,0,1,-1,3,0.66,high,#31a354,71.0047414,1.3872,95.36394864,7.6384,51.81402439,212.31,37.03522039
+1932,153220,22,"Developed, Low Intensity","20% trees, 40% grass, and 40% buildings",153,Conservation,Private easement,-1,-1,-1,1,-1,-1,1,-1,0,0,none,#ffffff,20.90844667,3.52,72.06732319,0.61,207.2560976,849.24,147.1338816
+1933,153221,22,"Developed, Low Intensity","20% trees, 40% grass, and 40% buildings",153,Conservation,Private easement,-1,-1,-1,1,-1,-1,1,-1,1,0.15,low,#e5f5e0,31.9391771,2.992,76.82521326,2.1185,207.2560976,849.24,147.1338816
+1934,153222,22,"Developed, Low Intensity","20% trees, 40% grass, and 40% buildings",153,Conservation,Private easement,-1,-1,-1,1,-1,-1,1,-1,2,0.4,medium,#a1d99b,50.32372781,2.112,84.75503004,4.632666667,207.2560976,849.24,147.1338816
+1935,153223,22,"Developed, Low Intensity","20% trees, 40% grass, and 40% buildings",153,Conservation,Private easement,-1,-1,-1,1,-1,-1,1,-1,3,0.66,high,#31a354,69.44366054,1.1968,93.0020395,7.2474,207.2560976,849.24,147.1338816
+1936,153230,23,"Developed, Medium Intensity","15% trees, 35% grass, and 50% buildings",153,Conservation,Private easement,-1,-1,-1,1,-1,-1,1,-1,0,0,none,#ffffff,17.69813636,3.08,61.93838294,0.36,234.070122,954.85,720.4716833
+1937,153231,23,"Developed, Medium Intensity","15% trees, 35% grass, and 50% buildings",153,Conservation,Private easement,-1,-1,-1,1,-1,-1,1,-1,1,0.15,low,#e5f5e0,29.21041333,2.618,68.21561405,1.906,234.070122,954.85,720.4716833
+1938,153232,23,"Developed, Medium Intensity","15% trees, 35% grass, and 50% buildings",153,Conservation,Private easement,-1,-1,-1,1,-1,-1,1,-1,2,0.4,medium,#a1d99b,48.39754162,1.848,78.67766589,4.482666667,234.070122,954.85,720.4716833
+1939,153233,23,"Developed, Medium Intensity","15% trees, 35% grass, and 50% buildings",153,Conservation,Private easement,-1,-1,-1,1,-1,-1,1,-1,3,0.66,high,#31a354,68.35215504,1.0472,89.55819981,7.1624,234.070122,954.85,720.4716833
+1940,153240,24,"Developed, High Intensity","10% trees, 20% grass, and 70% buildings",153,Conservation,Private easement,-1,-1,-1,1,-1,-1,1,-1,0,0,none,#ffffff,10.98142029,1.76,44.78642515,0.245,267.9065041,3418.485,1805.616283
+1941,153241,24,"Developed, High Intensity","10% trees, 20% grass, and 70% buildings",153,Conservation,Private easement,-1,-1,-1,1,-1,-1,1,-1,1,0.15,low,#e5f5e0,23.50120467,1.496,53.63644993,1.80825,267.9065041,3418.485,1805.616283
+1942,153242,24,"Developed, High Intensity","10% trees, 20% grass, and 70% buildings",153,Conservation,Private easement,-1,-1,-1,1,-1,-1,1,-1,2,0.4,medium,#a1d99b,44.36751198,1.056,68.38649122,4.413666667,267.9065041,3418.485,1805.616283
+1943,153243,24,"Developed, High Intensity","10% trees, 20% grass, and 70% buildings",153,Conservation,Private easement,-1,-1,-1,1,-1,-1,1,-1,3,0.66,high,#31a354,66.06847158,0.5984,83.72653416,7.1233,267.9065041,3418.485,1805.616283
+1944,153310,31,Barren Land,,153,Conservation,Private easement,-1,-1,-1,1,-1,0,1,-1,0,0,none,#ffffff,6.8,0,25.5,0,0,0,0
+1945,153311,31,Barren Land,,153,Conservation,Private easement,-1,-1,-1,1,-1,0,1,-1,1,0.15,low,#e5f5e0,19.94699743,0,37.24298855,1.6,0,0,0
+1946,153312,31,Barren Land,,153,Conservation,Private easement,-1,-1,-1,1,-1,0,1,-1,2,0.4,medium,#a1d99b,41.8586598,0,56.81463613,4.266666667,0,0,0
+1947,153313,31,Barren Land,,153,Conservation,Private easement,-1,-1,-1,1,-1,0,1,-1,3,0.66,high,#31a354,64.64678868,0,77.16914961,7.04,0,0,0
+1948,153410,41,Deciduous Forest,,153,Conservation,Private easement,-1,-1,-1,-1,-1,0,1,-1,0,0,none,#ffffff,85.88498714,0,96.08994273,8.8,0,0,0
+1949,153411,41,Deciduous Forest,,153,Conservation,Private easement,-1,-1,-1,-1,-1,0,1,-1,1,0.15,low,#e5f5e0,85.88498714,0,96.08994273,8.8,0,0,0
+1950,153412,41,Deciduous Forest,,153,Conservation,Private easement,-1,-1,-1,-1,-1,0,1,-1,2,0.4,medium,#a1d99b,85.88498714,0,96.08994273,8.8,0,0,0
+1951,153413,41,Deciduous Forest,,153,Conservation,Private easement,-1,-1,-1,-1,-1,0,1,-1,3,0.66,high,#31a354,85.88498714,0,96.08994273,8.8,0,0,0
+1952,153420,42,Evergreen Forest,,153,Conservation,Private easement,-1,-1,-1,-1,-1,0,1,-1,0,0,none,#ffffff,105.6849871,0,96.08994273,14.4,0,0,0
+1953,153421,42,Evergreen Forest,,153,Conservation,Private easement,-1,-1,-1,-1,-1,0,1,-1,1,0.15,low,#e5f5e0,105.6849871,0,96.08994273,14.4,0,0,0
+1954,153422,42,Evergreen Forest,,153,Conservation,Private easement,-1,-1,-1,-1,-1,0,1,-1,2,0.4,medium,#a1d99b,105.6849871,0,96.08994273,14.4,0,0,0
+1955,153423,42,Evergreen Forest,,153,Conservation,Private easement,-1,-1,-1,-1,-1,0,1,-1,3,0.66,high,#31a354,105.6849871,0,96.08994273,14.4,0,0,0
+1956,153430,43,Mixed Forest,,153,Conservation,Private easement,-1,-1,-1,-1,-1,0,1,-1,0,0,none,#ffffff,91.76997429,0,119.1798855,8.8,0,0,0
+1957,153431,43,Mixed Forest,,153,Conservation,Private easement,-1,-1,-1,-1,-1,0,1,-1,1,0.15,low,#e5f5e0,91.76997429,0,119.1798855,8.8,0,0,0
+1958,153432,43,Mixed Forest,,153,Conservation,Private easement,-1,-1,-1,-1,-1,0,1,-1,2,0.4,medium,#a1d99b,91.76997429,0,119.1798855,8.8,0,0,0
+1959,153433,43,Mixed Forest,,153,Conservation,Private easement,-1,-1,-1,-1,-1,0,1,-1,3,0.66,high,#31a354,91.76997429,0,119.1798855,8.8,0,0,0
+1960,153520,52,Shrub/Scrub,,153,Conservation,Private easement,-1,-1,-1,1,-1,0,1,-1,0,0,none,#ffffff,47.875,0,68.15477645,0,0,0,0
+1961,153521,52,Shrub/Scrub,,153,Conservation,Private easement,-1,-1,-1,1,-1,0,1,-1,1,0.15,low,#e5f5e0,54.86074743,0,73.49954853,1.6,0,0,0
+1962,153522,52,Shrub/Scrub,,153,Conservation,Private easement,-1,-1,-1,1,-1,0,1,-1,2,0.4,medium,#a1d99b,66.5036598,0,82.407502,4.266666667,0,0,0
+1963,153523,52,Shrub/Scrub,,153,Conservation,Private easement,-1,-1,-1,1,-1,0,1,-1,3,0.66,high,#31a354,78.61228868,0,91.6717736,7.04,0,0,0
+1964,153710,71,Herbaceuous,,153,Conservation,Private easement,-1,-1,-1,1,-1,0,1,-1,0,0,none,#ffffff,10.10660117,8,98.79264417,0,0,0,0
+1965,153711,71,Herbaceuous,,153,Conservation,Private easement,-1,-1,-1,1,-1,0,1,-1,1,0.15,low,#e5f5e0,22.75760842,6.8,99.54173609,1.6,0,0,0
+1966,153712,71,Herbaceuous,,153,Conservation,Private easement,-1,-1,-1,1,-1,0,1,-1,2,0.4,medium,#a1d99b,43.84262051,4.8,100.7902226,4.266666667,0,0,0
+1967,153713,71,Herbaceuous,,153,Conservation,Private easement,-1,-1,-1,1,-1,0,1,-1,3,0.66,high,#31a354,65.77103307,2.72,102.0886486,7.04,0,0,0
+1968,153810,81,Hay/Pasture,,153,Conservation,Private easement,-1,-1,-1,1,-1,0,1,-1,0,0,none,#ffffff,10.10660117,8,98.79264417,0,0,0,0
+1969,153811,81,Hay/Pasture,,153,Conservation,Private easement,-1,-1,-1,1,-1,0,1,-1,1,0.15,low,#e5f5e0,22.75760842,6.8,99.54173609,1.6,0,0,0
+1970,153812,81,Hay/Pasture,,153,Conservation,Private easement,-1,-1,-1,1,-1,0,1,-1,2,0.4,medium,#a1d99b,43.84262051,4.8,100.7902226,4.266666667,0,0,0
+1971,153813,81,Hay/Pasture,,153,Conservation,Private easement,-1,-1,-1,1,-1,0,1,-1,3,0.66,high,#31a354,65.77103307,2.72,102.0886486,7.04,0,0,0
+1972,153820,82,Cultivated Crops,,153,Conservation,Private easement,-1,-1,-1,-1,-1,0,1,-1,0,0,none,#ffffff,4.793840162,0,65.75263422,0,0,0,0
+1973,153821,82,Cultivated Crops,,153,Conservation,Private easement,-1,-1,-1,-1,-1,0,1,-1,1,0.15,low,#e5f5e0,18.24176156,0,71.45772764,1.6,0,0,0
+1974,153822,82,Cultivated Crops,,153,Conservation,Private easement,-1,-1,-1,-1,-1,0,1,-1,2,0.4,medium,#a1d99b,40.6549639,0,80.96621666,4.266666667,0,0,0
+1975,153823,82,Cultivated Crops,,153,Conservation,Private easement,-1,-1,-1,-1,-1,0,1,-1,3,0.66,high,#31a354,63.96469433,0,90.85504525,7.04,0,0,0
+1976,153900,90,Woody Wetlands,,153,Conservation,Private easement,-1,-1,-1,-1,-1,0,1,-1,0,0,none,#ffffff,33.5,0,259,0,0,0,0
+1977,153901,90,Woody Wetlands,,153,Conservation,Private easement,-1,-1,-1,-1,-1,0,1,-1,1,0.15,low,#e5f5e0,42.64199743,0,235.7179885,1.6,0,0,0
+1978,153902,90,Woody Wetlands,,153,Conservation,Private easement,-1,-1,-1,-1,-1,0,1,-1,2,0.4,medium,#a1d99b,57.8786598,0,196.9146361,4.266666667,0,0,0
+1979,153903,90,Woody Wetlands,,153,Conservation,Private easement,-1,-1,-1,-1,-1,0,1,-1,3,0.66,high,#31a354,73.72478868,0,156.5591496,7.04,0,0,0
+1980,153950,95,Emergent Herbaceuous Wetlands,,153,Conservation,Private easement,-1,-1,-1,-1,-1,0,1,-1,0,0,none,#ffffff,33.5,0,259,0,0,0,0
+1981,153951,95,Emergent Herbaceuous Wetlands,,153,Conservation,Private easement,-1,-1,-1,-1,-1,0,1,-1,1,0.15,low,#e5f5e0,42.64199743,0,235.7179885,1.6,0,0,0
+1982,153952,95,Emergent Herbaceuous Wetlands,,153,Conservation,Private easement,-1,-1,-1,-1,-1,0,1,-1,2,0.4,medium,#a1d99b,57.8786598,0,196.9146361,4.266666667,0,0,0
+1983,153953,95,Emergent Herbaceuous Wetlands,,153,Conservation,Private easement,-1,-1,-1,-1,-1,0,1,-1,3,0.66,high,#31a354,73.72478868,0,156.5591496,7.04,0,0,0


### PR DESCRIPTION
The issue here, described by Chris:

>I think I've figured out the root cause of the bug: the NLCD nodata value 0 was encoded as an actual LULC class labelled "Background" in the carbon table but not included in any of the other tables or the QAQC table. I'll fix that and resend the table for whenever we have time to update the tool.