### PR TITLE
Better frontend dependency installs for dev vs prod

### DIFF
--- a/backend-worker/worker.py
+++ b/backend-worker/worker.py
@@ -50,7 +50,7 @@ _ALBERS_EQUAL_AREA_SRS.SetAxisMappingStrategy(osr.OAMS_TRADITIONAL_GIS_ORDER)
 
 LULC_FILENAME = 'lulc_overlay_3857.tif'
 LULC_RASTER_PATHS = {
-    'vsigs': f'/vsigs/natcap-urban-online-datasets-public/{LULC_FILENAME}',  # TODO: does not work
+    'vsicurl': f'/vsicurl/https://storage.googleapis.com/natcap-urban-online-datasets-public/{LULC_FILENAME}',
     'docker': f'/opt/appdata/{LULC_FILENAME}',
     'local': os.path.join(os.path.dirname(__file__), '..', 'appdata',
                           LULC_FILENAME)

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -30,7 +30,10 @@ services:
         - fileserver-dev
       profiles: [dev]
     frontend-prod:
-      build: frontend
+      build:
+        context: frontend
+        args:
+          PROD: true
       command: yarn start-docker-prod
       ports:
         - 3000:3000
@@ -45,7 +48,10 @@ services:
           target: .env
       profiles: [prod]
     frontend-dev:
-      build: frontend
+      build:
+        context: frontend
+        args:
+          PROD: false
       command: yarn start-docker-dev
       ports:
         - 3000:3000

--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -8,9 +8,7 @@ WORKDIR /opt/frontend
 
 ADD ./package.json /opt/frontend/
 ADD ./yarn.lock /opt/frontend/
-#RUN yarn add puppeteer --ignore-scripts
 RUN yarn install --production=${PROD}
-#RUN yarn cache clean && yarn install --production=false
 
 EXPOSE 3000
 

--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -1,12 +1,15 @@
 FROM node:20
 
+ARG PROD
+
 # Just install the packages; the source code will be loaded in later.
 RUN mkdir /opt/frontend
 WORKDIR /opt/frontend
 
 ADD ./package.json /opt/frontend/
-RUN yarn add puppeteer --ignore-scripts
-RUN yarn install --production=false
+ADD ./yarn.lock /opt/frontend/
+#RUN yarn add puppeteer --ignore-scripts
+RUN yarn install --production=${PROD}
 #RUN yarn cache clean && yarn install --production=false
 
 EXPOSE 3000

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -13,12 +13,15 @@
     },
     "dependencies": {
         "@blueprintjs/core": "^5.12.0",
+        "@vitejs/plugin-react": "^5.1.4",
+        "cross-env": "^10.1.0",
         "dotenv": "^17.2.4",
         "jsts": "^2.12.1",
         "localforage": "^1.10.0",
         "ol": "^6.15.1",
         "react": "^18.2.0",
-        "react-dom": "^18.2.0"
+        "react-dom": "^18.2.0",
+        "vite": "^7.3.1"
     },
     "devDependencies": {
         "@babel/eslint-parser": "^7.28.6",
@@ -26,10 +29,8 @@
         "@testing-library/jest-dom": "^6.9.1",
         "@testing-library/react": "^16.3.2",
         "@testing-library/user-event": "^14.6.1",
-        "@vitejs/plugin-react": "^5.1.4",
         "@vitest/coverage-v8": "^4.0.18",
         "c8": "^10.1.3",
-        "cross-env": "^10.1.0",
         "eslint": "^10.0.0",
         "eslint-config-airbnb": "^19.0.4",
         "eslint-plugin-import": "^2.32.0",
@@ -39,7 +40,6 @@
         "happy-dom": "^20.6.1",
         "jsdom": "^28.0.0",
         "puppeteer": "^24.37.2",
-        "vite": "^7.3.1",
         "vitest": "^4.0.18"
     }
 }


### PR DESCRIPTION
Leveraging the docker profiles to minimize node dependencies we need to install in production. Also copy over the yarn.lock file to speedup installations.

Also resolved an unrelated bug in the backend worker. `vsigs` requires auth, even for public buckets, so use `vsicurl` instead.