### PR TITLE
Update cronjob script

### DIFF
--- a/scripts/renew-cert.sh
+++ b/scripts/renew-cert.sh
@@ -2,6 +2,11 @@
 # renew the certificate. use --dry-run flag for testing.
 cd /home/ddenu/urban-online-workflow;
 
-docker compose run --rm certbot certonly --force-renew --webroot --webroot-path /var/www/certbot/ -d urbanonline.naturalcapitalproject.org;
-
 date >> /home/ddenu/cronjoblogs.txt;
+
+# --force-renew : force cert to renew even if not set to expire 
+# --webroot : use the active webserver to place challenge, so Certbot
+#             doesn't need to listen on port 80 directly.
+docker compose run --rm certbot certonly --force-renew \
+	--webroot --webroot-path /var/www/certbot/ \
+	-d urbanonline.naturalcapitalproject.org;


### PR DESCRIPTION
Add some useful comments and printing out the date first.

No changes to how we're calling for the renewal because I think the below error was on letsencrypts side. I manually ran the same command and it worked as expected.

>An unexpected error occurred:
>Service busy; retry later.

